### PR TITLE
Add plugins common utils

### DIFF
--- a/plugins/commonutils.go
+++ b/plugins/commonutils.go
@@ -1,0 +1,35 @@
+package plugins
+
+import (
+	"errors"
+
+	"github.com/jfrog/jfrog-cli-core/artifactory/commands"
+	"github.com/jfrog/jfrog-cli-core/plugins/components"
+	"github.com/jfrog/jfrog-cli-core/utils/config"
+	"github.com/jfrog/jfrog-client-go/utils"
+)
+
+// Get the common 'server-id' flag
+func GetServerIdFlag() components.StringFlag {
+	return components.StringFlag{
+		Name:        "server-id",
+		Description: "Artifactory server ID configured using the config command.",
+	}
+}
+
+// Return the Artifactory Details of the provided 'server-id', or the default one.
+func GetRtDetails(c *components.Context) (*config.ArtifactoryDetails, error) {
+	details, err := commands.GetConfig(c.GetStringFlagValue("server-id"), false)
+	if err != nil {
+		return nil, err
+	}
+	if details.Url == "" {
+		return nil, errors.New("no server-id was found, or the server-id has no url")
+	}
+	details.Url = utils.AddTrailingSlashIfNeeded(details.Url)
+	err = config.CreateInitialRefreshableTokensIfNeeded(details)
+	if err != nil {
+		return nil, err
+	}
+	return details, nil
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add infrastructure for adding common plugins utils.
Add 2 common utils:
1. GetServerIdFlag - Get the `server-id` common flag.
2. GetRtDetails - Get the Artifactory Details of the provided 'server-id', or the default one