### PR TITLE
Fix .Net dependencies source interpretation

### DIFF
--- a/artifactory/utils/dotnet/dependencies/assetsjson.go
+++ b/artifactory/utils/dotnet/dependencies/assetsjson.go
@@ -4,18 +4,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
 	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"io/ioutil"
-	"path/filepath"
-	"strings"
 )
 
-var assetsFilePath = filepath.Join("obj", "project.assets.json")
+var assetsFilePath = filepath.Join(AssetDirName, AssetFileName)
 
-const AssetFileName = "project.assets.json"
+const (
+	AssetFileName = "project.assets.json"
+	AssetDirName  = "obj"
+)
 
 // Register project.assets.json extractor
 func init() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
It was found that multiple .Net projects in the same directory may be interpret wrong by our gathering dependencies sources logic. The logic was changed to avoid such cases. 