### PR TITLE
Report usage should run only if there is rt url

### DIFF
--- a/common/commands/command.go
+++ b/common/commands/command.go
@@ -42,7 +42,7 @@ func reportUsage(command Command, channel chan<- bool) {
 			log.Debug(usage.ReportUsagePrefix + err.Error())
 			return
 		}
-		if serverDetails != nil {
+		if serverDetails != nil && serverDetails.ArtifactoryUrl != "" {
 			log.Debug(usage.ReportUsagePrefix + "Sending info...")
 			serviceManager, err := utils.CreateServiceManager(serverDetails, -1, false)
 			if err != nil {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Report usage should not run if there is no Artifactory URL configured.