### PR TITLE
Fix config import from old server tokens

### DIFF
--- a/utils/config/configtoken.go
+++ b/utils/config/configtoken.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 )
 
-const tokenVersion = 1
+const tokenVersion = 2
 
 type configToken struct {
 	Version              int    `json:"version,omitempty"`
@@ -28,6 +28,13 @@ type configToken struct {
 	ClientCertKeyPath    string `json:"clientCertKeyPath,omitempty"`
 	ServerId             string `json:"serverId,omitempty"`
 	ApiKey               string `json:"apiKey,omitempty"`
+}
+
+func (token *configToken) convertToV2() {
+	if token.ArtifactoryUrl == "" {
+		token.ArtifactoryUrl = token.Url
+		token.Url = ""
+	}
 }
 
 func fromServerDetails(details *ServerDetails) *configToken {
@@ -109,6 +116,9 @@ func Import(serverToken string) (*ServerDetails, error) {
 	token := &configToken{}
 	if err = json.Unmarshal(decoded, token); err != nil {
 		return nil, err
+	}
+	if token.Version < tokenVersion {
+		token.convertToV2()
 	}
 	return toServerDetails(token), nil
 }

--- a/utils/config/configtoken_test.go
+++ b/utils/config/configtoken_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	v1Token = "eyJ2ZXJzaW9uIjoxLCJ1cmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEvYXJ0aWZhY3RvcnkvIiwiZGlzdHJpYnV0aW9uVXJsIjoiaHR0cDovLzEyNy4wLjAuMTo4MDgxL2Rpc3RyaWJ1dGlvbiIsInVzZXIiOiJhZG1pbiIsInBhc3N3b3JkIjoicGFzc3dvcmQiLCJ0b2tlblJlZnJlc2hJbnRlcnZhbCI6NjAsInNlcnZlcklkIjoibG9jYWwifQ=="
+	v2Token = `eyJ2ZXJzaW9uIjoxLCJ1cmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEvIiwiYXJ0aWZhY3RvcnlVcmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEvYXJ0aWZhY3RvcnkvIiwiZGlzdHJpYnV0aW9uVXJsIjoiaHR0cDovLzEyNy4wLjAuMTo4MDgxL2Rpc3RyaWJ1dGlvbi8iLCJ4cmF5VXJsIjoiaHR0cDovLzEyNy4wLjAuMTo4MDgxL3hyYXkvIiwib
+Wlzc2lvbkNvbnRyb2xVcmwiOiJodHRwOi8vMTI3LjAuMC4xOjgwODEvbWMvIiwicGlwZWxpbmVzVXJsIjoiaHR0cDovLzEyNy4wLjAuMTo4MDgxL3BpcGVsaW5lcy8iLCJ1c2VyIjoiYWRtaW4iLCJwYXNzd29yZCI6InBhc3N3b3JkIiwidG9rZW5SZWZyZXNoSW50ZXJ2YWwiOjYwLCJzZXJ2ZXJJZCI6ImxvY2FsIn0=`
+)
+
+func TestImportFromV1(t *testing.T) {
+	serverDetails, err := Import(v1Token)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "local", serverDetails.ServerId)
+	assert.Empty(t, serverDetails.Url)
+	assert.Equal(t, "http://127.0.0.1:8081/artifactory/", serverDetails.ArtifactoryUrl)
+	assert.Equal(t, "http://127.0.0.1:8081/distribution", serverDetails.DistributionUrl)
+	assert.Equal(t, "admin", serverDetails.User)
+	assert.Equal(t, "password", serverDetails.Password)
+}
+
+func TestImportFromV2(t *testing.T) {
+	serverDetails, err := Import(v2Token)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "local", serverDetails.ServerId)
+	assert.Equal(t, "http://127.0.0.1:8081/", serverDetails.Url)
+	assert.Equal(t, "http://127.0.0.1:8081/artifactory/", serverDetails.ArtifactoryUrl)
+	assert.Equal(t, "http://127.0.0.1:8081/distribution/", serverDetails.DistributionUrl)
+	assert.Equal(t, "http://127.0.0.1:8081/xray/", serverDetails.XrayUrl)
+	assert.Equal(t, "http://127.0.0.1:8081/mc/", serverDetails.MissionControlUrl)
+	assert.Equal(t, "http://127.0.0.1:8081/pipelines/", serverDetails.PipelinesUrl)
+	assert.Equal(t, "admin", serverDetails.User)
+	assert.Equal(t, "password", serverDetails.Password)
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Currently, when importing tokens created by JFrog CLI < 1.44, the URLs are incorrect.
To fix it, this PR is suggesting the following on importing an old token:
```go
token.ArtifactoryUrl = token.Url
token.Url = ""
```
