### PR TITLE
External process redirect the stdout to stderr

### DIFF
--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -262,11 +262,11 @@ func (config *gradleRunConfig) GetEnv() map[string]string {
 }
 
 func (config *gradleRunConfig) GetStdWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 func (config *gradleRunConfig) GetErrWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 func getGradleExecPath(useWrapper bool) (string, error) {

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -322,11 +322,11 @@ func (config *mvnRunConfig) GetEnv() map[string]string {
 }
 
 func (config *mvnRunConfig) GetStdWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 func (config *mvnRunConfig) GetErrWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 type mvnRunConfig struct {

--- a/artifactory/utils/container/containermanager.go
+++ b/artifactory/utils/container/containermanager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -120,10 +121,11 @@ func (pushCmd *pushCmd) GetEnv() map[string]string {
 }
 
 func (pushCmd *pushCmd) GetStdWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
+
 func (pushCmd *pushCmd) GetErrWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 // Image get image id command
@@ -146,11 +148,11 @@ func (getImageId *getImageIdCmd) GetEnv() map[string]string {
 }
 
 func (getImageId *getImageIdCmd) GetStdWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 func (getImageId *getImageIdCmd) GetErrWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 type FatManifest struct {
@@ -188,11 +190,11 @@ func (getImageSystemCompatibilityCmd *getImageSystemCompatibilityCmd) GetEnv() m
 }
 
 func (getImageSystemCompatibilityCmd *getImageSystemCompatibilityCmd) GetStdWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 func (getImageSystemCompatibilityCmd *getImageSystemCompatibilityCmd) GetErrWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 // Get registry from tag
@@ -233,11 +235,11 @@ func (loginCmd *LoginCmd) GetEnv() map[string]string {
 }
 
 func (loginCmd *LoginCmd) GetStdWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 func (loginCmd *LoginCmd) GetErrWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 // Image pull command
@@ -323,11 +325,11 @@ func (versionCmd *VersionCmd) GetEnv() map[string]string {
 }
 
 func (versionCmd *VersionCmd) GetStdWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 func (versionCmd *VersionCmd) GetErrWriter() io.WriteCloser {
-	return nil
+	return os.Stderr
 }
 
 func ValidateClientApiVersion() error {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

The “jfrog rt mvn/gradle/docker/go-publish” commands' output reaches into stdout and therefore gets mixed with the detailed summary.
This commit fixes this by redirect all the buildtools log into stderr.
Related PR: https://github.com/jfrog/gocmd/pull/42