### PR TITLE
V1: Archiving symlinks in upload command

### DIFF
--- a/artifactory/spec/specfiles.go
+++ b/artifactory/spec/specfiles.go
@@ -170,6 +170,7 @@ func ValidateSpec(files []File, isTargetMandatory, isSearchBasedSpec, isUpload b
 		isSymlinks, _ := file.IsSymlinks(false)
 		isRegexp := file.Regexp == "true"
 		isAnt := file.Ant == "true"
+		isExplode, _ := file.IsExplode(false)
 
 		if isTargetMandatory && !isTarget {
 			return errors.New("Spec must include target.")
@@ -228,8 +229,8 @@ func ValidateSpec(files []File, isTargetMandatory, isSearchBasedSpec, isUpload b
 		if isRegexp && isAnt {
 			return errors.New("Can not use the option of regexp and ant together.")
 		}
-		if isArchive && isSymlinks {
-			return errors.New("Symlinks cannot be stored in an archive.")
+		if isArchive && isSymlinks && isExplode {
+			return errors.New("When uploading symlink to artifactory a file in size 0 with properties describing the symlink is being saved.\nThis procces is not yet supported by artifactory when exploding symlinks from a zip.")
 		}
 		if isArchive && !isValidArchive {
 			return errors.New("The value of 'archive' (if provided) must be 'zip'.")

--- a/artifactory/spec/specfiles.go
+++ b/artifactory/spec/specfiles.go
@@ -230,7 +230,7 @@ func ValidateSpec(files []File, isTargetMandatory, isSearchBasedSpec, isUpload b
 			return errors.New("Can not use the option of regexp and ant together.")
 		}
 		if isArchive && isSymlinks && isExplode {
-			return errors.New("Symlinks cannot be stored in an archive that will be exploded in artifactory.\nWhen uploading symlink to artifactory a file in size 0 with properties describing the symlink is being saved.\nThis procces is not yet supported by artifactory when exploding symlinks from a zip.\nPossible uses: archive with symlinks or archive with explode.")
+			return errors.New("Symlinks cannot be stored in an archive that will be exploded in artifactory.\nWhen uploading symlink to artifactory a file in size 0 with properties describing the symlink is being saved.\nThis process is not yet supported by artifactory when exploding symlinks from a zip.\nPossible uses: archive with symlinks or archive with explode.")
 		}
 		if isArchive && !isValidArchive {
 			return errors.New("The value of 'archive' (if provided) must be 'zip'.")

--- a/artifactory/spec/specfiles.go
+++ b/artifactory/spec/specfiles.go
@@ -230,7 +230,7 @@ func ValidateSpec(files []File, isTargetMandatory, isSearchBasedSpec, isUpload b
 			return errors.New("Can not use the option of regexp and ant together.")
 		}
 		if isArchive && isSymlinks && isExplode {
-			return errors.New("When uploading symlink to artifactory a file in size 0 with properties describing the symlink is being saved.\nThis procces is not yet supported by artifactory when exploding symlinks from a zip.")
+			return errors.New("Symlinks cannot be stored in an archive that will be exploded in artifactory.\nWhen uploading symlink to artifactory a file in size 0 with properties describing the symlink is being saved.\nThis procces is not yet supported by artifactory when exploding symlinks from a zip.\nPossible uses: archive with symlinks or archive with explode.")
 		}
 		if isArchive && !isValidArchive {
 			return errors.New("The value of 'archive' (if provided) must be 'zip'.")


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    * Remove restriction about using --archive and --symlinks together.
    * The combination of --archive, --symlinks and --explode together is still forbidden. 
    When uploading a symlink to Artifactory, the symlink is represented in Artifactory as 0 size file with properties 
    describing the symlink. This symlink representation is not yet supported by Artifactory when exploding symlinks from a zip.