### PR TITLE
Bugfix - External processes hide log messages

### DIFF
--- a/artifactory/utils/container/containermanager.go
+++ b/artifactory/utils/container/containermanager.go
@@ -1,15 +1,14 @@
 package container
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 
-	gofrogcmd "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/auth"
@@ -121,6 +120,7 @@ func (pushCmd *pushCmd) RunCmd() error {
 	command.Stderr = os.Stderr
 	command.Stdout = os.Stderr
 	return command.Run()
+}
 
 // Image get image id command
 type getImageIdCmd struct {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Following this [commit](https://github.com/jfrog/jfrog-cli-core/commit/f1279f082f8cafb85c0336199d3645c6e8dc26b8), external processes close the stderr stream. As a result, the first process runs and closes the stderr stream and the next process' messages won't be print