### PR TITLE
Remove the addition of the "build.repo" attached prop

### DIFF
--- a/artifactory/commands/buildinfo/buildappend.go
+++ b/artifactory/commands/buildinfo/buildappend.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jfrog/jfrog-cli-core/utils/config"
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
-	servicesutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/http/httpclient"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
@@ -129,9 +128,9 @@ func (bac *BuildAppendCommand) getChecksumDetails(timestamp int64) (fileutils.Ch
 		return fileutils.ChecksumDetails{}, err
 	}
 
-	buildInfoRepo := servicesutils.BuildRepoNameFromProjectKey(bac.buildConfiguration.Project)
-	if buildInfoRepo == "" {
-		buildInfoRepo = "artifactory-build-info"
+	buildInfoRepo := "artifactory-build-info"
+	if bac.buildConfiguration.Project != "" {
+		buildInfoRepo = bac.buildConfiguration.Project + "-build-info"
 	}
 	buildInfoPath := serviceDetails.GetUrl() + buildInfoRepo + "/" + bac.buildNameToAppend + "/" + bac.buildNumberToAppend + "-" + strconv.FormatInt(timestamp, 10) + ".json"
 	details, resp, err := client.GetRemoteFileDetails(buildInfoPath, serviceDetails.CreateHttpClientDetails())

--- a/artifactory/utils/buildutils.go
+++ b/artifactory/utils/buildutils.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
-	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
@@ -40,17 +39,12 @@ func CreateBuildProperties(buildName, buildNumber, projectKey string) (string, e
 		return "", nil
 	}
 
-	buildRepo := utils.BuildRepoNameFromProjectKey(projectKey)
-	if buildRepo != "" {
-		buildRepo = ";build.repo=" + buildRepo
-	}
-
 	buildGeneralDetails, err := ReadBuildInfoGeneralDetails(buildName, buildNumber, projectKey)
 	if err != nil {
-		return fmt.Sprintf("build.name=%s;build.number=%s%s", buildName, buildNumber, buildRepo), err
+		return fmt.Sprintf("build.name=%s;build.number=%s", buildName, buildNumber), err
 	}
 	timestamp := strconv.FormatInt(buildGeneralDetails.Timestamp.UnixNano()/int64(time.Millisecond), 10)
-	return fmt.Sprintf("build.name=%s;build.number=%s;build.timestamp=%s%s", buildName, buildNumber, timestamp, buildRepo), nil
+	return fmt.Sprintf("build.name=%s;build.number=%s;build.timestamp=%s", buildName, buildNumber, timestamp), nil
 }
 
 func getPartialsBuildDir(buildName, buildNumber, projectKey string) (string, error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR depends on https://github.com/jfrog/jfrog-client-go/pull/303.
It removes the addition of the "build.repo" attached property, since it is not required by Artifactory.