### PR TITLE
Bugfix - unmarshalDeployableArtifacts produces NPD

### DIFF
--- a/artifactory/commands/gradle/gradle.go
+++ b/artifactory/commands/gradle/gradle.go
@@ -25,7 +25,7 @@ func NewGradleCommand() *GradleCommand {
 	return &GradleCommand{}
 }
 
-// Returns the ArtfiactoryDetails. The information returns from the config file provided.
+// Returns the ServerDetails. The information returns from the config file provided.
 func (gc *GradleCommand) ServerDetails() (*config.ServerDetails, error) {
 	// Get the serverDetails from the config file.
 	var err error
@@ -69,13 +69,16 @@ func (gc *GradleCommand) Run() error {
 	}
 	if gc.IsDetailedSummary() {
 		return gc.unmarshalDeployableArtifacts(deployableArtifactsFile)
-
 	}
 	return nil
 }
 
 func (gc *GradleCommand) unmarshalDeployableArtifacts(filesPath string) error {
-	result, err := commandsutils.UnmarshalDeployableArtifacts(filesPath, gc.serverDetails.ArtifactoryUrl)
+	serverDetails, err := gc.ServerDetails()
+	if err != nil {
+		return err
+	}
+	result, err := commandsutils.UnmarshalDeployableArtifacts(filesPath, serverDetails.ArtifactoryUrl)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -114,7 +114,6 @@ func (mc *MvnCommand) Run() error {
 	}
 	if mc.IsDetailedSummary() {
 		return mc.unmarshalDeployableArtifacts(deployableArtifactsFile)
-
 	}
 	return nil
 }
@@ -134,7 +133,11 @@ func (mc *MvnCommand) ServerDetails() (*config.ServerDetails, error) {
 }
 
 func (mc *MvnCommand) unmarshalDeployableArtifacts(filesPath string) error {
-	result, err := commandsutils.UnmarshalDeployableArtifacts(filesPath, mc.serverDetails.ArtifactoryUrl)
+	serverDetails, err := mc.ServerDetails()
+	if err != nil {
+		return err
+	}
+	result, err := commandsutils.UnmarshalDeployableArtifacts(filesPath, serverDetails.ArtifactoryUrl)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Accessing gc.serverDetails and mc.serverDetails directly, produces nil pointer dereference.
Instead we should retrieve the server details by gc.ServerDetails() and mc.ServerDetails().