### PR TITLE
Remove access token validation in config

### DIFF
--- a/common/commands/config.go
+++ b/common/commands/config.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/jfrog/jfrog-client-go/auth"
 
-	"github.com/jfrog/jfrog-cli-core/artifactory/commands/generic"
 	"github.com/jfrog/jfrog-cli-core/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/utils/config"
 	"github.com/jfrog/jfrog-cli-core/utils/lock"
@@ -316,8 +315,6 @@ func readAccessTokenFromConsole(details *config.ServerDetails) error {
 	fmt.Println()
 	if len(byteToken) > 0 {
 		details.SetAccessToken(string(byteToken))
-		_, err := new(generic.PingCommand).SetServerDetails(details).Ping()
-		return err
 	}
 	return nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Remove ping to Artifactory after configuring access token using the config command.
This is necessary to allow configuring non-Artifactory JFrog services with access tokens that don't have permission to Artifactory.