### PR TITLE
Improve conf tests

### DIFF
--- a/artifactory/commands/testdata/jfrog-cli.conf
+++ b/artifactory/commands/testdata/jfrog-cli.conf
@@ -14,5 +14,5 @@
       "isDefault": true
     }
   ],
-  "version": "3"
+  "version": "4"
 }

--- a/tests/jfrogclicore_test.go
+++ b/tests/jfrogclicore_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 const (
-	JfrogTestsHome       = ".jfrogCliCoreTest"
 	CoreIntegrationTests = "github.com/jfrog/jfrog-cli-core/tests"
 )
 

--- a/tests/jfrogclicore_test.go
+++ b/tests/jfrogclicore_test.go
@@ -1,13 +1,13 @@
 package tests
 
 import (
+	"os"
+	"testing"
+
 	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/utils/tests"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	clientTests "github.com/jfrog/jfrog-client-go/utils/tests"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 const (
@@ -16,21 +16,15 @@ const (
 )
 
 func TestUnitTests(t *testing.T) {
-	homePath, err := filepath.Abs(JfrogTestsHome)
-	if err != nil {
-		log.Error(err)
-		os.Exit(1)
-	}
-
-	oldHome, err := tests.SetJfrogHome(homePath)
+	oldHome, err := tests.SetJfrogHome()
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)
 	}
 	defer os.Setenv(coreutils.HomeDir, oldHome)
+	defer tests.CleanUnitTestsJfrogHome()
 
 	packages := clientTests.GetTestPackages("./../...")
 	packages = clientTests.ExcludeTestsPackage(packages, CoreIntegrationTests)
 	clientTests.RunTests(packages, false)
-	tests.CleanUnitTestsJfrogHome(homePath)
 }

--- a/utils/config/config_test.go
+++ b/utils/config/config_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/utils/log"
+	"github.com/jfrog/jfrog-cli-core/utils/tests"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -136,6 +137,7 @@ func TestConvertConfigV0ToV2(t *testing.T) {
 }
 
 func TestConfigEncryption(t *testing.T) {
+	// Config
 	tempDirPath, oldHomeDir := createTempEnv(t)
 	defer os.RemoveAll(tempDirPath)
 	defer os.Setenv(coreutils.HomeDir, oldHomeDir)
@@ -183,6 +185,11 @@ func createTempEnv(t *testing.T) (newHomeDir, oldHomeDir string) {
 }
 
 func TestGetArtifactoriesFromConfig(t *testing.T) {
+	oldHome, err := tests.SetJfrogHome()
+	assert.NoError(t, err)
+	defer os.Setenv(coreutils.HomeDir, oldHome)
+	defer tests.CleanUnitTestsJfrogHome()
+
 	config := `
 		{
 		  "artifactory": [

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+const JfrogTestsHome = ".jfrogCliCoreTest"
+
 // Prepare the .git environment for the test. Takes an existing folder and making it .git dir.
 // sourceDirPath - Relative path to the source dir to change to .git
 // targetDirPath - Relative path to the target created .git dir, usually 'testdata' under the parent dir.
@@ -46,8 +48,14 @@ func RenamePath(oldPath, newPath string, t *testing.T) {
 
 // Set HomeDir to desired location.
 // Caller is responsible to set the old home location back.
-func SetJfrogHome(newHome string) (oldHome string, err error) {
-	homePath, err := filepath.Abs(newHome)
+func SetJfrogHome() (oldHome string, err error) {
+	homePath, err := filepath.Abs(JfrogTestsHome)
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
+	homePath, err = filepath.Abs(homePath)
 	if err != nil {
 		return "", err
 	}
@@ -65,7 +73,12 @@ func SetJfrogHome(newHome string) (oldHome string, err error) {
 	return oldHome, nil
 }
 
-func CleanUnitTestsJfrogHome(homePath string) {
+func CleanUnitTestsJfrogHome() {
+	homePath, err := filepath.Abs(JfrogTestsHome)
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
 	errorOccurred := false
 	if err := os.RemoveAll(homePath); err != nil {
 		errorOccurred = true

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-const JfrogTestsHome = ".jfrogCliCoreTest"
+const JfrogTestsHome = ".jfrogTest"
 
 // Prepare the .git environment for the test. Takes an existing folder and making it .git dir.
 // sourceDirPath - Relative path to the source dir to change to .git


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

1. Prevent TestGetArtifactoriesFromConfig from overriding current CLI servers configurations - configure JFROG_HOME before the test starts.
2. Prevent TestRtDetailsFromConfigFile from creating jfrog-cli.conf.v4 file - upgrade test configuration from v3 to v4.