### PR TITLE
Bugfix: Error in uploading/downloading 0 files

### DIFF
--- a/artifactory/commands/generic/download.go
+++ b/artifactory/commands/generic/download.go
@@ -147,12 +147,11 @@ func (dc *DownloadCommand) download() error {
 
 	// Build Info
 	if isCollectBuildInfo {
-		var downloaded clientutils.ResultBuildInfo
-		err = utils.ReadAllContent(resultsReader, &downloaded)
+		err, resultBuildInfo := utils.ReadResultBuildInfo(resultsReader)
 		if err != nil {
 			return err
 		}
-		buildDependencies := convertFileInfoToBuildDependencies(downloaded.FilesInfo)
+		buildDependencies := convertFileInfoToBuildDependencies(resultBuildInfo.FilesInfo)
 		populateFunc := func(partial *buildinfo.Partial) {
 			partial.Dependencies = buildDependencies
 			partial.ModuleId = dc.buildConfiguration.Module

--- a/artifactory/commands/generic/upload.go
+++ b/artifactory/commands/generic/upload.go
@@ -159,12 +159,11 @@ func (uc *UploadCommand) upload() error {
 		}
 		// Build Info
 		if isCollectBuildInfo {
-			var uploaded clientutils.ResultBuildInfo
-			err = utils.ReadAllContent(resultsReader, &uploaded)
+			err, resultBuildInfo := utils.ReadResultBuildInfo(resultsReader)
 			if err != nil {
 				return err
 			}
-			buildArtifacts := convertFileInfoToBuildArtifacts(uploaded.FilesInfo)
+			buildArtifacts := convertFileInfoToBuildArtifacts(resultBuildInfo.FilesInfo)
 			populateFunc := func(partial *buildinfo.Partial) {
 				partial.Artifacts = buildArtifacts
 				partial.ModuleId = uc.buildConfiguration.Module

--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -217,12 +217,11 @@ func (npc *NpmPublishCommand) doDeploy(target string, artDetails *config.Artifac
 	}
 	resultsReader, _, failed, err := servicesManager.UploadFilesWithResultReader(up)
 	defer resultsReader.Close()
-	var uploaded specutils.ResultBuildInfo
-	err = utils.ReadAllContent(resultsReader, &uploaded)
+	err, resultBuildInfo := utils.ReadResultBuildInfo(resultsReader)
 	if err != nil {
 		return nil, err
 	}
-	artifactsFileInfo = uploaded.FilesInfo
+	artifactsFileInfo = resultBuildInfo.FilesInfo
 
 	// We deploying only one Artifact which have to be deployed, in case of failure we should fail
 	if failed > 0 {

--- a/artifactory/utils/buildutils.go
+++ b/artifactory/utils/buildutils.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
@@ -277,14 +278,19 @@ func ValidateBuildAndModuleParams(buildConfig *BuildConfiguration) error {
 	return nil
 }
 
-// ReadAllContent stores the entire content of the given contentReader in the value pointed by the given pointer.
-func ReadAllContent(cr *content.ContentReader, pointer interface{}) error {
+// Reads ResultBuildInfo from the content reader.
+func ReadResultBuildInfo(cr *content.ContentReader) (error, utils.ResultBuildInfo) {
+	var resultBuildInfo utils.ResultBuildInfo
 	file, err := os.Open(cr.GetFilePath())
 	if err != nil {
-		return errorutils.CheckError(err)
+		if os.IsNotExist(err) {
+			// The build info partials file is not generated. This would happen when no files were uploaded/downloaded.
+			return nil, resultBuildInfo
+		}
+		return errorutils.CheckError(err), resultBuildInfo
 	}
 	defer file.Close()
 	byteValue, _ := ioutil.ReadAll(file)
-	err = json.Unmarshal(byteValue, pointer)
-	return errorutils.CheckError(err)
+	err = json.Unmarshal(byteValue, &resultBuildInfo)
+	return errorutils.CheckError(err), resultBuildInfo
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Running upload and download commands with `--build-name`, `--build-number` and when the the pattern match no results, produces an unwanted error. The root cause for that is non-generated partials file.

The following commands fail:
```
jfrog rt u "*.nothing" generic-local/ --build-name=bob --build-number=1
jfrog rt dl "generic-local/*.nothing" --build-name=bob --build-number=1
```
Results:
> [Error] open : no such file or directory