### PR TITLE
fix: avoid panic on wrong image tag

### DIFF
--- a/artifactory/commands/container/containermanager.go
+++ b/artifactory/commands/container/containermanager.go
@@ -23,7 +23,11 @@ func (cmc *ContainerManagerCommand) ImageTag() string {
 func (cmc *ContainerManagerCommand) SetImageTag(imageTag string) *ContainerManagerCommand {
 	cmc.imageTag = imageTag
 	// Remove base URL from the image tag.
-	imageRelativePath := imageTag[strings.Index(imageTag, "/"):]
+	index := strings.Index(imageTag, "/")
+	imageRelativePath := imageTag
+	if index != -1 {
+		imageRelativePath = imageTag[index:]
+	}
 	// Use the default image tag if none exists.
 	if strings.LastIndex(imageRelativePath, ":") == -1 {
 		cmc.imageTag += ":latest"


### PR DESCRIPTION

Before the fix
```
 ./jfrog-cli rt dp nginx:latest test-sguproject-docker
nginx:latest
panic: runtime error: slice bounds out of range [-1:]

goroutine 1 [running]:
github.com/jfrog/jfrog-cli-core/artifactory/commands/container.(*ContainerManagerCommand).SetImageTag(0xc0002f5cc0, 0x7ffeefbff8e2, 0xc, 0x4)
        /Users/sguiheux/pkg/mod/github.com/jfrog/jfrog-cli-core@v1.4.2/artifactory/commands/container/containermanager.go:26 +0x14a
github.com/jfrog/jfrog-cli/artifactory.containerPushCmd(0xc0001ed340, 0x0, 0xc000268e58, 0x15cdecd)
        /Users/sguiheux/src/github.com/jfrog/jfrog-cli/artifactory/cli.go:1350 +0x29f
github.com/jfrog/jfrog-cli/artifactory.GetCommands.func27(0xc0001ed340, 0x0, 0xc0001ed340)
        /Users/sguiheux/src/github.com/jfrog/jfrog-cli/artifactory/cli.go:471 +0x34
github.com/codegangsta/cli.HandleAction(0x190a380, 0x1a84878, 0xc0001ed340, 0xc0001b1400, 0x0)
```

After the fix
```
❯ ./jfrog-cli rt dp nginx test-sguproject-docker
[Error] Invalid image tag received for pushing to Artifactory - tag does not include a slash.
```


