### PR TITLE
Bugfix - pip-install does not support local repos

### DIFF
--- a/artifactory/utils/pip/installer.go
+++ b/artifactory/utils/pip/installer.go
@@ -103,7 +103,7 @@ func (pi *PipInstaller) runPipInstallWithLogParsing(pipInstallCmd *PipCmd) error
 	if err != nil {
 		return err
 	}
-	downloadFileRegexp, err := clientutils.GetRegExp(`^\s\sDownloading\s[^\s]*\/packages\/[^\s]*\/([^\s]*)`)
+	downloadFileRegexp, err := clientutils.GetRegExp(`^\s\sDownloading\s[^\s]*\/([^\s]*)`)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Resolves: https://github.com/jfrog/jfrog-cli/issues/879

In order to collect the build info in pip install commands, we parse the pip-install build logs. To parse the downloaded file trace, we expect the following regex:
> ^\s\sDownloading\s[^\s]*\/packages\/[^\s]*\/([^\s]*)

Trace example using a remote Pypi registry:
>  Downloading http://127.0.0.1:8081/artifactory/api/pypi/pypi/packages/packages/ca/4d/7d59d82b777f3f7a1128608195655a1b36c1de89c292363d53d52d92a807/npm-0.1.1.tar.gz

However when using an Artifactory's local repository, we don't have the "packages" word in the trace:
>  Downloading http://127.0.0.1:8081/artifactory/api/pypi/pypi/ca/4d/7d59d82b777f3f7a1128608195655a1b36c1de89c292363d53d52d92a807/npm-0.1.1.tar.gz (2.5 kB) (edited) 