### PR TITLE
BuildAddGit - ignore error when revision does not exist in range

### DIFF
--- a/artifactory/commands/buildinfo/addgit.go
+++ b/artifactory/commands/buildinfo/addgit.go
@@ -3,11 +3,6 @@ package buildinfo
 import (
 	"errors"
 	"fmt"
-	"io"
-	"os"
-	"os/exec"
-	"strconv"
-
 	gofrogcmd "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-cli-core/artifactory/utils"
 	utilsconfig "github.com/jfrog/jfrog-cli-core/utils/config"
@@ -18,6 +13,10 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/spf13/viper"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
 )
 
 const (
@@ -178,34 +177,19 @@ func (config *BuildAddGitCommand) collectBuildIssues(vcsUrl string) ([]buildinfo
 }
 
 func (config *BuildAddGitCommand) DoCollect(issuesConfig *IssuesConfiguration, lastVcsRevision string) ([]buildinfo.AffectedIssue, error) {
-	// Create regex pattern.
-	issueRegexp, err := clientutils.GetRegExp(issuesConfig.Regexp)
+	var foundIssues []buildinfo.AffectedIssue
+	logRegExp, err := createLogRegExpHandler(issuesConfig, &foundIssues)
+	if err != nil {
+		return nil, err
+	}
+
+	errRegExp, err := createErrRegExpHandler(lastVcsRevision)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get log with limit, starting from the latest commit.
 	logCmd := &LogCmd{logLimit: issuesConfig.LogLimit, lastVcsRevision: lastVcsRevision}
-	var foundIssues []buildinfo.AffectedIssue
-	logRegExp := gofrogcmd.CmdOutputPattern{
-		RegExp: issueRegexp,
-		ExecFunc: func(pattern *gofrogcmd.CmdOutputPattern) (string, error) {
-			// Reached here - means no error occurred.
-
-			// Check for out of bound results.
-			if len(pattern.MatchedResults)-1 < issuesConfig.KeyGroupIndex || len(pattern.MatchedResults)-1 < issuesConfig.SummaryGroupIndex {
-				return "", errors.New("Unexpected result while parsing issues from git log. Make sure that the regular expression used to find issues, includes two capturing groups, for the issue ID and the summary.")
-			}
-			// Create found Affected Issue.
-			foundIssue := buildinfo.AffectedIssue{Key: pattern.MatchedResults[issuesConfig.KeyGroupIndex], Summary: pattern.MatchedResults[issuesConfig.SummaryGroupIndex], Aggregated: false}
-			if issuesConfig.TrackerUrl != "" {
-				foundIssue.Url = issuesConfig.TrackerUrl + pattern.MatchedResults[issuesConfig.KeyGroupIndex]
-			}
-			foundIssues = append(foundIssues, foundIssue)
-			log.Debug("Found issue: " + pattern.MatchedResults[issuesConfig.KeyGroupIndex])
-			return "", nil
-		},
-	}
 
 	// Change working dir to where .git is.
 	wd, err := os.Getwd()
@@ -219,17 +203,82 @@ func (config *BuildAddGitCommand) DoCollect(issuesConfig *IssuesConfiguration, l
 	}
 
 	// Run git command.
-	_, _, exitOk, err := gofrogcmd.RunCmdWithOutputParser(logCmd, false, &logRegExp)
-	if errorutils.CheckError(err) != nil {
-		return nil, err
+	_, _, exitOk, err := gofrogcmd.RunCmdWithOutputParser(logCmd, false, logRegExp, errRegExp)
+	if err != nil {
+		if _, ok := err.(RevisionRangeError); ok {
+			// Revision not found in range. Ignore and don't collect new issues.
+			log.Info(err.Error())
+			return []buildinfo.AffectedIssue{}, nil
+		}
+		return nil, errorutils.CheckError(err)
 	}
 	if !exitOk {
 		// May happen when trying to run git log for non-existing revision.
-		return nil, errorutils.CheckError(errors.New("Failed executing git log command."))
+		return nil, errorutils.CheckError(errors.New("failed executing git log command"))
 	}
 
 	// Return found issues.
 	return foundIssues, nil
+}
+
+// Creates a regexp handler to parse and fetch issues from the the output of the git log command.
+func createLogRegExpHandler(issuesConfig *IssuesConfiguration, foundIssues *[]buildinfo.AffectedIssue) (*gofrogcmd.CmdOutputPattern, error) {
+	// Create regex pattern.
+	issueRegexp, err := clientutils.GetRegExp(issuesConfig.Regexp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create handler with exec function.
+	logRegExp := gofrogcmd.CmdOutputPattern{
+		RegExp: issueRegexp,
+		ExecFunc: func(pattern *gofrogcmd.CmdOutputPattern) (string, error) {
+			// Reached here - means no error occurred.
+
+			// Check for out of bound results.
+			if len(pattern.MatchedResults)-1 < issuesConfig.KeyGroupIndex || len(pattern.MatchedResults)-1 < issuesConfig.SummaryGroupIndex {
+				return "", errors.New("unexpected result while parsing issues from git log. Make sure that the regular expression used to find issues, includes two capturing groups, for the issue ID and the summary")
+			}
+			// Create found Affected Issue.
+			foundIssue := buildinfo.AffectedIssue{Key: pattern.MatchedResults[issuesConfig.KeyGroupIndex], Summary: pattern.MatchedResults[issuesConfig.SummaryGroupIndex], Aggregated: false}
+			if issuesConfig.TrackerUrl != "" {
+				foundIssue.Url = issuesConfig.TrackerUrl + pattern.MatchedResults[issuesConfig.KeyGroupIndex]
+			}
+			*foundIssues = append(*foundIssues, foundIssue)
+			log.Debug("Found issue: " + pattern.MatchedResults[issuesConfig.KeyGroupIndex])
+			return "", nil
+		},
+	}
+	return &logRegExp, nil
+}
+
+// Error to be thrown when revision could not be found in the git revision range.
+type RevisionRangeError struct {
+	ErrorMsg string
+}
+
+func (err RevisionRangeError) Error() string {
+	return err.ErrorMsg
+}
+
+// Creates a regexp handler to handle the event of revision missing in the git revision range.
+func createErrRegExpHandler(lastVcsRevision string) (*gofrogcmd.CmdOutputPattern, error) {
+	// Create regex pattern.
+	invalidRangeExp, err := clientutils.GetRegExp(`fatal: Invalid revision range [a-fA-F0-9]+\.\.`)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create handler with exec function.
+	errRegExp := gofrogcmd.CmdOutputPattern{
+		RegExp: invalidRangeExp,
+		ExecFunc: func(pattern *gofrogcmd.CmdOutputPattern) (string, error) {
+			// Revision could not be found in the revision range, probably due to a squash / revert. Ignore and don't collect new issues.
+			errMsg := "Revision: '" + lastVcsRevision + "' that was fetched from latest build info does not exist in the git revision range. No new issues are added."
+			return "", RevisionRangeError{ErrorMsg: errMsg}
+		},
+	}
+	return &errRegExp, nil
 }
 
 func (config *BuildAddGitCommand) createIssuesConfigs() (err error) {

--- a/artifactory/commands/buildinfo/addgit_test.go
+++ b/artifactory/commands/buildinfo/addgit_test.go
@@ -2,6 +2,7 @@ package buildinfo
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"strings"
@@ -186,6 +187,11 @@ func TestAddGitDoCollect(t *testing.T) {
 		// Error - should find 2 issues
 		t.Errorf("Issues list expected to have 2 issues, instead found %d issues: %v", len(issues), issues)
 	}
+
+	// Test collection with a made up revision - the command should not throw an error, and 0 issues should be returned.
+	issues, err = config.DoCollect(config.issuesConfig, "abcdefABCDEF1234567890123456789012345678")
+	assert.NoError(t, err)
+	assert.Empty(t, issues)
 
 	// Clean git path
 	tests.RenamePath(dotGitPath, filepath.Join(baseDir, originalFolder), t)


### PR DESCRIPTION
Following [jfrog/jfrog-cli#858](https://github.com/jfrog/jfrog-cli/issues/858)