### PR TITLE
Support for Artifactory Projects

### DIFF
--- a/artifactory/commands/buildinfo/adddependencies.go
+++ b/artifactory/commands/buildinfo/adddependencies.go
@@ -43,7 +43,7 @@ func (badc *BuildAddDependenciesCommand) RtDetails() (*config.ArtifactoryDetails
 func (badc *BuildAddDependenciesCommand) Run() error {
 	log.Info("Running Build Add Dependencies command...")
 	if !badc.dryRun {
-		if err := utils.SaveBuildGeneralDetails(badc.buildConfiguration.BuildName, badc.buildConfiguration.BuildNumber); err != nil {
+		if err := utils.SaveBuildGeneralDetails(badc.buildConfiguration.BuildName, badc.buildConfiguration.BuildNumber, badc.buildConfiguration.Project); err != nil {
 			return err
 		}
 	}
@@ -203,7 +203,7 @@ func (badc *BuildAddDependenciesCommand) saveDependenciesToFileSystem(files map[
 	populateFunc := func(partial *buildinfo.Partial) {
 		partial.Dependencies = convertFileInfoToDependencies(files)
 	}
-	return utils.SavePartialBuildInfo(badc.buildConfiguration.BuildName, badc.buildConfiguration.BuildNumber, populateFunc)
+	return utils.SavePartialBuildInfo(badc.buildConfiguration.BuildName, badc.buildConfiguration.BuildNumber, badc.buildConfiguration.Project, populateFunc)
 }
 
 func convertFileInfoToDependencies(files map[string]*fileutils.FileDetails) []buildinfo.Dependency {

--- a/artifactory/commands/buildinfo/addgit.go
+++ b/artifactory/commands/buildinfo/addgit.go
@@ -66,7 +66,7 @@ func (config *BuildAddGitCommand) SetServerId(serverId string) *BuildAddGitComma
 
 func (config *BuildAddGitCommand) Run() error {
 	log.Info("Collecting git revision and remote url...")
-	err := utils.SaveBuildGeneralDetails(config.buildConfiguration.BuildName, config.buildConfiguration.BuildNumber)
+	err := utils.SaveBuildGeneralDetails(config.buildConfiguration.BuildName, config.buildConfiguration.BuildNumber, config.buildConfiguration.Project)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (config *BuildAddGitCommand) Run() error {
 			}
 		}
 	}
-	err = utils.SavePartialBuildInfo(config.buildConfiguration.BuildName, config.buildConfiguration.BuildNumber, populateFunc)
+	err = utils.SavePartialBuildInfo(config.buildConfiguration.BuildName, config.buildConfiguration.BuildNumber, config.buildConfiguration.Project, populateFunc)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/buildinfo/addgit_test.go
+++ b/artifactory/commands/buildinfo/addgit_test.go
@@ -36,7 +36,7 @@ func runTest(t *testing.T, originalDir string) {
 	baseDir, dotGitPath := tests.PrepareDotGitDir(t, originalDir, filepath.Join("..", "testdata"))
 	buildDir := getBuildDir(t)
 	checkFailureAndClean(t, buildDir, dotGitPath)
-	partials := getBuildInfoPartials(baseDir, t, buildName, "1")
+	partials := getBuildInfoPartials(baseDir, t, buildName, "1", "")
 	checkFailureAndClean(t, buildDir, dotGitPath)
 	checkVCSUrl(partials, t)
 	tests.RemovePath(buildDir, t)
@@ -53,14 +53,14 @@ func checkFailureAndClean(t *testing.T, buildDir string, oldPath string) {
 	}
 }
 
-func getBuildInfoPartials(baseDir string, t *testing.T, buildName string, buildNumber string) buildinfo.Partials {
+func getBuildInfoPartials(baseDir string, t *testing.T, buildName, buildNumber, projectKey string) buildinfo.Partials {
 	buildAddGitConfiguration := new(BuildAddGitCommand).SetDotGitPath(baseDir).SetBuildConfiguration(&utils.BuildConfiguration{BuildName: buildName, BuildNumber: buildNumber})
 	err := buildAddGitConfiguration.Run()
 	if err != nil {
 		t.Error("Cannot run build add git due to: " + err.Error())
 		return nil
 	}
-	partials, err := utils.ReadPartialBuildInfoFiles(buildName, buildNumber)
+	partials, err := utils.ReadPartialBuildInfoFiles(buildName, buildNumber, projectKey)
 	if err != nil {
 		t.Error("Cannot read partial build info due to: " + err.Error())
 		return nil
@@ -69,7 +69,7 @@ func getBuildInfoPartials(baseDir string, t *testing.T, buildName string, buildN
 }
 
 func getBuildDir(t *testing.T) string {
-	buildDir, err := utils.GetBuildDir(buildName, "1")
+	buildDir, err := utils.GetBuildDir(buildName, "1", "")
 	if err != nil {
 		t.Error("Cannot create temp dir due to: " + err.Error())
 		return ""

--- a/artifactory/commands/buildinfo/buildappend.go
+++ b/artifactory/commands/buildinfo/buildappend.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jfrog/jfrog-cli-core/utils/config"
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
+	servicesutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/http/httpclient"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
@@ -128,7 +129,11 @@ func (bac *BuildAppendCommand) getChecksumDetails(timestamp int64) (fileutils.Ch
 		return fileutils.ChecksumDetails{}, err
 	}
 
-	buildInfoPath := serviceDetails.GetUrl() + "artifactory-build-info/" + bac.buildNameToAppend + "/" + bac.buildNumberToAppend + "-" + strconv.FormatInt(timestamp, 10) + ".json"
+	buildInfoRepo := servicesutils.BuildRepoNameFromPrpjectKey(bac.buildConfiguration.Project)
+	if buildInfoRepo == "" {
+		buildInfoRepo = "artifactory-build-info"
+	}
+	buildInfoPath := serviceDetails.GetUrl() + buildInfoRepo + "/" + bac.buildNameToAppend + "/" + bac.buildNumberToAppend + "-" + strconv.FormatInt(timestamp, 10) + ".json"
 	details, resp, err := client.GetRemoteFileDetails(buildInfoPath, serviceDetails.CreateHttpClientDetails())
 	if err != nil {
 		return fileutils.ChecksumDetails{}, err

--- a/artifactory/commands/buildinfo/buildappend.go
+++ b/artifactory/commands/buildinfo/buildappend.go
@@ -38,7 +38,7 @@ func (bac *BuildAppendCommand) RtDetails() (*config.ArtifactoryDetails, error) {
 
 func (bac *BuildAppendCommand) Run() error {
 	log.Info("Running Build Append command...")
-	if err := utils.SaveBuildGeneralDetails(bac.buildConfiguration.BuildName, bac.buildConfiguration.BuildNumber); err != nil {
+	if err := utils.SaveBuildGeneralDetails(bac.buildConfiguration.BuildName, bac.buildConfiguration.BuildNumber, bac.buildConfiguration.Project); err != nil {
 		return err
 	}
 
@@ -63,7 +63,7 @@ func (bac *BuildAppendCommand) Run() error {
 			Md5:  checksumDetails.Md5,
 		}
 	}
-	err = utils.SavePartialBuildInfo(bac.buildConfiguration.BuildName, bac.buildConfiguration.BuildNumber, populateFunc)
+	err = utils.SavePartialBuildInfo(bac.buildConfiguration.BuildName, bac.buildConfiguration.BuildNumber, bac.buildConfiguration.Project, populateFunc)
 	if err == nil {
 		log.Info("Build", bac.buildNameToAppend+"/"+bac.buildNumberToAppend, "successfully appended to", bac.buildConfiguration.BuildName+"/"+bac.buildConfiguration.BuildNumber)
 	}
@@ -129,7 +129,7 @@ func (bac *BuildAppendCommand) getChecksumDetails(timestamp int64) (fileutils.Ch
 		return fileutils.ChecksumDetails{}, err
 	}
 
-	buildInfoRepo := servicesutils.BuildRepoNameFromPrpjectKey(bac.buildConfiguration.Project)
+	buildInfoRepo := servicesutils.BuildRepoNameFromProjectKey(bac.buildConfiguration.Project)
 	if buildInfoRepo == "" {
 		buildInfoRepo = "artifactory-build-info"
 	}

--- a/artifactory/commands/buildinfo/clean.go
+++ b/artifactory/commands/buildinfo/clean.go
@@ -30,7 +30,7 @@ func (bcc *BuildCleanCommand) RtDetails() (*config.ArtifactoryDetails, error) {
 
 func (bcc *BuildCleanCommand) Run() error {
 	log.Info("Cleaning build info...")
-	err := utils.RemoveBuildDir(bcc.buildConfiguration.BuildName, bcc.buildConfiguration.BuildNumber)
+	err := utils.RemoveBuildDir(bcc.buildConfiguration.BuildName, bcc.buildConfiguration.BuildNumber, bcc.buildConfiguration.Project)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/buildinfo/collectenv.go
+++ b/artifactory/commands/buildinfo/collectenv.go
@@ -24,14 +24,14 @@ func (bcec *BuildCollectEnvCommand) SetBuildConfiguration(buildConfiguration *ut
 
 func (bcec *BuildCollectEnvCommand) Run() error {
 	log.Info("Collecting environment variables...")
-	err := utils.SaveBuildGeneralDetails(bcec.buildConfiguration.BuildName, bcec.buildConfiguration.BuildNumber)
+	err := utils.SaveBuildGeneralDetails(bcec.buildConfiguration.BuildName, bcec.buildConfiguration.BuildNumber, bcec.buildConfiguration.Project)
 	if err != nil {
 		return err
 	}
 	populateFunc := func(partial *buildinfo.Partial) {
 		partial.Env = getEnvVariables()
 	}
-	err = utils.SavePartialBuildInfo(bcec.buildConfiguration.BuildName, bcec.buildConfiguration.BuildNumber, populateFunc)
+	err = utils.SavePartialBuildInfo(bcec.buildConfiguration.BuildName, bcec.buildConfiguration.BuildNumber, bcec.buildConfiguration.Project, populateFunc)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/buildinfo/publish.go
+++ b/artifactory/commands/buildinfo/publish.go
@@ -55,7 +55,7 @@ func (bpc *BuildPublishCommand) Run() error {
 		return err
 	}
 
-	generatedBuildsInfo, err := utils.GetGeneratedBuildsInfo(bpc.buildConfiguration.BuildName, bpc.buildConfiguration.BuildNumber)
+	generatedBuildsInfo, err := utils.GetGeneratedBuildsInfo(bpc.buildConfiguration.BuildName, bpc.buildConfiguration.BuildNumber, bpc.buildConfiguration.Project)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func (bpc *BuildPublishCommand) Run() error {
 	}
 
 	if !bpc.config.DryRun {
-		return utils.RemoveBuildDir(bpc.buildConfiguration.BuildName, bpc.buildConfiguration.BuildNumber)
+		return utils.RemoveBuildDir(bpc.buildConfiguration.BuildName, bpc.buildConfiguration.BuildNumber, bpc.buildConfiguration.Project)
 	}
 	return nil
 }
@@ -77,7 +77,8 @@ func (bpc *BuildPublishCommand) Run() error {
 func (bpc *BuildPublishCommand) createBuildInfoFromPartials() (*buildinfo.BuildInfo, error) {
 	buildName := bpc.buildConfiguration.BuildName
 	buildNumber := bpc.buildConfiguration.BuildNumber
-	partials, err := utils.ReadPartialBuildInfoFiles(buildName, buildNumber)
+	projectKey := bpc.buildConfiguration.Project
+	partials, err := utils.ReadPartialBuildInfoFiles(buildName, buildNumber, projectKey)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func (bpc *BuildPublishCommand) createBuildInfoFromPartials() (*buildinfo.BuildI
 	buildInfo.SetArtifactoryPluginVersion(coreutils.GetUserAgent())
 	buildInfo.Name = buildName
 	buildInfo.Number = buildNumber
-	buildGeneralDetails, err := utils.ReadBuildInfoGeneralDetails(buildName, buildNumber)
+	buildGeneralDetails, err := utils.ReadBuildInfoGeneralDetails(buildName, buildNumber, projectKey)
 	if err != nil {
 		return nil, err
 	}

--- a/artifactory/commands/buildinfo/publish.go
+++ b/artifactory/commands/buildinfo/publish.go
@@ -64,8 +64,7 @@ func (bpc *BuildPublishCommand) Run() error {
 		buildInfo.Append(v)
 	}
 
-	project := utils.GetBuildProject(bpc.buildConfiguration.Project)
-	if err = servicesManager.PublishBuildInfo(buildInfo, project); err != nil {
+	if err = servicesManager.PublishBuildInfo(buildInfo, bpc.buildConfiguration.Project); err != nil {
 		return err
 	}
 

--- a/artifactory/commands/buildinfo/xrayscan.go
+++ b/artifactory/commands/buildinfo/xrayscan.go
@@ -50,7 +50,7 @@ func (bsc *BuildScanCommand) Run() error {
 		return err
 	}
 
-	xrayScanParams := getXrayScanParams(bsc.buildConfiguration.BuildName, bsc.buildConfiguration.BuildNumber)
+	xrayScanParams := getXrayScanParams(*bsc.buildConfiguration)
 	result, err := servicesManager.XrayScanBuild(xrayScanParams)
 	if err != nil {
 		return err
@@ -88,10 +88,11 @@ type scanSummary struct {
 	Url         string `json:"more_details_url,omitempty"`
 }
 
-func getXrayScanParams(buildName, buildNumber string) services.XrayScanParams {
+func getXrayScanParams(buildConfiguration utils.BuildConfiguration) services.XrayScanParams {
 	xrayScanParams := services.NewXrayScanParams()
-	xrayScanParams.BuildName = buildName
-	xrayScanParams.BuildNumber = buildNumber
+	xrayScanParams.BuildName = buildConfiguration.BuildName
+	xrayScanParams.BuildNumber = buildConfiguration.BuildNumber
+	xrayScanParams.ProjectKey = buildConfiguration.Project
 
 	return xrayScanParams
 }

--- a/artifactory/commands/container/buildcreate.go
+++ b/artifactory/commands/container/buildcreate.go
@@ -35,7 +35,7 @@ func (bpc *BuildDockerCreateCommand) Run() error {
 	buildName := bpc.BuildConfiguration().BuildName
 	buildNumber := bpc.BuildConfiguration().BuildNumber
 	project := bpc.BuildConfiguration().Project
-	if err := utils.SaveBuildGeneralDetails(buildName, buildNumber); err != nil {
+	if err := utils.SaveBuildGeneralDetails(buildName, buildNumber, project); err != nil {
 		return err
 	}
 	serviceManager, err := utils.CreateServiceManager(rtDetails, false)
@@ -50,7 +50,7 @@ func (bpc *BuildDockerCreateCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	return utils.SaveBuildInfo(buildName, buildNumber, buildInfo)
+	return utils.SaveBuildInfo(buildName, buildNumber, project, buildInfo)
 }
 
 func (pc *BuildDockerCreateCommand) CommandName() string {

--- a/artifactory/commands/container/buildcreate.go
+++ b/artifactory/commands/container/buildcreate.go
@@ -34,6 +34,7 @@ func (bpc *BuildDockerCreateCommand) Run() error {
 	image := container.NewImage(bpc.imageTag)
 	buildName := bpc.BuildConfiguration().BuildName
 	buildNumber := bpc.BuildConfiguration().BuildNumber
+	project := bpc.BuildConfiguration().Project
 	if err := utils.SaveBuildGeneralDetails(buildName, buildNumber); err != nil {
 		return err
 	}
@@ -41,7 +42,7 @@ func (bpc *BuildDockerCreateCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	builder, err := container.NewKanikoBuildInfoBuilder(image, bpc.Repo(), buildName, buildNumber, serviceManager, container.Push, cm, bpc.manifestSha256)
+	builder, err := container.NewKanikoBuildInfoBuilder(image, bpc.Repo(), buildName, buildNumber, project, serviceManager, container.Push, cm, bpc.manifestSha256)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/container/pull.go
+++ b/artifactory/commands/container/pull.go
@@ -41,6 +41,7 @@ func (pc *PullCommand) Run() error {
 	}
 	buildName := pc.BuildConfiguration().BuildName
 	buildNumber := pc.BuildConfiguration().BuildNumber
+	project := pc.BuildConfiguration().Project
 	// Return if no build name and number was provided
 	if buildName == "" || buildNumber == "" {
 		return nil
@@ -52,7 +53,7 @@ func (pc *PullCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	builder, err := container.NewBuildInfoBuilder(image, pc.Repo(), buildName, buildNumber, serviceManager, container.Pull, cm)
+	builder, err := container.NewBuildInfoBuilder(image, pc.Repo(), buildName, buildNumber, project, serviceManager, container.Pull, cm)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/container/pull.go
+++ b/artifactory/commands/container/pull.go
@@ -46,7 +46,7 @@ func (pc *PullCommand) Run() error {
 	if buildName == "" || buildNumber == "" {
 		return nil
 	}
-	if err := utils.SaveBuildGeneralDetails(buildName, buildNumber); err != nil {
+	if err := utils.SaveBuildGeneralDetails(buildName, buildNumber, project); err != nil {
 		return err
 	}
 	serviceManager, err := utils.CreateServiceManager(rtDetails, false)
@@ -61,7 +61,7 @@ func (pc *PullCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	return utils.SaveBuildInfo(buildName, buildNumber, buildInfo)
+	return utils.SaveBuildInfo(buildName, buildNumber, project, buildInfo)
 }
 
 func (pc *PullCommand) CommandName() string {

--- a/artifactory/commands/container/push.go
+++ b/artifactory/commands/container/push.go
@@ -53,7 +53,7 @@ func (pc *PushCommand) Run() error {
 	if pc.buildConfiguration.BuildName == "" || pc.buildConfiguration.BuildNumber == "" {
 		return nil
 	}
-	if err := utils.SaveBuildGeneralDetails(pc.buildConfiguration.BuildName, pc.buildConfiguration.BuildNumber); err != nil {
+	if err := utils.SaveBuildGeneralDetails(pc.buildConfiguration.BuildName, pc.buildConfiguration.BuildNumber, pc.buildConfiguration.Project); err != nil {
 		return err
 	}
 	serviceManager, err := utils.CreateServiceManagerWithThreads(rtDetails, false, pc.threads)
@@ -68,7 +68,7 @@ func (pc *PushCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	return utils.SaveBuildInfo(pc.BuildConfiguration().BuildName, pc.BuildConfiguration().BuildNumber, buildInfo)
+	return utils.SaveBuildInfo(pc.BuildConfiguration().BuildName, pc.BuildConfiguration().BuildNumber, pc.BuildConfiguration().Project, buildInfo)
 }
 
 func (pc *PushCommand) CommandName() string {

--- a/artifactory/commands/container/push.go
+++ b/artifactory/commands/container/push.go
@@ -60,7 +60,7 @@ func (pc *PushCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	builder, err := container.NewBuildInfoBuilder(image, pc.Repo(), pc.BuildConfiguration().BuildName, pc.BuildConfiguration().BuildNumber, serviceManager, container.Push, cm)
+	builder, err := container.NewBuildInfoBuilder(image, pc.Repo(), pc.BuildConfiguration().BuildName, pc.BuildConfiguration().BuildNumber, pc.BuildConfiguration().Project, serviceManager, container.Push, cm)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/dotnet/dotnetcommand.go
+++ b/artifactory/commands/dotnet/dotnetcommand.go
@@ -123,14 +123,14 @@ func (dc *DotnetCommand) Exec() error {
 		return err
 	}
 
-	if err = utils.SaveBuildGeneralDetails(dc.buildConfiguration.BuildName, dc.buildConfiguration.BuildNumber); err != nil {
+	if err = utils.SaveBuildGeneralDetails(dc.buildConfiguration.BuildName, dc.buildConfiguration.BuildNumber, dc.buildConfiguration.Project); err != nil {
 		return err
 	}
 	buildInfo, err := sol.BuildInfo(dc.buildConfiguration.Module)
 	if err != nil {
 		return err
 	}
-	return utils.SaveBuildInfo(dc.buildConfiguration.BuildName, dc.buildConfiguration.BuildNumber, buildInfo)
+	return utils.SaveBuildInfo(dc.buildConfiguration.BuildName, dc.buildConfiguration.BuildNumber, dc.buildConfiguration.Project, buildInfo)
 }
 
 func (dc *DotnetCommand) updateSolutionPathAndGetFileName() (string, error) {

--- a/artifactory/commands/generic/download.go
+++ b/artifactory/commands/generic/download.go
@@ -70,7 +70,7 @@ func (dc *DownloadCommand) download() error {
 	// Build Info Collection:
 	isCollectBuildInfo := len(dc.buildConfiguration.BuildName) > 0 && len(dc.buildConfiguration.BuildNumber) > 0
 	if isCollectBuildInfo && !dc.DryRun() {
-		if err = utils.SaveBuildGeneralDetails(dc.buildConfiguration.BuildName, dc.buildConfiguration.BuildNumber); err != nil {
+		if err = utils.SaveBuildGeneralDetails(dc.buildConfiguration.BuildName, dc.buildConfiguration.BuildNumber, dc.buildConfiguration.Project); err != nil {
 			return err
 		}
 	}
@@ -155,7 +155,7 @@ func (dc *DownloadCommand) download() error {
 			partial.ModuleId = dc.buildConfiguration.Module
 			partial.ModuleType = buildinfo.Generic
 		}
-		err = utils.SavePartialBuildInfo(dc.buildConfiguration.BuildName, dc.buildConfiguration.BuildNumber, populateFunc)
+		err = utils.SavePartialBuildInfo(dc.buildConfiguration.BuildName, dc.buildConfiguration.BuildNumber, dc.buildConfiguration.Project, populateFunc)
 	}
 
 	return err

--- a/artifactory/commands/generic/upload.go
+++ b/artifactory/commands/generic/upload.go
@@ -97,7 +97,7 @@ func (uc *UploadCommand) upload() error {
 		if err := utils.SaveBuildGeneralDetails(uc.buildConfiguration.BuildName, uc.buildConfiguration.BuildNumber); err != nil {
 			return err
 		}
-		buildProps, err = utils.CreateBuildProperties(uc.buildConfiguration.BuildName, uc.buildConfiguration.BuildNumber)
+		buildProps, err = utils.CreateBuildProperties(uc.buildConfiguration.BuildName, uc.buildConfiguration.BuildNumber, uc.buildConfiguration.Project)
 		if err != nil {
 			return err
 		}

--- a/artifactory/commands/generic/upload.go
+++ b/artifactory/commands/generic/upload.go
@@ -94,7 +94,7 @@ func (uc *UploadCommand) upload() error {
 	isCollectBuildInfo := len(uc.buildConfiguration.BuildName) > 0 && len(uc.buildConfiguration.BuildNumber) > 0
 	if isCollectBuildInfo && !uc.DryRun() {
 		addVcsProps = true
-		if err := utils.SaveBuildGeneralDetails(uc.buildConfiguration.BuildName, uc.buildConfiguration.BuildNumber); err != nil {
+		if err := utils.SaveBuildGeneralDetails(uc.buildConfiguration.BuildName, uc.buildConfiguration.BuildNumber, uc.buildConfiguration.Project); err != nil {
 			return err
 		}
 		buildProps, err = utils.CreateBuildProperties(uc.buildConfiguration.BuildName, uc.buildConfiguration.BuildNumber, uc.buildConfiguration.Project)
@@ -173,7 +173,7 @@ func (uc *UploadCommand) upload() error {
 			partial.ModuleId = uc.buildConfiguration.Module
 			partial.ModuleType = buildinfo.Generic
 		}
-		err = utils.SavePartialBuildInfo(uc.buildConfiguration.BuildName, uc.buildConfiguration.BuildNumber, populateFunc)
+		err = utils.SavePartialBuildInfo(uc.buildConfiguration.BuildName, uc.buildConfiguration.BuildNumber, uc.buildConfiguration.Project, populateFunc)
 
 	}
 	return err

--- a/artifactory/commands/golang/go.go
+++ b/artifactory/commands/golang/go.go
@@ -85,9 +85,10 @@ func (gc *GoCommand) Run() error {
 	}
 	buildName := gc.buildConfiguration.BuildName
 	buildNumber := gc.buildConfiguration.BuildNumber
+	projectKey := gc.buildConfiguration.Project
 	isCollectBuildInfo := len(buildName) > 0 && len(buildNumber) > 0
 	if isCollectBuildInfo {
-		err = utils.SaveBuildGeneralDetails(buildName, buildNumber)
+		err = utils.SaveBuildGeneralDetails(buildName, buildNumber, projectKey)
 		if err != nil {
 			return err
 		}
@@ -165,7 +166,7 @@ func (gc *GoCommand) Run() error {
 		if err != nil {
 			return err
 		}
-		err = utils.SaveBuildInfo(buildName, buildNumber, goProject.BuildInfo(false, gc.buildConfiguration.Module, targetRepo))
+		err = utils.SaveBuildInfo(buildName, buildNumber, projectKey, goProject.BuildInfo(false, gc.buildConfiguration.Module, targetRepo))
 	}
 
 	return err

--- a/artifactory/commands/golang/gopublish.go
+++ b/artifactory/commands/golang/gopublish.go
@@ -87,7 +87,7 @@ func (gpc *GoPublishCommand) Run() error {
 	projectKey := gpc.buildConfiguration.Project
 	isCollectBuildInfo := len(buildName) > 0 && len(buildNumber) > 0
 	if isCollectBuildInfo {
-		err = utils.SaveBuildGeneralDetails(buildName, buildNumber)
+		err = utils.SaveBuildGeneralDetails(buildName, buildNumber, projectKey)
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ func (gpc *GoPublishCommand) Run() error {
 		if err != nil {
 			return err
 		}
-		err = utils.SaveBuildInfo(buildName, buildNumber, goProject.BuildInfo(true, gpc.buildConfiguration.Module, gpc.RepositoryConfig.TargetRepo()))
+		err = utils.SaveBuildInfo(buildName, buildNumber, projectKey, goProject.BuildInfo(true, gpc.buildConfiguration.Module, gpc.RepositoryConfig.TargetRepo()))
 	}
 
 	return err

--- a/artifactory/commands/golang/gopublish.go
+++ b/artifactory/commands/golang/gopublish.go
@@ -84,6 +84,7 @@ func (gpc *GoPublishCommand) Run() error {
 
 	buildName := gpc.buildConfiguration.BuildName
 	buildNumber := gpc.buildConfiguration.BuildNumber
+	projectKey := gpc.buildConfiguration.Project
 	isCollectBuildInfo := len(buildName) > 0 && len(buildNumber) > 0
 	if isCollectBuildInfo {
 		err = utils.SaveBuildGeneralDetails(buildName, buildNumber)
@@ -99,7 +100,7 @@ func (gpc *GoPublishCommand) Run() error {
 
 	// Publish the package to Artifactory
 	if gpc.publishPackage {
-		err = goProject.PublishPackage(gpc.TargetRepo(), buildName, buildNumber, serviceManager)
+		err = goProject.PublishPackage(gpc.TargetRepo(), buildName, buildNumber, projectKey, serviceManager)
 		if err != nil {
 			return err
 		}

--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -130,7 +130,7 @@ func createGradleRunConfig(tasks, configPath string, configuration *utils.BuildC
 		vConfig.Set(utils.FORK_COUNT, threads)
 	}
 
-	runConfig.env[gradleBuildInfoProperties], err = utils.CreateBuildInfoPropertiesFile(configuration.BuildName, configuration.BuildNumber, vConfig, utils.Gradle)
+	runConfig.env[gradleBuildInfoProperties], err = utils.CreateBuildInfoPropertiesFile(configuration.BuildName, configuration.BuildNumber, configuration.Project, vConfig, utils.Gradle)
 	if err != nil {
 		return nil, err
 	}

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -185,6 +185,7 @@ func (mc *MvnCommand) createMvnRunConfig(dependenciesPath string) (*mvnRunConfig
 	if len(mc.configuration.BuildName) > 0 && len(mc.configuration.BuildNumber) > 0 {
 		vConfig.Set(utils.BUILD_NAME, mc.configuration.BuildName)
 		vConfig.Set(utils.BUILD_NUMBER, mc.configuration.BuildNumber)
+		vConfig.Set(utils.BUILD_PROJECT, mc.configuration.Project)
 		err = utils.SaveBuildGeneralDetails(mc.configuration.BuildName, mc.configuration.BuildNumber)
 		if err != nil {
 			return nil, err
@@ -200,7 +201,7 @@ func (mc *MvnCommand) createMvnRunConfig(dependenciesPath string) (*mvnRunConfig
 		setEmptyDeployer(vConfig)
 	}
 
-	buildInfoProperties, err := utils.CreateBuildInfoPropertiesFile(mc.configuration.BuildName, mc.configuration.BuildNumber, vConfig, utils.Maven)
+	buildInfoProperties, err := utils.CreateBuildInfoPropertiesFile(mc.configuration.BuildName, mc.configuration.BuildNumber, mc.configuration.Project, vConfig, utils.Maven)
 	if err != nil {
 		return nil, err
 	}

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -186,7 +186,7 @@ func (mc *MvnCommand) createMvnRunConfig(dependenciesPath string) (*mvnRunConfig
 		vConfig.Set(utils.BUILD_NAME, mc.configuration.BuildName)
 		vConfig.Set(utils.BUILD_NUMBER, mc.configuration.BuildNumber)
 		vConfig.Set(utils.BUILD_PROJECT, mc.configuration.Project)
-		err = utils.SaveBuildGeneralDetails(mc.configuration.BuildName, mc.configuration.BuildNumber)
+		err = utils.SaveBuildGeneralDetails(mc.configuration.BuildName, mc.configuration.BuildNumber, mc.configuration.Project)
 		if err != nil {
 			return nil, err
 		}

--- a/artifactory/commands/npm/installorci.go
+++ b/artifactory/commands/npm/installorci.go
@@ -210,7 +210,7 @@ func (nca *NpmCommandArgs) prepareBuildInfo() error {
 	var err error
 	if len(nca.buildConfiguration.BuildName) > 0 && len(nca.buildConfiguration.BuildNumber) > 0 {
 		nca.collectBuildInfo = true
-		if err = utils.SaveBuildGeneralDetails(nca.buildConfiguration.BuildName, nca.buildConfiguration.BuildNumber); err != nil {
+		if err = utils.SaveBuildGeneralDetails(nca.buildConfiguration.BuildName, nca.buildConfiguration.BuildNumber, nca.buildConfiguration.Project); err != nil {
 			return err
 		}
 
@@ -379,7 +379,7 @@ func (nca *NpmCommandArgs) saveDependenciesData() error {
 		partial.ModuleType = buildinfo.Npm
 	}
 
-	if err := utils.SavePartialBuildInfo(nca.buildConfiguration.BuildName, nca.buildConfiguration.BuildNumber, populateFunc); err != nil {
+	if err := utils.SavePartialBuildInfo(nca.buildConfiguration.BuildName, nca.buildConfiguration.BuildNumber, nca.buildConfiguration.Project, populateFunc); err != nil {
 		return err
 	}
 

--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -209,7 +209,7 @@ func (npc *NpmPublishCommand) doDeploy(target string, artDetails *config.Artifac
 	up.ArtifactoryCommonParams = &specutils.ArtifactoryCommonParams{Pattern: npc.packedFilePath, Target: target}
 	if npc.collectBuildInfo {
 		utils.SaveBuildGeneralDetails(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber)
-		up.BuildProps, err = utils.CreateBuildProperties(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber)
+		up.BuildProps, err = utils.CreateBuildProperties(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber, npc.buildConfiguration.Project)
 		if err != nil {
 			return nil, err
 		}

--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -208,7 +208,7 @@ func (npc *NpmPublishCommand) doDeploy(target string, artDetails *config.Artifac
 	up := services.UploadParams{}
 	up.ArtifactoryCommonParams = &specutils.ArtifactoryCommonParams{Pattern: npc.packedFilePath, Target: target}
 	if npc.collectBuildInfo {
-		utils.SaveBuildGeneralDetails(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber)
+		utils.SaveBuildGeneralDetails(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber, npc.buildConfiguration.Project)
 		up.BuildProps, err = utils.CreateBuildProperties(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber, npc.buildConfiguration.Project)
 		if err != nil {
 			return nil, err
@@ -244,7 +244,7 @@ func (npc *NpmPublishCommand) saveArtifactData() error {
 		partial.ModuleId = npc.buildConfiguration.Module
 		partial.ModuleType = buildinfo.Npm
 	}
-	return utils.SavePartialBuildInfo(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber, populateFunc)
+	return utils.SavePartialBuildInfo(npc.buildConfiguration.BuildName, npc.buildConfiguration.BuildNumber, npc.buildConfiguration.Project, populateFunc)
 }
 
 func (npc *NpmPublishCommand) setPublishPath() error {

--- a/artifactory/commands/pip/install.go
+++ b/artifactory/commands/pip/install.go
@@ -107,7 +107,7 @@ func (pic *PipInstallCommand) saveBuildInfo(allDependencies map[string]*buildinf
 	modules = append(modules, module)
 
 	buildInfo.Modules = modules
-	utils.SaveBuildInfo(pic.buildConfiguration.BuildName, pic.buildConfiguration.BuildNumber, buildInfo)
+	utils.SaveBuildInfo(pic.buildConfiguration.BuildName, pic.buildConfiguration.BuildNumber, pic.buildConfiguration.Project, buildInfo)
 }
 
 func (pic *PipInstallCommand) determineModuleName(pythonExecutablePath string) error {
@@ -147,7 +147,7 @@ func (pic *PipInstallCommand) prepare() (pythonExecutablePath string, err error)
 	// Prepare build-info.
 	if pic.buildConfiguration.BuildName != "" && pic.buildConfiguration.BuildNumber != "" {
 		pic.shouldCollectBuildInfo = true
-		if err = utils.SaveBuildGeneralDetails(pic.buildConfiguration.BuildName, pic.buildConfiguration.BuildNumber); err != nil {
+		if err = utils.SaveBuildGeneralDetails(pic.buildConfiguration.BuildName, pic.buildConfiguration.BuildNumber, pic.buildConfiguration.Project); err != nil {
 			return
 		}
 	}
@@ -195,7 +195,7 @@ func getSetupPyFilePath() (string, error) {
 }
 
 func (pic *PipInstallCommand) cleanBuildInfoDir() {
-	if err := utils.RemoveBuildDir(pic.buildConfiguration.BuildName, pic.buildConfiguration.BuildNumber); err != nil {
+	if err := utils.RemoveBuildDir(pic.buildConfiguration.BuildName, pic.buildConfiguration.BuildNumber, pic.buildConfiguration.Project); err != nil {
 		log.Error(fmt.Sprintf("Failed cleaning build-info directory: %s", err.Error()))
 	}
 }

--- a/artifactory/utils/argsutils.go
+++ b/artifactory/utils/argsutils.go
@@ -154,8 +154,17 @@ func ExtractBuildDetailsFromArgs(args []string) (cleanArgs []string, buildConfig
 	}
 	RemoveFlagFromCommand(&cleanArgs, flagIndex, valueIndex)
 
+	flagIndex, valueIndex, buildConfig.Project, err = FindFlag("--project", cleanArgs)
+	if err != nil {
+		return
+	}
+	RemoveFlagFromCommand(&cleanArgs, flagIndex, valueIndex)
+
 	// Retrieve build name and build number from env if both missing
 	buildConfig.BuildName, buildConfig.BuildNumber = GetBuildNameAndNumber(buildConfig.BuildName, buildConfig.BuildNumber)
+	// Retrieve project from env if missing
+	buildConfig.Project = GetBuildProject(buildConfig.Project)
+
 	flagIndex, valueIndex, buildConfig.Module, err = FindFlag("--module", cleanArgs)
 	if err != nil {
 		return

--- a/artifactory/utils/buildinfoproperties.go
+++ b/artifactory/utils/buildinfoproperties.go
@@ -193,11 +193,11 @@ func CreateBuildInfoPropertiesFile(buildName, buildNumber, projectKey string, co
 		return "", err
 	}
 	if buildName != "" || buildNumber != "" {
-		err = SaveBuildGeneralDetails(buildName, buildNumber)
+		err = SaveBuildGeneralDetails(buildName, buildNumber, projectKey)
 		if err != nil {
 			return "", err
 		}
-		err = setBuildTimestampToConfig(buildName, buildNumber, config)
+		err = setBuildTimestampToConfig(buildName, buildNumber, projectKey, config)
 		if err != nil {
 			return "", err
 		}
@@ -292,7 +292,7 @@ func createGeneratedBuildInfoFile(buildName, buildNumber, projectKey string, con
 	config.Set(BUILD_NUMBER, buildNumber)
 	config.Set(BUILD_PROJECT, projectKey)
 
-	buildPath, err := GetBuildDir(config.GetString(BUILD_NAME), config.GetString(BUILD_NUMBER))
+	buildPath, err := GetBuildDir(buildName, buildNumber, projectKey)
 	if err != nil {
 		return err
 	}
@@ -308,8 +308,8 @@ func createGeneratedBuildInfoFile(buildName, buildNumber, projectKey string, con
 	return nil
 }
 
-func setBuildTimestampToConfig(buildName, buildNumber string, config *viper.Viper) error {
-	buildGeneralDetails, err := ReadBuildInfoGeneralDetails(buildName, buildNumber)
+func setBuildTimestampToConfig(buildName, buildNumber, projectKey string, config *viper.Viper) error {
+	buildGeneralDetails, err := ReadBuildInfoGeneralDetails(buildName, buildNumber, projectKey)
 	if err != nil {
 		return err
 	}

--- a/artifactory/utils/buildinfoproperties_test.go
+++ b/artifactory/utils/buildinfoproperties_test.go
@@ -28,7 +28,7 @@ func testCreateDefaultPropertiesFile(projectType ProjectType, t *testing.T) {
 	providedConfig := viper.New()
 	providedConfig.Set("type", projectType.String())
 
-	propsFile, err := CreateBuildInfoPropertiesFile("", "", providedConfig, projectType)
+	propsFile, err := CreateBuildInfoPropertiesFile("", "", "", providedConfig, projectType)
 	if err != nil {
 		t.Error(err)
 	}
@@ -90,7 +90,7 @@ func createSimplePropertiesFile(t *testing.T, propertiesFileConfig map[string]st
 	for k, v := range yamlConfig {
 		vConfig.Set(k, v)
 	}
-	propsFilePath, err := CreateBuildInfoPropertiesFile("", "", vConfig, Maven)
+	propsFilePath, err := CreateBuildInfoPropertiesFile("", "", "", vConfig, Maven)
 	if err != nil {
 		t.Error(err)
 	}
@@ -128,7 +128,7 @@ func TestGeneratedBuildInfoFile(t *testing.T) {
 	for k, v := range yamlConfig {
 		vConfig.Set(k, v)
 	}
-	propsFilePath, err := CreateBuildInfoPropertiesFile("buildName", "buildNumber", vConfig, Maven)
+	propsFilePath, err := CreateBuildInfoPropertiesFile("buildName", "buildNumber", "projectKey", vConfig, Maven)
 	if err != nil {
 		t.Error(err)
 	}

--- a/artifactory/utils/buildutils.go
+++ b/artifactory/utils/buildutils.go
@@ -36,16 +36,22 @@ func GetBuildDir(buildName, buildNumber string) (string, error) {
 	return buildsDir, nil
 }
 
-func CreateBuildProperties(buildName, buildNumber string) (string, error) {
+func CreateBuildProperties(buildName, buildNumber, projectKey string) (string, error) {
 	if buildName == "" || buildNumber == "" {
 		return "", nil
 	}
+
+	buildRepo := utils.BuildRepoNameFromPrpjectKey(projectKey)
+	if buildRepo != "" {
+		buildRepo = ";build.repo=" + buildRepo
+	}
+
 	buildGeneralDetails, err := ReadBuildInfoGeneralDetails(buildName, buildNumber)
 	if err != nil {
-		return fmt.Sprintf("build.name=%s;build.number=%s", buildName, buildNumber), err
+		return fmt.Sprintf("build.name=%s;build.number=%s%s", buildName, buildNumber, buildRepo), err
 	}
 	timestamp := strconv.FormatInt(buildGeneralDetails.Timestamp.UnixNano()/int64(time.Millisecond), 10)
-	return fmt.Sprintf("build.name=%s;build.number=%s;build.timestamp=%s", buildName, buildNumber, timestamp), nil
+	return fmt.Sprintf("build.name=%s;build.number=%s;build.timestamp=%s%s", buildName, buildNumber, timestamp, buildRepo), nil
 }
 
 func getPartialsBuildDir(buildName, buildNumber string) (string, error) {

--- a/artifactory/utils/container/buildinfo.go
+++ b/artifactory/utils/container/buildinfo.go
@@ -32,7 +32,7 @@ type Builder interface {
 }
 
 // Create instance of docker build info builder.
-func newBuildInfoBuilder(builder *buildInfoBuilder, image *Image, repository, buildName, buildNumber string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType, containerManager ContainerManager) (err error) {
+func newBuildInfoBuilder(builder *buildInfoBuilder, image *Image, repository, buildName, buildNumber, project string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType, containerManager ContainerManager) (err error) {
 	builder.repositoryDetails.key = repository
 	builder.repositoryDetails.isRemote, err = artutils.IsRemoteRepo(repository, serviceManager)
 	if err != nil {
@@ -41,26 +41,27 @@ func newBuildInfoBuilder(builder *buildInfoBuilder, image *Image, repository, bu
 	builder.image = image
 	builder.buildName = buildName
 	builder.buildNumber = buildNumber
+	builder.project = project
 	builder.serviceManager = serviceManager
 	builder.commandType = commandType
 	builder.containerManager = containerManager
 	return nil
 }
 
-func NewBuildInfoBuilder(image *Image, repository, buildName, buildNumber string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType, containerManager ContainerManager) (Builder, error) {
+func NewBuildInfoBuilder(image *Image, repository, buildName, buildNumber, project string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType, containerManager ContainerManager) (Builder, error) {
 	builder := &buildInfoBuilder{}
 	var err error
-	if err = newBuildInfoBuilder(builder, image, repository, buildName, buildNumber, serviceManager, commandType, containerManager); err != nil {
+	if err = newBuildInfoBuilder(builder, image, repository, buildName, buildNumber, project, serviceManager, commandType, containerManager); err != nil {
 		return nil, err
 	}
 	builder.imageId, err = builder.containerManager.Id(builder.image)
 	return builder, err
 }
 
-func NewKanikoBuildInfoBuilder(image *Image, repository, buildName, buildNumber string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType, containerManager ContainerManager, manifestSha256 string) (Builder, error) {
+func NewKanikoBuildInfoBuilder(image *Image, repository, buildName, buildNumber, project string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType, containerManager ContainerManager, manifestSha256 string) (Builder, error) {
 	builder := &buildInfoBuilder{}
 	var err error
-	if err = newBuildInfoBuilder(builder, image, repository, buildName, buildNumber, serviceManager, commandType, containerManager); err != nil {
+	if err = newBuildInfoBuilder(builder, image, repository, buildName, buildNumber, project, serviceManager, commandType, containerManager); err != nil {
 		return nil, err
 	}
 	builder.manifestSha256 = manifestSha256
@@ -73,6 +74,7 @@ type buildInfoBuilder struct {
 	repositoryDetails RepositoryDetails
 	buildName         string
 	buildNumber       string
+	project           string
 	serviceManager    artifactory.ArtifactoryServicesManager
 
 	// internal fields
@@ -235,7 +237,7 @@ func (builder *buildInfoBuilder) handleMissingLayer(layerMediaType, layerFileNam
 
 // Set build properties on image layers in Artifactory.
 func (builder *buildInfoBuilder) setBuildProperties() (int, error) {
-	props, err := artutils.CreateBuildProperties(builder.buildName, builder.buildNumber)
+	props, err := artutils.CreateBuildProperties(builder.buildName, builder.buildNumber, builder.project)
 	if err != nil {
 		return 0, err
 	}

--- a/artifactory/utils/golang/project/project.go
+++ b/artifactory/utils/golang/project/project.go
@@ -32,7 +32,7 @@ import (
 type Go interface {
 	Dependencies() []executers.Package
 	CreateBuildInfoDependencies(includeInfoFiles bool) error
-	PublishPackage(targetRepo, buildName, buildNumber string, servicesManager artifactory.ArtifactoryServicesManager) error
+	PublishPackage(targetRepo, buildName, buildNumber, projectKey string, servicesManager artifactory.ArtifactoryServicesManager) error
 	PublishDependencies(targetRepo string, servicesManager artifactory.ArtifactoryServicesManager, includeDepSlice []string) (succeeded, failed int, err error)
 	BuildInfo(includeArtifacts bool, module, targetRepository string) *buildinfo.BuildInfo
 	LoadDependencies() error
@@ -94,10 +94,10 @@ func (project *goProject) loadDependencies() ([]executers.Package, error) {
 }
 
 // Publish go project to Artifactory.
-func (project *goProject) PublishPackage(targetRepo, buildName, buildNumber string, servicesManager artifactory.ArtifactoryServicesManager) error {
+func (project *goProject) PublishPackage(targetRepo, buildName, buildNumber, projectKey string, servicesManager artifactory.ArtifactoryServicesManager) error {
 	log.Info("Publishing", project.getId(), "to", targetRepo)
 
-	props, err := utils.CreateBuildProperties(buildName, buildNumber)
+	props, err := utils.CreateBuildProperties(buildName, buildNumber, projectKey)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,6 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
-replace github.com/jfrog/jfrog-client-go => /Users/eyalb/dev/forks/jfrog-client-go
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go dev
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd master

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,6 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go dev
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v0.19.2-0.20210207101104-3e0d4008c3cc
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd master

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,6 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v0.19.2-0.20210207101104-3e0d4008c3cc
+replace github.com/jfrog/jfrog-client-go => /Users/eyalb/dev/forks/jfrog-client-go
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd master

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/jfrog/jfrog-client-go v0.18.0 h1:r3zAzG8JgQpVsSRWZstWnfGG27uaV6mZccc0
 github.com/jfrog/jfrog-client-go v0.18.0/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
 github.com/jfrog/jfrog-client-go v0.19.1 h1:aejiaRH3BQVdIBNdcje3Y+XE8BbQcew5lyuW1Gsd1ZA=
 github.com/jfrog/jfrog-client-go v0.19.1/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
+github.com/jfrog/jfrog-client-go v0.19.2-0.20210207101104-3e0d4008c3cc h1:59AH3phiTot3KRYXMPUguLtELAEup29z+ad1eDpInYA=
+github.com/jfrog/jfrog-client-go v0.19.2-0.20210207101104-3e0d4008c3cc/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

This PR adds support for the new Projects functionality in Artifactory. It relies on https://github.com/jfrog/jfrog-client-go/pull/283 to be merged before first.

1. The build-publish command now accpets an optional "project" flag, with the project key value. If provided, the build-info is published to the project's build-info repository, named my-project-key-build-info. If not provided, the build-info is published (by default) to a repository named artifactory-build-info.

2. All commands which deploy files to Artifactory also accpet the new "project" flag. They use it to add a new "build.repo" property on each of the deployed artifacts, in addition to the existing "build.name", "build.number" and "build.timestamp" props. The "build.repo" prop stores the name of the build-info repository, which is part of the project, to which the artifacts and the build-info are deployed to.

