### PR TITLE
Use Maven dependency:resolve in audit

### DIFF
--- a/xray/commands/audit/mvn.go
+++ b/xray/commands/audit/mvn.go
@@ -13,7 +13,6 @@ import (
 
 type AuditMavenCommand struct {
 	serverDetails          *config.ServerDetails
-	excludeTestDeps        bool
 	insecureTls            bool
 	watches                []string
 	projectKey             string
@@ -24,11 +23,6 @@ type AuditMavenCommand struct {
 
 func (auditCmd *AuditMavenCommand) SetServerDetails(server *config.ServerDetails) *AuditMavenCommand {
 	auditCmd.serverDetails = server
-	return auditCmd
-}
-
-func (auditCmd *AuditMavenCommand) SetExcludeTestDeps(excludeTestDeps bool) *AuditMavenCommand {
-	auditCmd.excludeTestDeps = excludeTestDeps
 	return auditCmd
 }
 
@@ -93,10 +87,7 @@ func (auditCmd *AuditMavenCommand) getModulesDependencyTrees() (modules []*servi
 }
 
 func (auditCmd *AuditMavenCommand) runMvn(buildConfiguration *utils.BuildConfiguration) error {
-	goals := []string{"-B", "compile"}
-	if !auditCmd.excludeTestDeps {
-		goals = append(goals, "test-compile")
-	}
+	goals := []string{"-B", "dependency:resolve"}
 	log.Debug(fmt.Sprintf("mvn command goals: %v", goals))
 	configFilePath, exists, err := utils.GetProjectConfFilePath(utils.Maven)
 	if err != nil {

--- a/xray/commands/audit/mvn_test.go
+++ b/xray/commands/audit/mvn_test.go
@@ -19,7 +19,7 @@ func TestMavenTreesMultiModule(t *testing.T) {
 
 	// Check root module
 	multi := getAndAssertNode(t, modulesDependencyTrees, "org.jfrog.test:multi:3.7-SNAPSHOT")
-	assert.Empty(t, multi.Nodes)
+	assert.Len(t, multi.Nodes, 1)
 
 	// Check multi1 with a transitive dependency
 	multi1 := getAndAssertNode(t, modulesDependencyTrees, "org.jfrog.test:multi1:3.7-SNAPSHOT")
@@ -32,35 +32,4 @@ func TestMavenTreesMultiModule(t *testing.T) {
 	assert.Len(t, multi2.Nodes, 1)
 	multi3 := getAndAssertNode(t, modulesDependencyTrees, "org.jfrog.test:multi3:3.7-SNAPSHOT")
 	assert.Len(t, multi3.Nodes, 4)
-}
-
-func TestMavenTreesExcludeTestDeps(t *testing.T) {
-	// Create and change directory to test workspace
-	_, cleanUp := createTestWorkspace(t, "artifactory-maven-plugin")
-	defer cleanUp()
-
-	// Run getModulesDependencyTrees
-	auditCmd := NewAuditMvnCommand()
-	modulesDependencyTrees, err := auditCmd.getModulesDependencyTrees()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, modulesDependencyTrees)
-
-	// Assert module
-	module := getAndAssertNode(t, modulesDependencyTrees, "org.jfrog.buildinfo:artifactory-maven-plugin:3.2.3")
-	assert.Len(t, module.Nodes, 12)
-
-	// Assert direct and transitive dependencies
-	directDependency := getAndAssertNode(t, module.Nodes, "org.slf4j:slf4j-simple:1.7.30")
-	assert.Len(t, directDependency.Nodes, 1)
-	getAndAssertNode(t, directDependency.Nodes, "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.2")
-
-	// Run getModulesDependencyTrees
-	auditCmd.excludeTestDeps = true
-	modulesDependencyTrees, err = auditCmd.getModulesDependencyTrees()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, modulesDependencyTrees)
-
-	// Assert module
-	module = getAndAssertNode(t, modulesDependencyTrees, "org.jfrog.buildinfo:artifactory-maven-plugin:3.2.3")
-	assert.Len(t, module.Nodes, 11)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Instead of running `mvn compile` or `mvn compile compileTest`, use `mvn dependency:resolve`. The `resolve` Mojo of the `dependency` plugin doesn't compile the Java classes and therefore expected to be faster.