### PR TITLE
Bugfix - Detailed summary doesn't print for maven/gradle builds

### DIFF
--- a/artifactory/utils/buildinfoproperties.go
+++ b/artifactory/utils/buildinfoproperties.go
@@ -324,7 +324,9 @@ func createDeployableArtifactsFile(config *viper.Viper) error {
 	if err != nil {
 		return err
 	}
-	config.Set(DEPLOYABLE_ARTIFACTS, tempFile.Name())
+	// If this is a Windows machine there is a need to modify the path for the build info file to match Java syntax with double \\
+	path := ioutils.DoubleWinPathSeparator(tempFile.Name())
+	config.Set(DEPLOYABLE_ARTIFACTS, path)
 	return nil
 }
 func setBuildTimestampToConfig(buildName, buildNumber, projectKey string, config *viper.Viper) error {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Deployable artifact file path on windows contain backslashes which interpreter as special characters. As a result, the path gets corrupted.
To fix this we encode all backslashes.