### PR TITLE
Download build-info extractors from ojo

### DIFF
--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -19,7 +19,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
-const gradleExtractorDependencyVersion = "4.18.0"
+const gradleExtractorDependencyVersion = "4.23.0"
 const gradleInitScriptTemplate = "gradle.init"
 
 const usePlugin = "useplugin"

--- a/artifactory/commands/gradle/gradle_test.go
+++ b/artifactory/commands/gradle/gradle_test.go
@@ -1,0 +1,35 @@
+package gradle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDownloadExtractorsFromOjo(t *testing.T) {
+	// Set 'JFROG_CLI_DEPENDENCIES_DIR' env var to a temp dir
+	tempDirPath, err := fileutils.CreateTempDir()
+	assert.NoError(t, err)
+	defer fileutils.RemoveTempDir(tempDirPath)
+	err = os.Setenv(coreutils.DependenciesDir, tempDirPath)
+	assert.NoError(t, err)
+
+	// Make sure the JAR will be downloaded from ojo
+	err = os.Unsetenv(utils.JCenterRemoteServerEnv)
+	assert.NoError(t, err)
+	err = os.Unsetenv(utils.ExtractorsRemoteEnv)
+	assert.NoError(t, err)
+
+	// Download JAR
+	dependenciesPath, gradlePluginFilename, err := downloadGradleDependencies()
+	assert.NoError(t, err)
+
+	// Make sure the Gradle build-info extractor JAR exist
+	expectedJarPath := filepath.Join(dependenciesPath, gradlePluginFilename)
+	assert.FileExists(t, expectedJarPath)
+}

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const mavenExtractorDependencyVersion = "2.20.0"
+const mavenExtractorDependencyVersion = "2.25.0"
 const classworldsConfFileName = "classworlds.conf"
 const MavenHome = "M2_HOME"
 

--- a/artifactory/commands/mvn/mvn_test.go
+++ b/artifactory/commands/mvn/mvn_test.go
@@ -1,0 +1,38 @@
+package mvn
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDownloadExtractorsFromOjo(t *testing.T) {
+	// Set 'JFROG_CLI_DEPENDENCIES_DIR' env var to a temp dir
+	tempDirPath, err := fileutils.CreateTempDir()
+	assert.NoError(t, err)
+	defer fileutils.RemoveTempDir(tempDirPath)
+	err = os.Setenv(coreutils.DependenciesDir, tempDirPath)
+	assert.NoError(t, err)
+
+	// Make sure the JAR will be downloaded from ojo
+	err = os.Unsetenv(utils.JCenterRemoteServerEnv)
+	assert.NoError(t, err)
+	err = os.Unsetenv(utils.ExtractorsRemoteEnv)
+	assert.NoError(t, err)
+
+	// Download JAR and create classworlds.conf
+	dependenciesPath, err := downloadDependencies()
+	assert.NoError(t, err)
+
+	// Make sure the Maven build-info extractor JAR and the classwords.conf file exists
+	expectedJarPath := filepath.Join(dependenciesPath, fmt.Sprintf("build-info-extractor-maven3-%s-uber.jar", mavenExtractorDependencyVersion))
+	assert.FileExists(t, expectedJarPath)
+	expectedClasswordsPath := filepath.Join(dependenciesPath, "classworlds.conf")
+	assert.FileExists(t, expectedClasswordsPath)
+}

--- a/artifactory/utils/dependenciesutils.go
+++ b/artifactory/utils/dependenciesutils.go
@@ -74,8 +74,8 @@ func GetExtractorsRemoteDetails(downloadPath string) (*config.ServerDetails, str
 // Deprecated. Get Artifactory server details and a repository proxying JCenter/oss.jfrog.org according to 'JFROG_CLI_JCENTER_REMOTE_SERVER' and 'JFROG_CLI_JCENTER_REMOTE_REPO' env vars.
 func getJcenterRemoteDetails(serverId, downloadPath string) (*config.ServerDetails, string, error) {
 	log.Warn(`It looks like the 'JFROG_CLI_JCENTER_REMOTE_SERVER' or 'JFROG_CLI_JCENTER_REMOTE_REPO' are set.
-	These environment variables are used by the JFrog CLI to download the build-info extractors JARs for Maven and Gradle builds. 
-	These environment variables are deprecated. 
+	These environment variables were used by the JFrog CLI to download the build-info extractors JARs for Maven and Gradle builds. 
+	These environment variables are now deprecated. 
 	For more information, please refer to the documentation at https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-DownloadingtheMavenandGradleExtractorJARs.`)
 	serverDetails, err := config.GetSpecificConfig(serverId, false, true)
 	repoName := os.Getenv(JCenterRemoteRepoEnv)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Following Bintray sunset, we should download Maven and Gradle build-info extractors JARs from `https://oss.jfrog.org/artifactory` instead of from JCenter.

This PR introduce the following changes:
1. Introduce `JFROG_CLI_EXTRACTORS_REMOTE`. This env var in form of ServerID/RemoteRepo.
2. Deprecate `JFROG_CLI_JCENTER_REMOTE_SERVER` and suggest to use `JFROG_CLI_EXTRACTORS_REMOTE` instead.
3.  * If `JFROG_CLI_JCENTER_REMOTE_SERVER` and `JFROG_CLI_EXTRACTORS_REMOTE` are not set, download JARs from  https://oss.jfrog.org/artifactory.
     * If `JFROG_CLI_JCENTER_REMOTE_SERVER` is set - use it and `JFROG_CLI_JCENTER_REMOTE_REPO` as before and print a warning message. Following this error message, it is the user's responsibility to change the remote repository URL from https://jcenter.bintray.com to https://oss.jfrog.org.
    * If `JFROG_CLI_EXTRACTORS_REMOTE` is set, download the JARs from the configured server ID and repository.
4. Update Maven and Gradle extractors version to latest.