### PR TITLE
Use different extractors version when using JCenter

### DIFF
--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -20,6 +20,7 @@ import (
 )
 
 const gradleExtractorDependencyVersion = "4.23.0"
+const gradleExtractorDependencyJCenterVersion = "4.21.0"
 const gradleInitScriptTemplate = "gradle.init"
 
 const usePlugin = "useplugin"
@@ -102,10 +103,11 @@ func downloadGradleDependencies() (gradleDependenciesDir, gradlePluginFilename s
 	if err != nil {
 		return
 	}
-	gradleDependenciesDir = filepath.Join(dependenciesPath, "gradle", gradleExtractorDependencyVersion)
-	gradlePluginFilename = fmt.Sprintf("build-info-extractor-gradle-%s-uber.jar", gradleExtractorDependencyVersion)
+	extractorVersion := utils.GetExtractorVersion(gradleExtractorDependencyVersion, gradleExtractorDependencyJCenterVersion)
+	gradleDependenciesDir = filepath.Join(dependenciesPath, "gradle", extractorVersion)
+	gradlePluginFilename = fmt.Sprintf("build-info-extractor-gradle-%s-uber.jar", extractorVersion)
 
-	filePath := fmt.Sprintf("org/jfrog/buildinfo/build-info-extractor-gradle/%s", gradleExtractorDependencyVersion)
+	filePath := fmt.Sprintf("org/jfrog/buildinfo/build-info-extractor-gradle/%s", extractorVersion)
 	downloadPath := path.Join(filePath, gradlePluginFilename)
 
 	filepath.Join(gradleDependenciesDir, gradlePluginFilename)

--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -20,6 +20,7 @@ import (
 )
 
 const gradleExtractorDependencyVersion = "4.23.0"
+// Deprecated. This version is the latest published in JCenter.
 const gradleExtractorDependencyJCenterVersion = "4.21.0"
 const gradleInitScriptTemplate = "gradle.init"
 

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -21,6 +21,7 @@ import (
 )
 
 const mavenExtractorDependencyVersion = "2.25.0"
+const mavenExtractorDependencyJCenterVersion = "2.23.0"
 const classworldsConfFileName = "classworlds.conf"
 const MavenHome = "M2_HOME"
 
@@ -121,10 +122,11 @@ func downloadDependencies() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dependenciesPath = filepath.Join(dependenciesPath, "maven", mavenExtractorDependencyVersion)
+	extractorVersion := utils.GetExtractorVersion(mavenExtractorDependencyVersion, mavenExtractorDependencyJCenterVersion)
+	dependenciesPath = filepath.Join(dependenciesPath, "maven", extractorVersion)
 
-	filename := fmt.Sprintf("build-info-extractor-maven3-%s-uber.jar", mavenExtractorDependencyVersion)
-	filePath := fmt.Sprintf("org/jfrog/buildinfo/build-info-extractor-maven3/%s", mavenExtractorDependencyVersion)
+	filename := fmt.Sprintf("build-info-extractor-maven3-%s-uber.jar", extractorVersion)
+	filePath := fmt.Sprintf("org/jfrog/buildinfo/build-info-extractor-maven3/%s", extractorVersion)
 	downloadPath := path.Join(filePath, filename)
 
 	err = utils.DownloadExtractorIfNeeded(downloadPath, filepath.Join(dependenciesPath, filename))

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -21,6 +21,7 @@ import (
 )
 
 const mavenExtractorDependencyVersion = "2.25.0"
+// Deprecated. This version is the latest published in JCenter.
 const mavenExtractorDependencyJCenterVersion = "2.23.0"
 const classworldsConfFileName = "classworlds.conf"
 const MavenHome = "M2_HOME"

--- a/artifactory/utils/dependenciesutils.go
+++ b/artifactory/utils/dependenciesutils.go
@@ -71,9 +71,18 @@ func GetExtractorsRemoteDetails(downloadPath string) (*config.ServerDetails, str
 	return &config.ServerDetails{ArtifactoryUrl: "https://oss.jfrog.org/artifactory/"}, path.Join("oss-release-local", downloadPath), nil
 }
 
+// Deprecated. Return the version of the build-info extractor to download.
+// If 'JFROG_CLI_JCENTER_REMOTE_SERVER' is used, choose the latest published JCenter version.
+func GetExtractorVersion(ojoVersion, jCenterVersion string) string {
+	if os.Getenv(JCenterRemoteServerEnv) != "" {
+		return jCenterVersion
+	}
+	return ojoVersion
+}
+
 // Deprecated. Get Artifactory server details and a repository proxying JCenter/oss.jfrog.org according to 'JFROG_CLI_JCENTER_REMOTE_SERVER' and 'JFROG_CLI_JCENTER_REMOTE_REPO' env vars.
 func getJcenterRemoteDetails(serverId, downloadPath string) (*config.ServerDetails, string, error) {
-	log.Warn(`It looks like the 'JFROG_CLI_JCENTER_REMOTE_SERVER' or 'JFROG_CLI_JCENTER_REMOTE_REPO' are set.
+	log.Warn(`It looks like the 'JFROG_CLI_JCENTER_REMOTE_SERVER' or 'JFROG_CLI_JCENTER_REMOTE_REPO' environment variables are set.
 	These environment variables were used by the JFrog CLI to download the build-info extractors JARs for Maven and Gradle builds. 
 	These environment variables are now deprecated. 
 	For more information, please refer to the documentation at https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-DownloadingtheMavenandGradleExtractorJARs.`)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Thie PR is a follow-up to #102.
Following JCenter sunset, we stopped publishing the build-info extractors. Therefore, the version in JCenter is not the latest.

If `JFROG_CLI_JCENTER_REMOTE_SERVER` deprecated env var is set, use Maven extractor 2.23.0 instead of 2.25.0 and Gradle extractor 4.21.0 instead of 4.23.0.