### PR TITLE
Refactor Maven and Gradle utils

### DIFF
--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -4,8 +4,8 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/generic"
 	commandsutils "github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
-	"github.com/jfrog/jfrog-cli-core/v2/common/commands/gradle"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	gradleutils "github.com/jfrog/jfrog-cli-core/v2/utils/gradle"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 )
 
@@ -54,7 +54,7 @@ func (gc *GradleCommand) Run() error {
 		tempFile.Close()
 	}
 
-	err := gradle.RunGradle(gc.tasks, gc.configPath, deployableArtifactsFile, gc.configuration, gc.threads, false, gc.IsXrayScan())
+	err := gradleutils.RunGradle(gc.tasks, gc.configPath, deployableArtifactsFile, gc.configuration, gc.threads, false, gc.IsXrayScan())
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -4,15 +4,9 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/generic"
 	commandsutils "github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
-	"github.com/jfrog/jfrog-cli-core/v2/common/commands/mvn"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	mvnutils "github.com/jfrog/jfrog-cli-core/v2/utils/mvn"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
-)
-
-const (
-	mavenExtractorDependencyVersion = "2.27.0"
-	classworldsConfFileName         = "classworlds.conf"
-	MavenHome                       = "M2_HOME"
 )
 
 type MvnCommand struct {
@@ -105,7 +99,7 @@ func (mc *MvnCommand) Run() error {
 		tempFile.Close()
 	}
 
-	err := mvn.RunMvn(mc.configPath, deployableArtifactsFile, mc.configuration, mc.goals, mc.threads, mc.insecureTls, mc.IsXrayScan())
+	err := mvnutils.RunMvn(mc.configPath, deployableArtifactsFile, mc.configuration, mc.goals, mc.threads, mc.insecureTls, mc.IsXrayScan())
 	if err != nil {
 		return err
 	}

--- a/utils/gradle/utils.go
+++ b/utils/gradle/utils.go
@@ -1,4 +1,4 @@
-package gradle
+package gradleutils
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	gradleExtractorDependencyVersion = "4.24.5"
+	gradleExtractorDependencyVersion = "4.24.10"
 	gradleInitScriptTemplate         = "gradle.init"
 	usePlugin                        = "useplugin"
 	useWrapper                       = "usewrapper"

--- a/utils/gradle/utils_test.go
+++ b/utils/gradle/utils_test.go
@@ -1,4 +1,4 @@
-package gradle
+package gradleutils
 
 import (
 	"os"

--- a/utils/mvn/utils.go
+++ b/utils/mvn/utils.go
@@ -1,4 +1,4 @@
-package mvn
+package mvnutils
 
 import (
 	"errors"
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	mavenExtractorDependencyVersion = "2.27.0"
+	mavenExtractorDependencyVersion = "2.28.4"
 	classworldsConfFileName         = "classworlds.conf"
 	MavenHome                       = "M2_HOME"
 )

--- a/utils/mvn/utils_test.go
+++ b/utils/mvn/utils_test.go
@@ -1,4 +1,4 @@
-package mvn
+package mvnutils
 
 import (
 	"fmt"

--- a/xray/commands/audit/gradle.go
+++ b/xray/commands/audit/gradle.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
-	"github.com/jfrog/jfrog-cli-core/v2/common/commands/gradle"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	gradleutils "github.com/jfrog/jfrog-cli-core/v2/utils/gradle"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
 )
@@ -107,7 +107,7 @@ func (auditCmd *AuditGradleCommand) runGradle(buildConfiguration *utils.BuildCon
 	} else {
 		configFilePath = ""
 	}
-	return gradle.RunGradle(tasks, configFilePath, "", buildConfiguration, 0, auditCmd.useWrapper, true)
+	return gradleutils.RunGradle(tasks, configFilePath, "", buildConfiguration, 0, auditCmd.useWrapper, true)
 }
 
 func (na *AuditGradleCommand) CommandName() string {

--- a/xray/commands/audit/mvn.go
+++ b/xray/commands/audit/mvn.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
-	"github.com/jfrog/jfrog-cli-core/v2/common/commands/mvn"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	mvnutils "github.com/jfrog/jfrog-cli-core/v2/utils/mvn"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
 )
@@ -107,7 +107,7 @@ func (auditCmd *AuditMavenCommand) runMvn(buildConfiguration *utils.BuildConfigu
 	} else {
 		configFilePath = ""
 	}
-	return mvn.RunMvn(configFilePath, "", buildConfiguration, goals, 0, auditCmd.insecureTls, true)
+	return mvnutils.RunMvn(configFilePath, "", buildConfiguration, goals, 0, auditCmd.insecureTls, true)
 }
 
 func (na *AuditMavenCommand) CommandName() string {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
* Move Gradle and Maven utils from common/commands to package utils.
* Update build info extractors versions to 2.28.4/4.24.10.