### PR TITLE
Config - fix pipelines key and default mc URL

### DIFF
--- a/common/commands/config.go
+++ b/common/commands/config.go
@@ -119,7 +119,7 @@ func (cc *ConfigCommand) Config() error {
 		coreutils.SetIfEmpty(&cc.details.ArtifactoryUrl, cc.details.Url+"artifactory/")
 		coreutils.SetIfEmpty(&cc.details.DistributionUrl, cc.details.Url+"distribution/")
 		coreutils.SetIfEmpty(&cc.details.XrayUrl, cc.details.Url+"xray/")
-		coreutils.SetIfEmpty(&cc.details.MissionControlUrl, cc.details.Url+"missioncontrol/")
+		coreutils.SetIfEmpty(&cc.details.MissionControlUrl, cc.details.Url+"mc/")
 		coreutils.SetIfEmpty(&cc.details.PipelinesUrl, cc.details.Url+"pipelines/")
 	}
 	cc.details.ArtifactoryUrl = clientutils.AddTrailingSlashIfNeeded(cc.details.ArtifactoryUrl)
@@ -237,7 +237,7 @@ func (cc *ConfigCommand) getConfigurationFromUser() error {
 		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.DistributionUrl, cc.details.Url+"distribution/") || disallowUsingSavedPassword
 		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.ArtifactoryUrl, cc.details.Url+"artifactory/") || disallowUsingSavedPassword
 		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.XrayUrl, cc.details.Url+"xray/") || disallowUsingSavedPassword
-		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.MissionControlUrl, cc.details.Url+"missioncontrol/") || disallowUsingSavedPassword
+		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.MissionControlUrl, cc.details.Url+"mc/") || disallowUsingSavedPassword
 		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.PipelinesUrl, cc.details.Url+"pipelines/") || disallowUsingSavedPassword
 	}
 

--- a/common/commands/config_test.go
+++ b/common/commands/config_test.go
@@ -104,13 +104,13 @@ func testUrls(t *testing.T, interactive bool) {
 	assert.Equal(t, "http://localhost:8080/artifactory/", outputConfig.GetArtifactoryUrl())
 	assert.Equal(t, "http://localhost:8080/distribution/", outputConfig.GetDistributionUrl())
 	assert.Equal(t, "http://localhost:8080/xray/", outputConfig.GetXrayUrl())
-	assert.Equal(t, "http://localhost:8080/missioncontrol/", outputConfig.GetMissionControlUrl())
+	assert.Equal(t, "http://localhost:8080/mc/", outputConfig.GetMissionControlUrl())
 	assert.Equal(t, "http://localhost:8080/pipelines/", outputConfig.GetPipelinesUrl())
 
 	inputDetails.ArtifactoryUrl = "http://localhost:8081/artifactory"
 	inputDetails.DistributionUrl = "http://localhost:8081/distribution"
 	inputDetails.XrayUrl = "http://localhost:8081/xray"
-	inputDetails.MissionControlUrl = "http://localhost:8081/missioncontrol"
+	inputDetails.MissionControlUrl = "http://localhost:8081/mc"
 	inputDetails.PipelinesUrl = "http://localhost:8081/pipelines"
 	outputConfig, err = configAndGetTestServer(t, &inputDetails, false, interactive)
 	assert.NoError(t, err)
@@ -119,7 +119,7 @@ func testUrls(t *testing.T, interactive bool) {
 	assert.Equal(t, "http://localhost:8081/artifactory/", outputConfig.GetArtifactoryUrl())
 	assert.Equal(t, "http://localhost:8081/distribution/", outputConfig.GetDistributionUrl())
 	assert.Equal(t, "http://localhost:8081/xray/", outputConfig.GetXrayUrl())
-	assert.Equal(t, "http://localhost:8081/missioncontrol/", outputConfig.GetMissionControlUrl())
+	assert.Equal(t, "http://localhost:8081/mc/", outputConfig.GetMissionControlUrl())
 	assert.Equal(t, "http://localhost:8081/pipelines/", outputConfig.GetPipelinesUrl())
 }
 
@@ -176,7 +176,7 @@ func createTestServerDetails() *config.ServerDetails {
 		ArtifactoryUrl:    "http://localhost:8080/artifactory",
 		DistributionUrl:   "http://localhost:8080/distribution",
 		XrayUrl:           "http://localhost:8080/xray",
-		MissionControlUrl: "http://localhost:8080/missioncontrol",
+		MissionControlUrl: "http://localhost:8080/mc",
 		PipelinesUrl:      "http://localhost:8080/pipelines",
 		ServerId:          "test",
 		IsDefault:         false,

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -536,7 +536,7 @@ type ServerDetails struct {
 	DistributionUrl      string `json:"distributionUrl,omitempty"`
 	XrayUrl              string `json:"xrayUrl,omitempty"`
 	MissionControlUrl    string `json:"missionControlUrl,omitempty"`
-	PipelinesUrl         string `json:"pipelines,omitempty"`
+	PipelinesUrl         string `json:"pipelinesUrl,omitempty"`
 	User                 string `json:"user,omitempty"`
 	Password             string `json:"password,omitempty"`
 	SshKeyPath           string `json:"sshKeyPath,omitempty"`

--- a/utils/config/config_test.go
+++ b/utils/config/config_test.go
@@ -75,7 +75,7 @@ func TestConvertConfigV0ToV5(t *testing.T) {
 			"defPackageLicense": "Apache-2.0"
 		  },
 		  "missioncontrol": {
-			  "url": "http://localhost:8080/missioncontrol/"
+			  "url": "http://localhost:8080/mc/"
 		  }
 		}
 	`
@@ -113,7 +113,7 @@ func TestConvertConfigV1ToV5(t *testing.T) {
 			"defPackageLicense": "Apache-2.0"
 		  },
 		  "missioncontrol": {
-			"url": "http://localhost:8080/missioncontrol/"
+			"url": "http://localhost:8080/mc/"
 		  },
 		  "Version": "1"
 		}
@@ -160,7 +160,7 @@ func TestConvertConfigV4ToV5(t *testing.T) {
 			"defPackageLicense": "Apache-2.0"
 		  },
 		  "missioncontrol": {
-			"url": "http://localhost:8080/missioncontrol/"
+			"url": "http://localhost:8080/mc/"
 		  },
 		  "version": "4"
 		}
@@ -318,7 +318,7 @@ func assertionV5Helper(t *testing.T, convertedConfig *ConfigV5, expectedVersion 
 	assert.True(t, rtConverted[0].IsDefault)
 	assert.Equal(t, DefaultServerId, rtConverted[0].ServerId)
 	assert.Equal(t, "http://localhost:8080/artifactory/", rtConverted[0].ArtifactoryUrl)
-	assert.Equal(t, "http://localhost:8080/missioncontrol/", rtConverted[0].MissionControlUrl)
+	assert.Equal(t, "http://localhost:8080/mc/", rtConverted[0].MissionControlUrl)
 	assert.Equal(t, "user", rtConverted[0].User)
 	assert.Equal(t, "password", rtConverted[0].Password)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

* Change pipelines URL key in the configuration from `pipelines` to `pipelinesUrl`
* After providing the platform URL, mission control endpoint should be `/mc` and not `missioncontrol`.