### PR TITLE
Allow running pip install without setup.py

### DIFF
--- a/artifactory/commands/pip/install.go
+++ b/artifactory/commands/pip/install.go
@@ -156,25 +156,16 @@ func (pic *PipInstallCommand) prepare() (pythonExecutablePath string, err error)
 }
 
 func getPackageName(pythonExecutablePath string, pipArgs []string) (string, error) {
-	// Check if using requirements file.
-	isRequirementsFileUsed, err := isCommandUsesRequirementsFile(pipArgs)
-	if err != nil {
-		return "", err
-	}
-	if isRequirementsFileUsed {
-		return "", nil
-	}
-
 	// Build uses setup.py file.
 	// Setup.py should be in current dir.
-	filePath, err := getSetuppyFilePath()
+	filePath, err := getSetupPyFilePath()
 	if err != nil {
 		return "", err
 	}
 
 	if filePath == "" {
-		// Couldn't resolve requirements file or setup.py.
-		return "", errorutils.CheckError(errors.New("Could not find installation file for pip command, the command must include '--requirement' or be executed from within the directory containing the 'setup.py' file."))
+		// setup.py does not exist in directory.
+		return "", nil
 	}
 
 	// Extract package name from setup.py.
@@ -185,22 +176,9 @@ func getPackageName(pythonExecutablePath string, pipArgs []string) (string, erro
 	return packageName, err
 }
 
-// Look for 'requirements' flag in command args.
-// If found, validate the file exists and return its path.
-func isCommandUsesRequirementsFile(args []string) (bool, error) {
-	// Get requirements flag args.
-	_, _, requirementsFilePath, err := utils.FindFlagFirstMatch([]string{"-r", "--requirement"}, args)
-	if err != nil || requirementsFilePath == "" {
-		// Args don't include a path to requirements file.
-		return false, err
-	}
-
-	return true, nil
-}
-
 // Look for 'setup.py' file in current work dir.
 // If found, return its absolute path.
-func getSetuppyFilePath() (string, error) {
+func getSetupPyFilePath() (string, error) {
 	wd, err := os.Getwd()
 	if errorutils.CheckError(err) != nil {
 		return "", err
@@ -213,7 +191,8 @@ func getSetuppyFilePath() (string, error) {
 		return "", err
 	}
 	if !validPath {
-		return "", errorutils.CheckError(errors.New(fmt.Sprintf("Could not find setup.py file in current directory: %s", wd)))
+		log.Debug("Could not find setup.py file in current directory:", wd)
+		return "", nil
 	}
 
 	return filePath, nil

--- a/artifactory/commands/pip/install.go
+++ b/artifactory/commands/pip/install.go
@@ -159,13 +159,9 @@ func getPackageName(pythonExecutablePath string, pipArgs []string) (string, erro
 	// Build uses setup.py file.
 	// Setup.py should be in current dir.
 	filePath, err := getSetupPyFilePath()
-	if err != nil {
+	if err != nil || filePath == "" {
+		// Error was returned or setup.py does not exist in directory.
 		return "", err
-	}
-
-	if filePath == "" {
-		// setup.py does not exist in directory.
-		return "", nil
 	}
 
 	// Extract package name from setup.py.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fixes https://github.com/jfrog/jfrog-cli/issues/948

This PR resolves 2 issues:
1. When setup.py does not exist in CWD, running `jfrog rt pipi <package-name> --build-name=<buildName> --build-number=<buildNumber>` will fail with "Could not find setup.py file in current directory". Only when the `-r` flag provided, the execution didn't fail. The preferred behavior should be: If setup.py does not exist, always use the build name as the module name.
2. When setup.py does exist in CWD, running `jfrog rt pipi <package-name> --build-name=<buildName> --build-number=<buildNumber> -r requirements.txt` will set the module name as the build-name, although it has a setup.py file.