### PR TITLE
Improve audit output

### DIFF
--- a/utils/gradle/utils.go
+++ b/utils/gradle/utils.go
@@ -2,7 +2,6 @@ package gradleutils
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -10,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	gofrogcmd "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -38,7 +36,7 @@ func RunGradle(tasks, configPath, deployableArtifactsFile string, configuration 
 		return err
 	}
 	defer os.Remove(gradleRunConfig.env[gradleBuildInfoProperties])
-	return gofrogcmd.RunCmd(gradleRunConfig)
+	return gradleRunConfig.runCmd()
 }
 
 func downloadGradleDependencies() (gradleDependenciesDir, gradlePluginFilename string, err error) {
@@ -57,9 +55,10 @@ func downloadGradleDependencies() (gradleDependenciesDir, gradlePluginFilename s
 }
 
 func createGradleRunConfig(tasks, configPath, deployableArtifactsFile string, configuration *utils.BuildConfiguration, threads int, gradleDependenciesDir, gradlePluginFilename string, useWrapperIfMissingConfig, disableDeploy bool) (*gradleRunConfig, error) {
-	runConfig := &gradleRunConfig{env: map[string]string{}}
-	runConfig.tasks = tasks
-
+	runConfig := &gradleRunConfig{
+		env:   map[string]string{},
+		tasks: tasks,
+	}
 	var vConfig *viper.Viper
 	var err error
 	if configPath == "" {
@@ -156,16 +155,15 @@ func (config *gradleRunConfig) GetCmd() *exec.Cmd {
 	return exec.Command(cmd[0], cmd[1:]...)
 }
 
-func (config *gradleRunConfig) GetEnv() map[string]string {
-	return config.env
-}
-
-func (config *gradleRunConfig) GetStdWriter() io.WriteCloser {
-	return os.Stderr
-}
-
-func (config *gradleRunConfig) GetErrWriter() io.WriteCloser {
-	return os.Stderr
+func (config *gradleRunConfig) runCmd() error {
+	command := config.GetCmd()
+	command.Env = os.Environ()
+	for k, v := range config.env {
+		command.Env = append(command.Env, k+"="+v)
+	}
+	command.Stderr = os.Stderr
+	command.Stdout = os.Stderr
+	return command.Run()
 }
 
 func getGradleExecPath(useWrapper bool) (string, error) {

--- a/utils/mvn/utils.go
+++ b/utils/mvn/utils.go
@@ -3,7 +3,6 @@ package mvnutils
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -11,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	gofrogcmd "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -45,7 +43,7 @@ func RunMvn(configPath, deployableArtifactsFile string, buildConf *utils.BuildCo
 	}
 
 	defer os.Remove(mvnRunConfig.buildInfoProperties)
-	return gofrogcmd.RunCmd(mvnRunConfig)
+	return mvnRunConfig.runCmd()
 }
 
 func validateMavenInstallation() error {
@@ -197,18 +195,6 @@ func (config *mvnRunConfig) GetCmd() *exec.Cmd {
 	return exec.Command(cmd[0], cmd[1:]...)
 }
 
-func (config *mvnRunConfig) GetEnv() map[string]string {
-	return map[string]string{}
-}
-
-func (config *mvnRunConfig) GetStdWriter() io.WriteCloser {
-	return os.Stderr
-}
-
-func (config *mvnRunConfig) GetErrWriter() io.WriteCloser {
-	return os.Stderr
-}
-
 type mvnRunConfig struct {
 	java                         string
 	plexusClassworlds            string
@@ -223,4 +209,11 @@ type mvnRunConfig struct {
 	generatedBuildInfoPath       string
 	mavenOpts                    string
 	deployableArtifactsFilePath  string
+}
+
+func (config *mvnRunConfig) runCmd() error {
+	command := config.GetCmd()
+	command.Stderr = os.Stderr
+	command.Stdout = os.Stderr
+	return command.Run()
 }

--- a/xray/commands/audit/javautils.go
+++ b/xray/commands/audit/javautils.go
@@ -93,19 +93,15 @@ func runScanGraph(modulesDependencyTrees []*services.GraphNode, serverDetails *c
 		licenses = append(licenses, scanResults.Licenses...)
 	}
 	fmt.Println("The full scan results are available here: " + tempDirPath)
-
-	if len(violations) > 0 {
-		if err = xrutils.PrintViolationsTable(violations, false); err != nil {
-			return err
-		}
-	}
-	if len(vulnerabilities) > 0 {
+	if includeVulnerabilities {
 		xrutils.PrintVulnerabilitiesTable(vulnerabilities, false)
+	} else {
+		err = xrutils.PrintViolationsTable(violations, false)
 	}
-	if len(licenses) > 0 {
+	if includeLicenses {
 		xrutils.PrintLicensesTable(licenses, false)
 	}
-	return nil
+	return err
 }
 
 func addModuleTree(module buildinfo.Module) *services.GraphNode {

--- a/xray/commands/audit/npm.go
+++ b/xray/commands/audit/npm.go
@@ -145,13 +145,12 @@ func (auditCmd *AuditNpmCommand) Run() (err error) {
 		return err
 	}
 	fmt.Println("The full scan results are available here: " + tempDirPath)
-	if len(scanResults.Violations) > 0 {
+	if auditCmd.includeVulnerabilities {
+		xrutils.PrintVulnerabilitiesTable(scanResults.Vulnerabilities, false)
+	} else {
 		err = xrutils.PrintViolationsTable(scanResults.Violations, false)
 	}
-	if len(scanResults.Vulnerabilities) > 0 {
-		xrutils.PrintVulnerabilitiesTable(scanResults.Vulnerabilities, false)
-	}
-	if len(scanResults.Licenses) > 0 {
+	if auditCmd.includeLincenses {
 		xrutils.PrintLicensesTable(scanResults.Licenses, false)
 	}
 	return err


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
 
* Fix an issue whereby stderr and stdout closed after executing the Maven and Gradle commands. As a result, prints to the logs were invisible.
* Print audit results in the npm, Gradle, and Maven audit when there are no vulnerabilities/licenses/violations. For example:
```
jfrog xr audit-gradle --licenses
```
### Results:
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/11367982/125484278-dec274d2-7b1d-49c9-baef-deb17d9aac21.png">

```
jfrog xr audit-gradle --watches=all
```
### Results:
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/11367982/125484477-d8110cbf-5ef8-47c4-9c66-9495665be42b.png">
