### PR TITLE
Bug fix - Displayed summary is cut

### DIFF
--- a/artifactory/commands/generic/download.go
+++ b/artifactory/commands/generic/download.go
@@ -63,6 +63,13 @@ func (dc *DownloadCommand) CommandName() string {
 }
 
 func (dc *DownloadCommand) Run() error {
+	if dc.progressBar != nil {
+		defer dc.progressBar.Quit()
+	}
+	return dc.download()
+}
+
+func (dc *DownloadCommand) download() error {
 	if dc.SyncDeletesPath() != "" && !dc.Quiet() && !coreutils.AskYesNo("Sync-deletes may delete some files in your local file system. Are you sure you want to continue?\n"+
 		"You can avoid this confirmation message by adding --quiet to the command.", false) {
 		return nil

--- a/artifactory/commands/generic/upload.go
+++ b/artifactory/commands/generic/upload.go
@@ -58,6 +58,9 @@ func (uc *UploadCommand) CommandName() string {
 }
 
 func (uc *UploadCommand) Run() error {
+	if uc.progressBar != nil {
+		defer uc.progressBar.Quit()
+	}
 	return uc.upload()
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR fixes an issue, which causes the displayed summary for upload and download commands to get corrupted., as shown below. This fix requires an addition PR to the https://github.com/jfrog/jfrog-cli repository.

```
$ jfrog rt dl generic-local/*dd* aa/ --threads 30
 Log path: /Users/eyalb/.jfrog/logs/jfrog-cli.2020-10-06.14-04-30.39948.log
 Working...  \                    
{
  "status": "success",
  "totals": {
    "success": 1,
    "failure": 0
 Log path: /Users/eyalb/.jfrog/logs/jfrog-cli.2020-10-06.14-04-30.39948.log

```