### PR TITLE
Fix dotnet nuget config missing protocolVersion attribute (#98)

### DIFF
--- a/artifactory/utils/dotnet/configfiletemplate.go
+++ b/artifactory/utils/dotnet/configfiletemplate.go
@@ -11,7 +11,7 @@ const ConfigFileTemplate = `<?xml version="1.0" encoding="utf-8"?>
 const ConfigFileFormat = `<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="JFrogCli" value="%s" />
+    <add key="JFrogCli" value="%s" protocolVersion="%s" />
   </packageSources>
   <packageSourceCredentials>
     <JFrogCli>


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. I did **not** add tests owing to a lack of skill!
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Added support for protocolVersion in generated NuGet.config file to enable support for NuGet v3 feed.
Removed support for building NuGet.config using native dotnet tool as it doesn't support configuring protocolVersion.