### PR TITLE
Bugfix - Detailed summary doesn't print for maven/gradle builds

### DIFF
--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	gradleutils "github.com/jfrog/jfrog-cli-core/v2/utils/gradle"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/ioutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 )
 
@@ -50,7 +51,8 @@ func (gc *GradleCommand) Run() error {
 		if err != nil {
 			return err
 		}
-		deployableArtifactsFile = tempFile.Name()
+		// If this is a Windows machine there is a need to modify the path for the build info file to match Java syntax with double \\
+		deployableArtifactsFile = ioutils.DoubleWinPathSeparator(tempFile.Name())
 		tempFile.Close()
 	}
 

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -5,6 +5,7 @@ import (
 	commandsutils "github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/ioutils"
 	mvnutils "github.com/jfrog/jfrog-cli-core/v2/utils/mvn"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 )
@@ -95,7 +96,8 @@ func (mc *MvnCommand) Run() error {
 		if err != nil {
 			return err
 		}
-		deployableArtifactsFile = tempFile.Name()
+		// If this is a Windows machine there is a need to modify the path for the build info file to match Java syntax with double \\
+		deployableArtifactsFile = ioutils.DoubleWinPathSeparator(tempFile.Name())
 		tempFile.Close()
 	}
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Deployable artifact file path on windows contain backslashes which interpreter as special characters. As a result, the path gets corrupted.
To fix this we encode all backslashes.