### PR TITLE
Bugfix - Incorrect custom BI extractors URL

### DIFF
--- a/artifactory/utils/dependenciesutils.go
+++ b/artifactory/utils/dependenciesutils.go
@@ -91,7 +91,7 @@ func getJcenterRemoteRepoName() string {
 }
 
 func downloadFileFromArtifactory(artDetails *config.ServerDetails, downloadPath, targetPath string) error {
-	downloadUrl := fmt.Sprintf("%s%s", artDetails.Url, downloadPath)
+	downloadUrl := fmt.Sprintf("%s%s", artDetails.ArtifactoryUrl, downloadPath)
 	log.Info("Downloading build-info-extractor from", downloadUrl)
 	filename, localDir := fileutils.GetFileAndDirFromPath(targetPath)
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

When downloading the Maven and Gradle build-info-extractors JARs, the URL is the platform URL, but should be Artifactory URL.