### PR TITLE
Unreleased bug - npm-publish not adding build props

### DIFF
--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -209,11 +209,10 @@ func (npc *NpmPublishCommand) doDeploy(target string, artDetails *config.Artifac
 	up.ArtifactoryCommonParams = &specutils.ArtifactoryCommonParams{Pattern: npc.packedFilePath, Target: target}
 	if npc.collectBuildInfo {
 		utils.SaveBuildGeneralDetails(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber)
-		props, err := utils.CreateBuildProperties(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber)
+		up.BuildProps, err = utils.CreateBuildProperties(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber)
 		if err != nil {
 			return nil, err
 		}
-		up.ArtifactoryCommonParams.Props = props
 	}
 	resultsReader, _, failed, err := servicesManager.UploadFilesWithResultReader(up)
 	defer resultsReader.Close()


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fixes the following unreleased bug, which was detected by the npm tests:
When publishing an npm package to Artifactory, the package is deployed without the build.name, build.number and build.timestamp props.

This caused the following tests failures:
```

[Info] [Command] jfrog rt npmp cli-tests-npm-1611824469 --npm-args= --build-name=cli-tests-npm-build-1611824469 --build-number=9 --module=jfrog-test
[Warn] You are using a deprecated syntax of the "npmp" command.
	To use the new syntax, the command expects the details of the Artifactory server and repositories to be pre-configured.
	To create this configuration, run the following command from the root directory of the project:
	$ jfrog rt npmc
	This will create the configuration inside the .jfrog directory under the root directory of the project.
	The new command syntax looks very similar to the npm CLI command i.e.:
	$ jfrog rt npmp [npm args and option] --build-name=*BUILD_NAME* --build-number=*BUILD_NUMBER*
[Info] Running npm Publish
npm notice 
npm notice package: @jscope/jfrog-cli-tests@1.0.0
npm notice === Tarball Contents === 
npm notice 335B package.json
npm notice === Tarball Details === 
npm notice name:          @jscope/jfrog-cli-tests                 
npm notice version:       1.0.0                                   
npm notice filename:      jscope-jfrog-cli-tests-1.0.0.tgz        
npm notice package size:  299 B                                   
npm notice unpacked size: 335 B                                   
npm notice shasum:        d7e333cccd7c3ae37bdaf5f6956ceb8d4d152df6
npm notice integrity:     sha512-l6S4V3jBzQEP4[...]J+DBfJg0oqebg==
npm notice total files:   1                                       
npm notice 
jscope-jfrog-cli-tests-1.0.0.tgz
[Info] [Thread 2] Uploading artifact: C:\gopath\src\github.com\jfrog\jfrog-cli\out\npmscopedproject\jscope-jfrog-cli-tests-1.0.0.tgz
[Info] npm publish finished successfully.
[Info] [Command] jfrog rt bp cli-tests-npm-build-1611824469 9
[Info] Deploying build info...
[Info] Build info successfully deployed. Browse it in Artifactory under *****/webapp/builds/cli-tests-npm-build-1611824469/9
[Info] Searching artifacts...
[Info] Found 0 artifacts.
    utils.go:174: 
        	Error Trace:	utils.go:174
        	            				artifactory_test.go:3995
        	            				npm_test.go:287
        	            				npm_test.go:99
        	            				npm_test.go:46
        	Error:      	elements differ
        	            	
        	            	extra elements in list A:
        	            	([]interface {}) (len=1) {
        	            	 (string) (len=76) "cli-tests-npm-1611824469/@jscope/jfrog-cli-tests/-/jfrog-cli-tests-1.0.0.tgz"
        	            	}
        	            	
        	            	
        	            	listA:
        	            	([]string) (len=1) {
        	            	 (string) (len=76) "cli-tests-npm-1611824469/@jscope/jfrog-cli-tests/-/jfrog-cli-tests-1.0.0.tgz"
        	            	}
        	            	
        	            	
        	            	listB:
        	            	([]string) <nil>
        	Test:       	TestLegacyNpm
        	Messages:   	Expected: [cli-tests-npm-1611824469/@jscope/jfrog-cli-tests/-/jfrog-cli-tests-1.0.0.tgz] 
        	            	Actual: []
[Info] [Command] jfrog rt npm-publish cli-tests-npm-1611824469 --npm-args= --build-name=cli-tests-npm-build-1611824469 --build-number=10
[Warn] You are using a deprecated syntax of the "npm-publish" command.
	To use the new syntax, the command expects the details of the Artifactory server and repositories to be pre-configured.
	To create this configuration, run the following command from the root directory of the project:
	$ jfrog rt npmc
	This will create the configuration inside the .jfrog directory under the root directory of the project.
	The new command syntax looks very similar to the npm CLI command i.e.:
	$ jfrog rt npm-publish [npm args and option] --build-name=*BUILD_NAME* --build-number=*BUILD_NUMBER*
[Info] Running npm Publish
npm notice 
npm notice package: jfrog-cli-tests@1.0.0
npm notice === Tarball Contents === 
npm notice 316B package.json
npm notice === Tarball Details === 
npm notice name:          jfrog-cli-tests                         
npm notice version:       1.0.0                                   
npm notice filename:      jfrog-cli-tests-1.0.0.tgz               
npm notice package size:  282 B                                   
npm notice unpacked size: 316 B                                   
npm notice shasum:        f80807089a52662e67666c53bfe143e60b529d4a
npm notice integrity:     sha512-QpGUCNexprUON[...]U7Z6bHDKfXYFg==
npm notice total files:   1                                       
npm notice 
jfrog-cli-tests-1.0.0.tgz
[Info] [Thread 2] Uploading artifact: C:\gopath\src\github.com\jfrog\jfrog-cli\out\npmproject\jfrog-cli-tests-1.0.0.tgz
[Info] npm publish finished successfully.
[Info] [Command] jfrog rt bp cli-tests-npm-build-1611824469 10
[Info] Deploying build info...
[Info] Build info successfully deployed. Browse it in Artifactory under *****/webapp/builds/cli-tests-npm-build-1611824469/10
[Info] Searching artifacts...
[Info] Found 0 artifacts.
    utils.go:174: 
        	Error Trace:	utils.go:174
        	            				artifactory_test.go:3995
        	            				npm_test.go:280
        	            				npm_test.go:99
        	            				npm_test.go:46
        	Error:      	elements differ
        	            	
        	            	extra elements in list A:
        	            	([]interface {}) (len=1) {
        	            	 (string) (len=68) "cli-tests-npm-1611824469/jfrog-cli-tests/-/jfrog-cli-tests-1.0.0.tgz"
        	            	}
        	            	
        	            	
        	            	listA:
        	            	([]string) (len=1) {
        	            	 (string) (len=68) "cli-tests-npm-1611824469/jfrog-cli-tests/-/jfrog-cli-tests-1.0.0.tgz"
        	            	}
        	            	
        	            	
        	            	listB:
        	            	([]string) <nil>
        	Test:       	TestLegacyNpm
        	Messages:   	Expected: [cli-tests-npm-1611824469/jfrog-cli-tests/-/jfrog-cli-tests-1.0.0.tgz] 
        	            	Actual: []
[Info] Searching artifacts...
[Info] Found 3 artifacts.
[Info] [Thread 2] Deleting cli-tests-npm-1611824469/.npm
[Info] [Thread 1] Deleting cli-tests-npm-1611824469/jfrog-cli-tests
[Info] [Thread 0] Deleting cli-tests-npm-1611824469/@jscope
--- FAIL: TestLegacyNpm (65.64s)
=== RUN   TestNativeNpm
[Info] [Command] jfrog rt c default --interactive=false --url=*****/ --enc-password=true

```