### PR TITLE
Bugfix - npmi on version 7 builds flat dep tree

### DIFF
--- a/artifactory/commands/npm/installorci.go
+++ b/artifactory/commands/npm/installorci.go
@@ -471,7 +471,7 @@ func (nca *NpmCommandArgs) setTypeRestriction(key string, val interface{}) {
 // Run npm list and parse the returned json
 func (nca *NpmCommandArgs) prepareDependencies(typeRestriction string) error {
 	// Run npm list
-	data, errData, err := npm.RunList(strings.Join(append(nca.npmArgs, " -only="+typeRestriction), " "), nca.executablePath)
+	data, errData, err := npm.RunList(strings.Join(append(nca.npmArgs, " --all -only="+typeRestriction), " "), nca.executablePath)
 	if err != nil {
 		log.Warn("npm list command failed with error:", err.Error())
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

In npm 7, running npm ls produces a flat dependency tree with direct dependencies only (see https://github.com/npm/cli/blob/v7.0.0/CHANGELOG.md#npm-ls).
To get the transitive dependency tree as in versions prior to 6, we should add the --all flag.
Fortunately, npm commands do not fail when providing unknown flags. Therefore we can add the --all flag also when running with npm<7.