### PR TITLE
Bug fix - Command summary gets cut by the progress bar

### DIFF
--- a/artifactory/commands/generic/download.go
+++ b/artifactory/commands/generic/download.go
@@ -26,16 +26,11 @@ type DownloadCommand struct {
 	buildConfiguration *utils.BuildConfiguration
 	GenericCommand
 	configuration *utils.DownloadConfiguration
-	logFile       *os.File
-	progressBar   ioUtils.Progress
+	progress      ioUtils.Progress
 }
 
 func NewDownloadCommand() *DownloadCommand {
 	return &DownloadCommand{GenericCommand: *NewGenericCommand()}
-}
-
-func (dc *DownloadCommand) LogFile() *os.File {
-	return dc.logFile
 }
 
 func (dc *DownloadCommand) SetBuildConfiguration(buildConfiguration *utils.BuildConfiguration) *DownloadCommand {
@@ -52,10 +47,8 @@ func (dc *DownloadCommand) SetConfiguration(configuration *utils.DownloadConfigu
 	return dc
 }
 
-func (dc *DownloadCommand) SetProgressBarComponents(progressBar ioUtils.Progress, logFile *os.File) *DownloadCommand {
-	dc.progressBar = progressBar
-	dc.logFile = logFile
-	return dc
+func (dc *DownloadCommand) SetProgress(progress ioUtils.Progress) {
+	dc.progress = progress
 }
 
 func (dc *DownloadCommand) CommandName() string {
@@ -63,9 +56,6 @@ func (dc *DownloadCommand) CommandName() string {
 }
 
 func (dc *DownloadCommand) Run() error {
-	if dc.progressBar != nil {
-		defer dc.progressBar.Quit()
-	}
 	return dc.download()
 }
 
@@ -76,7 +66,7 @@ func (dc *DownloadCommand) download() error {
 	}
 
 	// Create Service Manager:
-	servicesManager, err := utils.CreateDownloadServiceManager(dc.rtDetails, dc.configuration.Threads, dc.DryRun(), dc.progressBar)
+	servicesManager, err := utils.CreateDownloadServiceManager(dc.rtDetails, dc.configuration.Threads, dc.DryRun(), dc.progress)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/generic/download.go
+++ b/artifactory/commands/generic/download.go
@@ -63,6 +63,13 @@ func (dc *DownloadCommand) CommandName() string {
 }
 
 func (dc *DownloadCommand) Run() error {
+	if dc.progressBar != nil {
+		defer dc.progressBar.Quit()
+	}
+	return dc.download()
+}
+
+func (dc *DownloadCommand) download() error {
 	if dc.SyncDeletesPath() != "" && !dc.Quiet() && !coreutils.AskYesNo("Sync-deletes may delete some files in your local file system. Are you sure you want to continue?\n"+
 		"You can avoid this confirmation message by adding --quiet to the command.", false) {
 		return nil

--- a/artifactory/commands/generic/upload.go
+++ b/artifactory/commands/generic/upload.go
@@ -21,16 +21,11 @@ type UploadCommand struct {
 	GenericCommand
 	uploadConfiguration *utils.UploadConfiguration
 	buildConfiguration  *utils.BuildConfiguration
-	logFile             *os.File
-	progressBar         ioUtils.Progress
+	progress            ioUtils.Progress
 }
 
 func NewUploadCommand() *UploadCommand {
 	return &UploadCommand{GenericCommand: *NewGenericCommand()}
-}
-
-func (uc *UploadCommand) LogFile() *os.File {
-	return uc.logFile
 }
 
 func (uc *UploadCommand) SetBuildConfiguration(buildConfiguration *utils.BuildConfiguration) *UploadCommand {
@@ -47,10 +42,8 @@ func (uc *UploadCommand) SetUploadConfiguration(uploadConfiguration *utils.Uploa
 	return uc
 }
 
-func (uc *UploadCommand) SetProgressBarComponents(progressBar ioUtils.Progress, logFile *os.File) *UploadCommand {
-	uc.progressBar = progressBar
-	uc.logFile = logFile
-	return uc
+func (uc *UploadCommand) SetProgress(progress ioUtils.Progress) {
+	uc.progress = progress
 }
 
 func (uc *UploadCommand) CommandName() string {
@@ -58,9 +51,6 @@ func (uc *UploadCommand) CommandName() string {
 }
 
 func (uc *UploadCommand) Run() error {
-	if uc.progressBar != nil {
-		defer uc.progressBar.Quit()
-	}
 	return uc.upload()
 }
 
@@ -88,7 +78,7 @@ func (uc *UploadCommand) upload() error {
 	if errorutils.CheckError(err) != nil {
 		return err
 	}
-	servicesManager, err := utils.CreateUploadServiceManager(rtDetails, uc.uploadConfiguration.Threads, uc.DryRun(), uc.progressBar)
+	servicesManager, err := utils.CreateUploadServiceManager(rtDetails, uc.uploadConfiguration.Threads, uc.DryRun(), uc.progress)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/generic/upload.go
+++ b/artifactory/commands/generic/upload.go
@@ -58,6 +58,9 @@ func (uc *UploadCommand) CommandName() string {
 }
 
 func (uc *UploadCommand) Run() error {
+	if uc.progressBar != nil {
+		defer uc.progressBar.Quit()
+	}
 	return uc.upload()
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR fixes an issue, which causes the displayed summary for upload and download commands to get corrupted., as shown below. This fix requires an addition PR to the https://github.com/jfrog/jfrog-cli repository.
```
$ jfrog rt dl generic-local/*dd* aa/ --threads 30
 Log path: /Users/eyalb/.jfrog/logs/jfrog-cli.2020-10-06.14-04-30.39948.log
 Working...  \                    
{
  "status": "success",
  "totals": {
    "success": 1,
    "failure": 0
 Log path: /Users/eyalb/.jfrog/logs/jfrog-cli.2020-10-06.14-04-30.39948.log
```