### PR TITLE
v1: Improve ssh usability

### DIFF
--- a/common/commands/config.go
+++ b/common/commands/config.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/utils/ioutils"
@@ -22,7 +21,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Internal golang locking for the same process.
@@ -113,13 +111,17 @@ func (cc *ConfigCommand) Config() error {
 			return err
 		}
 	} else if cc.details.Url != "" {
-		cc.details.Url = clientutils.AddTrailingSlashIfNeeded(cc.details.Url)
-		// Derive JFrog services URLs from platform URL
-		coreutils.SetIfEmpty(&cc.details.ArtifactoryUrl, cc.details.Url+"artifactory/")
-		coreutils.SetIfEmpty(&cc.details.DistributionUrl, cc.details.Url+"distribution/")
-		coreutils.SetIfEmpty(&cc.details.XrayUrl, cc.details.Url+"xray/")
-		coreutils.SetIfEmpty(&cc.details.MissionControlUrl, cc.details.Url+"mc/")
-		coreutils.SetIfEmpty(&cc.details.PipelinesUrl, cc.details.Url+"pipelines/")
+		if fileutils.IsSshUrl(cc.details.Url) {
+			coreutils.SetIfEmpty(&cc.details.ArtifactoryUrl, cc.details.Url)
+		} else {
+			cc.details.Url = clientutils.AddTrailingSlashIfNeeded(cc.details.Url)
+			// Derive JFrog services URLs from platform URL
+			coreutils.SetIfEmpty(&cc.details.ArtifactoryUrl, cc.details.Url+"artifactory/")
+			coreutils.SetIfEmpty(&cc.details.DistributionUrl, cc.details.Url+"distribution/")
+			coreutils.SetIfEmpty(&cc.details.XrayUrl, cc.details.Url+"xray/")
+			coreutils.SetIfEmpty(&cc.details.MissionControlUrl, cc.details.Url+"mc/")
+			coreutils.SetIfEmpty(&cc.details.PipelinesUrl, cc.details.Url+"pipelines/")
+		}
 	}
 	cc.details.ArtifactoryUrl = clientutils.AddTrailingSlashIfNeeded(cc.details.ArtifactoryUrl)
 	cc.details.DistributionUrl = clientutils.AddTrailingSlashIfNeeded(cc.details.DistributionUrl)
@@ -232,17 +234,15 @@ func (cc *ConfigCommand) getConfigurationFromUser() error {
 	}
 
 	if cc.details.Url != "" {
-		cc.details.Url = clientutils.AddTrailingSlashIfNeeded(cc.details.Url)
-		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.DistributionUrl, cc.details.Url+"distribution/") || disallowUsingSavedPassword
-		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.ArtifactoryUrl, cc.details.Url+"artifactory/") || disallowUsingSavedPassword
-		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.XrayUrl, cc.details.Url+"xray/") || disallowUsingSavedPassword
-		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.MissionControlUrl, cc.details.Url+"mc/") || disallowUsingSavedPassword
-		disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.PipelinesUrl, cc.details.Url+"pipelines/") || disallowUsingSavedPassword
-	}
-
-	if !cc.disablePromptUrls {
-		if err := cc.promptUrls(&disallowUsingSavedPassword); err != nil {
-			return err
+		if fileutils.IsSshUrl(cc.details.Url) {
+			coreutils.SetIfEmpty(&cc.details.ArtifactoryUrl, cc.details.Url)
+		} else {
+			cc.details.Url = clientutils.AddTrailingSlashIfNeeded(cc.details.Url)
+			disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.DistributionUrl, cc.details.Url+"distribution/") || disallowUsingSavedPassword
+			disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.ArtifactoryUrl, cc.details.Url+"artifactory/") || disallowUsingSavedPassword
+			disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.XrayUrl, cc.details.Url+"xray/") || disallowUsingSavedPassword
+			disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.MissionControlUrl, cc.details.Url+"mc/") || disallowUsingSavedPassword
+			disallowUsingSavedPassword = coreutils.SetIfEmpty(&cc.details.PipelinesUrl, cc.details.Url+"pipelines/") || disallowUsingSavedPassword
 		}
 	}
 
@@ -250,18 +250,23 @@ func (cc *ConfigCommand) getConfigurationFromUser() error {
 		if err := getSshKeyPath(cc.details); err != nil {
 			return err
 		}
-	}
-
-	// Api-Key/Password/Access-Token
-	if cc.details.ApiKey == "" && cc.details.Password == "" && cc.details.AccessToken == "" {
-		err := readAccessTokenFromConsole(cc.details)
-		if err != nil {
-			return err
+	} else {
+		if !cc.disablePromptUrls {
+			if err := cc.promptUrls(&disallowUsingSavedPassword); err != nil {
+				return err
+			}
 		}
-		if len(cc.details.GetAccessToken()) == 0 {
-			err = ioutils.ReadCredentialsFromConsole(cc.details, cc.defaultDetails, disallowUsingSavedPassword)
+		// Api-Key/Password/Access-Token
+		if cc.details.ApiKey == "" && cc.details.Password == "" && cc.details.AccessToken == "" {
+			err := readAccessTokenFromConsole(cc.details)
 			if err != nil {
 				return err
+			}
+			if len(cc.details.GetAccessToken()) == 0 {
+				err = ioutils.ReadCredentialsFromConsole(cc.details, cc.defaultDetails, disallowUsingSavedPassword)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -309,17 +314,11 @@ func (cc *ConfigCommand) readRefreshableTokenFromConsole() {
 }
 
 func readAccessTokenFromConsole(details *config.ServerDetails) error {
-	print("JFrog access token (Leave blank for username and password/API key): ")
-	byteToken, err := terminal.ReadPassword(int(syscall.Stdin))
-	if err != nil {
-		return errorutils.CheckError(err)
+	token, err := ioutils.ScanPasswordFromConsole("JFrog access token (Leave blank for username and password/API key): ")
+	if err == nil {
+		details.SetAccessToken(token)
 	}
-	// New-line required after the access token input:
-	fmt.Println()
-	if len(byteToken) > 0 {
-		details.SetAccessToken(string(byteToken))
-	}
-	return nil
+	return err
 }
 
 func getSshKeyPath(details *config.ServerDetails) error {
@@ -341,7 +340,7 @@ func getSshKeyPath(details *config.ServerDetails) error {
 		return err
 	}
 
-	optionalPrefix := ""
+	messageSuffix := ": "
 	if exists {
 		sshKeyBytes, err := ioutil.ReadFile(details.SshKeyPath)
 		if err != nil {
@@ -355,12 +354,15 @@ func getSshKeyPath(details *config.ServerDetails) error {
 		log.Info("The key file at the specified path is encrypted.")
 	} else {
 		log.Info("Could not find key in provided path. You may place the key file there later.")
-		optionalPrefix = "(optional)"
+		messageSuffix = " (optional): "
 	}
 	if details.SshPassphrase == "" {
-		ioutils.ScanFromConsole("SSH key passphrase "+optionalPrefix, &details.SshPassphrase, "")
+		token, err := ioutils.ScanPasswordFromConsole("SSH key passphrase" + messageSuffix)
+		if err != nil {
+			return err
+		}
+		details.SetSshPassphrase(token)
 	}
-
 	return err
 }
 
@@ -424,6 +426,7 @@ func printConfigs(configuration []*config.ServerDetails) {
 		logIfNotEmpty(details.AccessToken, "Access token:\t\t\t", true)
 		logIfNotEmpty(details.RefreshToken, "Refresh token:\t\t\t", true)
 		logIfNotEmpty(details.SshKeyPath, "SSH key file path:\t\t", false)
+		logIfNotEmpty(details.SshPassphrase, "SSH passphrase:\t\t\t", true)
 		logIfNotEmpty(details.ClientCertPath, "Client certificate file path:\t", false)
 		logIfNotEmpty(details.ClientCertKeyPath, "Client certificate key path:\t", false)
 		log.Output("Default:\t\t\t" + strconv.FormatBool(details.IsDefault))
@@ -534,7 +537,8 @@ func checkSingleAuthMethod(details *config.ServerDetails) error {
 	authMethods := []bool{
 		details.User != "" && details.Password != "",
 		details.ApiKey != "",
-		details.AccessToken != "" && details.RefreshToken == ""}
+		details.AccessToken != "" && details.RefreshToken == "",
+		details.SshKeyPath != ""}
 	if coreutils.SumTrueValues(authMethods) > 1 {
 		return errorutils.CheckError(errors.New("Only one authentication method is allowed: Username + Password/API key, RSA Token (SSH) or Access Token"))
 	}

--- a/common/commands/config_test.go
+++ b/common/commands/config_test.go
@@ -47,9 +47,8 @@ func TestApiKey(t *testing.T) {
 
 func TestArtifactorySshKey(t *testing.T) {
 	inputDetails := createTestServerDetails()
-	inputDetails.User = "admin"
-	inputDetails.Password = "password"
 	inputDetails.SshKeyPath = "/tmp/sshKey"
+	inputDetails.SshPassphrase = "123456"
 	inputDetails.ArtifactoryUrl = "ssh://localhost:1339/"
 
 	configAndTest(t, inputDetails, false)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
+	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/mod v0.3.0
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,9 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e h1:gsTQYXdTw2Gq7RBsWvlQ91b+aEQ6bXFUngBGuR8sPpI=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
+golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -541,7 +541,7 @@ type ServerDetails struct {
 	User                 string `json:"user,omitempty"`
 	Password             string `json:"password,omitempty"`
 	SshKeyPath           string `json:"sshKeyPath,omitempty"`
-	SshPassphrase        string `json:"SshPassphrase,omitempty"`
+	SshPassphrase        string `json:"sshPassphrase,omitempty"`
 	AccessToken          string `json:"accessToken,omitempty"`
 	RefreshToken         string `json:"refreshToken,omitempty"`
 	TokenRefreshInterval int    `json:"tokenRefreshInterval,omitempty"`
@@ -590,6 +590,10 @@ func (serverDetails *ServerDetails) SetAccessToken(accessToken string) {
 
 func (serverDetails *ServerDetails) SetRefreshToken(refreshToken string) {
 	serverDetails.RefreshToken = refreshToken
+}
+
+func (serverDetails *ServerDetails) SetSshPassphrase(sshPassphrase string) {
+	serverDetails.SshPassphrase = sshPassphrase
 }
 
 func (serverDetails *ServerDetails) SetClientCertPath(certificatePath string) {

--- a/utils/ioutils/ioutils.go
+++ b/utils/ioutils/ioutils.go
@@ -23,20 +23,27 @@ func ReadCredentialsFromConsole(details, savedDetails coreutils.Credentials, dis
 		disallowUsingSavedPassword = true
 	}
 	if details.GetPassword() == "" {
-		print("JFrog password or API key: ")
-		bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
-		err = errorutils.CheckError(err)
+		password, err := ScanPasswordFromConsole("JFrog password or API key: ")
 		if err != nil {
 			return err
 		}
-		details.SetPassword(string(bytePassword))
+		details.SetPassword(password)
 		if details.GetPassword() == "" && !disallowUsingSavedPassword {
 			details.SetPassword(savedDetails.GetPassword())
 		}
-		// New-line required after the password input:
-		fmt.Println()
 	}
 	return nil
+}
+
+func ScanPasswordFromConsole(message string) (string, error) {
+	print(message)
+	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return "", errorutils.CheckError(err)
+	}
+	// New-line required after the password input:
+	fmt.Println()
+	return string(bytePassword), nil
 }
 
 func ScanFromConsole(caption string, scanInto *string, defaultValue string) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
* Currently SSH connection is only allowed on Artifactory. When the user provides SSH platform URL, we should populate Artifactory's URL with this SSH URL.
* Username, password, and access tokens should not be provided when SSH URL is provided.
* SSH passphrase should be displayed (as `***`) when running `jfrog c show`.
* Upgrade crypto to the latest