### PR TITLE
Archiving symlinks in upload command

### DIFF
--- a/common/spec/specfiles.go
+++ b/common/spec/specfiles.go
@@ -173,6 +173,7 @@ func ValidateSpec(files []File, isTargetMandatory, isSearchBasedSpec, isUpload b
 		isSymlinks, _ := file.IsSymlinks(false)
 		isRegexp := file.Regexp == "true"
 		isAnt := file.Ant == "true"
+		isExplode, _ := file.IsExplode(false)
 
 		if isTargetMandatory && !isTarget {
 			return errors.New("Spec must include target.")
@@ -225,8 +226,8 @@ func ValidateSpec(files []File, isTargetMandatory, isSearchBasedSpec, isUpload b
 		if isRegexp && isAnt {
 			return errors.New("Can not use the option of regexp and ant together.")
 		}
-		if isArchive && isSymlinks {
-			return errors.New("Symlinks cannot be stored in an archive.")
+		if isArchive && isSymlinks && isExplode {
+			return errors.New("Symlinks cannot be stored in an archive that will be exploded in artifactory.\\nWhen uploading a symlink to Artifactory, the symlink is represented in Artifactory as 0 size filewith properties describing the symlink.\\nThis symlink representation is not yet supported by Artifactory when exploding symlinks from a zip.")
 		}
 		if isArchive && !isValidArchive {
 			return errors.New("The value of 'archive' (if provided) must be 'zip'.")

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.1.1-0.20210808084305-c49c99d0d807
+//replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.1.1-0.20210808084305-c49c99d0d807
+replace github.com/jfrog/jfrog-client-go => github.com/gailazar300/jfrog-client-go v0.18.1-0.20210808145454-c8d5d58d65a4
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd v0.4.2-0.20210711151504-537a5ef5b8e1

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
-//replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.1.1-0.20210808084305-c49c99d0d807
-replace github.com/jfrog/jfrog-client-go => github.com/gailazar300/jfrog-client-go v0.18.1-0.20210808145454-c8d5d58d65a4
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.1.1-0.20210808155522-4d77bb9e3091
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd v0.4.2-0.20210711151504-537a5ef5b8e1

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
+github.com/gailazar300/jfrog-client-go v0.18.1-0.20210808145454-c8d5d58d65a4 h1:TvHdRK+Mc4r/mt6t08PHkynVYP5RIHbq04wUJcp2ekM=
+github.com/gailazar300/jfrog-client-go v0.18.1-0.20210808145454-c8d5d58d65a4/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
@@ -155,8 +157,6 @@ github.com/jfrog/gocmd v0.4.2/go.mod h1:+nQOc+GQQu2e3dJBxymq9/y3ReLHDz6Eg/+QkGHP
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
 github.com/jfrog/gofrog v1.0.7 h1:sHR5IDGFY61+mGqTH/dIZlojTeIb6kXdK74oxMAjTgc=
 github.com/jfrog/gofrog v1.0.7/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
-github.com/jfrog/jfrog-client-go v1.1.1-0.20210808084305-c49c99d0d807 h1:A+I1SofhmhSNWkB85aWmdjM6geU6pVgoiiXaeQqpoYI=
-github.com/jfrog/jfrog-client-go v1.1.1-0.20210808084305-c49c99d0d807/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
-github.com/gailazar300/jfrog-client-go v0.18.1-0.20210808145454-c8d5d58d65a4 h1:TvHdRK+Mc4r/mt6t08PHkynVYP5RIHbq04wUJcp2ekM=
-github.com/gailazar300/jfrog-client-go v0.18.1-0.20210808145454-c8d5d58d65a4/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
@@ -157,6 +155,8 @@ github.com/jfrog/gocmd v0.4.2/go.mod h1:+nQOc+GQQu2e3dJBxymq9/y3ReLHDz6Eg/+QkGHP
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
 github.com/jfrog/gofrog v1.0.7 h1:sHR5IDGFY61+mGqTH/dIZlojTeIb6kXdK74oxMAjTgc=
 github.com/jfrog/gofrog v1.0.7/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
+github.com/jfrog/jfrog-client-go v1.1.1-0.20210808155522-4d77bb9e3091 h1:DzoKarXUOMaPdb4935yySc2XdGH6ARNgLS04IkNc9oI=
+github.com/jfrog/jfrog-client-go v1.1.1-0.20210808155522-4d77bb9e3091/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
* Remove restriction about using --archive and --symlinks together.
* The combination of --archive, --symlinks and --explode together is still forbidden. 
When uploading a symlink to Artifactory, the symlink is represented in Artifactory as 0 size file with properties 
describing the symlink. This symlink representation is not yet supported by Artifactory when exploding symlinks from a zip.