### PR TITLE
Upgrade config version

### DIFF
--- a/utils/config/config_test.go
+++ b/utils/config/config_test.go
@@ -38,7 +38,7 @@ func TestCovertConfigV0ToV1(t *testing.T) {
 	`
 	content, err := convertConfigV0toV1([]byte(configV0))
 	assert.NoError(t, err)
-	configV1 := new(ConfigV3)
+	configV1 := new(ConfigV4)
 	assert.NoError(t, json.Unmarshal(content, &configV1))
 	assertionHelper(t, configV1, "1", false)
 }
@@ -55,7 +55,7 @@ func TestCovertConfigV0ToV1EmptyArtifactory(t *testing.T) {
 	`
 	content, err := convertConfigV0toV1([]byte(configV0))
 	assert.NoError(t, err)
-	configV1 := new(ConfigV3)
+	configV1 := new(ConfigV4)
 	assert.NoError(t, json.Unmarshal(content, &configV1))
 }
 
@@ -89,7 +89,7 @@ func TestConvertConfigV1ToV3(t *testing.T) {
 
 	content, err := convertIfNeeded([]byte(config))
 	assert.NoError(t, err)
-	configV3 := new(ConfigV3)
+	configV3 := new(ConfigV4)
 	assert.NoError(t, json.Unmarshal(content, &configV3))
 	assertionHelper(t, configV3, coreutils.GetConfigVersion(), false)
 
@@ -128,7 +128,7 @@ func TestConvertConfigV0ToV2(t *testing.T) {
 
 	content, err := convertIfNeeded([]byte(configV0))
 	assert.NoError(t, err)
-	ConfigV3 := new(ConfigV3)
+	ConfigV3 := new(ConfigV4)
 	assert.NoError(t, json.Unmarshal(content, &ConfigV3))
 	assertionHelper(t, ConfigV3, coreutils.GetConfigVersion(), false)
 	assertCertsMigrationAndBackupCreation(t)
@@ -161,10 +161,10 @@ func TestConfigEncryption(t *testing.T) {
 	verifyEncryptionStatus(t, originalConfig, readConfig, false)
 }
 
-func readConfFromFile(t *testing.T) *ConfigV3 {
+func readConfFromFile(t *testing.T) *ConfigV4 {
 	confFilePath, err := getConfFilePath()
 	assert.NoError(t, err)
-	config := new(ConfigV3)
+	config := new(ConfigV4)
 	assert.FileExists(t, confFilePath)
 	content, err := fileutils.ReadFile(confFilePath)
 	assert.NoError(t, err)
@@ -209,7 +209,7 @@ func TestGetArtifactoriesFromConfig(t *testing.T) {
 	`
 	content, err := convertIfNeeded([]byte(config))
 	assert.NoError(t, err)
-	configV1 := new(ConfigV3)
+	configV1 := new(ConfigV4)
 	assert.NoError(t, json.Unmarshal(content, &configV1))
 	serverDetails, err := GetDefaultConfiguredArtifactoryConf(configV1.Artifactory)
 	assert.NoError(t, err)
@@ -239,7 +239,7 @@ func TestGetJfrogDependenciesPath(t *testing.T) {
 	assert.Equal(t, expectedDependenciesPath, dependenciesPath)
 }
 
-func assertionHelper(t *testing.T, convertedConfig *ConfigV3, expectedVersion string, expectedEnc bool) {
+func assertionHelper(t *testing.T, convertedConfig *ConfigV4, expectedVersion string, expectedEnc bool) {
 	assert.Equal(t, expectedVersion, convertedConfig.Version)
 	assert.Equal(t, expectedEnc, convertedConfig.Enc)
 
@@ -261,7 +261,7 @@ func assertionHelper(t *testing.T, convertedConfig *ConfigV3, expectedVersion st
 func TestHandleSecrets(t *testing.T) {
 	masterKey := "randomkeywithlengthofexactly32!!"
 
-	original := new(ConfigV3)
+	original := new(ConfigV4)
 	original.Artifactory = []*ArtifactoryDetails{{User: "user", Password: "password", Url: "http://localhost:8080/artifactory/", AccessToken: "accessToken",
 		RefreshToken: "refreshToken", ApiKey: "apiKEY", SshPassphrase: "sshPass"}}
 	original.Bintray = &BintrayDetails{ApiUrl: "APIurl", Key: "bintrayKey"}
@@ -278,16 +278,16 @@ func TestHandleSecrets(t *testing.T) {
 	verifyEncryptionStatus(t, original, newConf, false)
 }
 
-func copyConfig(t *testing.T, original *ConfigV3) *ConfigV3 {
+func copyConfig(t *testing.T, original *ConfigV4) *ConfigV4 {
 	b, err := json.Marshal(&original)
 	assert.NoError(t, err)
-	newConf := new(ConfigV3)
+	newConf := new(ConfigV4)
 	err = json.Unmarshal(b, &newConf)
 	assert.NoError(t, err)
 	return newConf
 }
 
-func verifyEncryptionStatus(t *testing.T, original, actual *ConfigV3, encryptionExpected bool) {
+func verifyEncryptionStatus(t *testing.T, original, actual *ConfigV4, encryptionExpected bool) {
 	var equals []bool
 	for i := range actual.Artifactory {
 		if original.Artifactory[i].Password != "" {

--- a/utils/config/encryption.go
+++ b/utils/config/encryption.go
@@ -33,7 +33,7 @@ const decryptErrorPrefix = "cannot decrypt config: "
 type secretHandler func(string, string) (string, error)
 
 // Encrypt config file if security configuration file exists and contains master key.
-func (config *ConfigV3) encrypt() error {
+func (config *ConfigV4) encrypt() error {
 	key, _, err := getMasterKeyFromSecurityConfFile()
 	if err != nil || key == "" {
 		return err
@@ -44,7 +44,7 @@ func (config *ConfigV3) encrypt() error {
 }
 
 // Decrypt config if encrypted and master key exists.
-func (config *ConfigV3) decrypt() error {
+func (config *ConfigV4) decrypt() error {
 	if !config.Enc {
 		return updateEncryptionIfNeeded(config)
 	}
@@ -62,7 +62,7 @@ func (config *ConfigV3) decrypt() error {
 }
 
 // Encrypt the config file if it is decrypted while security configuration file exists and contains a master key.
-func updateEncryptionIfNeeded(originalConfig *ConfigV3) error {
+func updateEncryptionIfNeeded(originalConfig *ConfigV4) error {
 	masterKey, _, err := getMasterKeyFromSecurityConfFile()
 	if err != nil || masterKey == "" {
 		return err
@@ -73,7 +73,7 @@ func updateEncryptionIfNeeded(originalConfig *ConfigV3) error {
 	if err != nil {
 		return err
 	}
-	tmpEncConfig := new(ConfigV3)
+	tmpEncConfig := new(ConfigV4)
 	err = json.Unmarshal(decryptedContent, &tmpEncConfig)
 	if err != nil {
 		return errorutils.CheckError(err)
@@ -88,7 +88,7 @@ func updateEncryptionIfNeeded(originalConfig *ConfigV3) error {
 }
 
 // Encrypt/Decrypt all secrets in the provided config, with the provided master key.
-func handleSecrets(config *ConfigV3, handler secretHandler, key string) error {
+func handleSecrets(config *ConfigV4, handler secretHandler, key string) error {
 	var err error
 	for _, rtDetails := range config.Artifactory {
 		rtDetails.Password, err = handler(rtDetails.Password, key)

--- a/utils/config/testdata/config/encryption/jfrog-cli.conf.v4
+++ b/utils/config/testdata/config/encryption/jfrog-cli.conf.v4
@@ -8,5 +8,5 @@
       "isDefault": true
     }
   ],
-  "version": "2"
+  "version": "4"
 }

--- a/utils/coreutils/utils.go
+++ b/utils/coreutils/utils.go
@@ -100,7 +100,7 @@ func GetExitCode(err error, success, failed int, failNoOp bool) ExitCode {
 }
 
 func GetConfigVersion() string {
-	return "3"
+	return "4"
 }
 
 func SumTrueValues(boolArr []bool) int {

--- a/utils/coreutils/utils.go
+++ b/utils/coreutils/utils.go
@@ -99,8 +99,8 @@ func GetExitCode(err error, success, failed int, failNoOp bool) ExitCode {
 	return ExitCodeNoError
 }
 
-func GetConfigVersion() string {
-	return "4"
+func GetConfigVersion() int {
+	return 4
 }
 
 func SumTrueValues(boolArr []bool) int {


### PR DESCRIPTION
For now on the converted config version will be saved in new file with a name
matching the version. This will allow backward compatibility for multiple CLI
proceses.

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
