### PR TITLE
Upgrade and adapt the code to jfrog-client-go v1.3.0

### DIFF
--- a/artifactory/commands/repository/repository.go
+++ b/artifactory/commands/repository/repository.go
@@ -148,14 +148,33 @@ func writeContentSynchronisation(resultMap *map[string]interface{}, key, value s
 		return errors.New("invalid value for Content Synchronisation")
 	}
 	var cs services.ContentSynchronisation
-	cs.Enabled, _ = strconv.ParseBool(answerArray[0])
-	cs.Statistics.Enabled, _ = strconv.ParseBool(answerArray[1])
-	cs.Properties.Enabled, _ = strconv.ParseBool(answerArray[2])
-	cs.Source.OriginAbsenceDetection, _ = strconv.ParseBool(answerArray[3])
+
+	enabled, err := strconv.ParseBool(answerArray[0])
+	if errorutils.CheckError(err) != nil {
+		return err
+	}
+	cs.Enabled = &enabled
+
+	enabled, err = strconv.ParseBool(answerArray[1])
+	if errorutils.CheckError(err) != nil {
+		return err
+	}
+	cs.Statistics.Enabled = &enabled
+
+	enabled, err = strconv.ParseBool(answerArray[2])
+	if errorutils.CheckError(err) != nil {
+		return err
+	}
+	cs.Properties.Enabled = &enabled
+
+	enabled, err = strconv.ParseBool(answerArray[3])
+	if errorutils.CheckError(err) != nil {
+		return err
+	}
+	cs.Source.OriginAbsenceDetection = &enabled
 
 	(*resultMap)[key] = cs
 	return nil
-
 }
 
 // repoHandler is a function that gets serviceManager, JSON configuration content and a flag indicates is the operation in an update operation

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.2.2
 	github.com/jfrog/gocmd v0.4.2
 	github.com/jfrog/gofrog v1.0.7
-	github.com/jfrog/jfrog-client-go v1.2.1
+	github.com/jfrog/jfrog-client-go v1.3.0
 	github.com/magiconair/properties v1.8.1
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mattn/go-shellwords v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tml
 github.com/jfrog/gofrog v1.0.7 h1:sHR5IDGFY61+mGqTH/dIZlojTeIb6kXdK74oxMAjTgc=
 github.com/jfrog/gofrog v1.0.7/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
 github.com/jfrog/jfrog-client-go v1.1.0/go.mod h1:bjBL6Svr951HZH7JvMtzPJ9Xy5cO0OweNjkhUzxKmtw=
-github.com/jfrog/jfrog-client-go v1.2.1 h1:MC4WSO2hkuaikjQBLy/s8VyPCOJL6y+cL4tM3BszsJM=
-github.com/jfrog/jfrog-client-go v1.2.1/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
+github.com/jfrog/jfrog-client-go v1.3.0 h1:tPx8Six4waOcmb7R/z7q0zk8XIGJlLvtUwQrqzbR/Yg=
+github.com/jfrog/jfrog-client-go v1.3.0/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
* Upgrade jfrog-client-go to v1.3.0.
* jfrog-client-go to v1.3.0 includes code changes in the area of repository management, which require some from the jfrog-clie-core side. Without this adaptation, the following compilation error is thrown - 
```
# github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/repository
vet: artifactory/commands/repository/repository.go:151:18: cannot use strconv.ParseBool(answerArray[0]) (value of type bool) as *bool value in assignment

``` 