### PR TITLE
Support projectKey in repo template

### DIFF
--- a/artifactory/commands/repository/repository.go
+++ b/artifactory/commands/repository/repository.go
@@ -34,21 +34,26 @@ func (rc *RepoCommand) PerformRepoCmd(isUpdate bool) (err error) {
 		return err
 	}
 	// All the values in the template are strings
-	// Go over the the confMap and write the values with the correct type using the writersMap
+	// Go over the confMap and write the values with the correct type using the writersMap
 	for key, value := range repoConfigMap {
 		if err = utils.ValidateMapEntry(key, value, writersMap); err != nil {
 			return
 		}
-		writersMap[key](&repoConfigMap, key, value.(string))
+		if err = writersMap[key](&repoConfigMap, key, value.(string)); err != nil {
+			return
+		}
 	}
 	// Write a JSON with the correct values
 	content, err := json.Marshal(repoConfigMap)
+	if err != nil {
+		return err
+	}
 
 	servicesManager, err := rtUtils.CreateServiceManager(rc.serverDetails, -1, false)
 	if err != nil {
 		return err
 	}
-	// Rclass and packgeType are mandatory keys in our templates
+	// Rclass and packageType are mandatory keys in our templates
 	// Using their values we'll pick the suitable handler from one of the handler maps to create/update a repository
 	switch repoConfigMap[Rclass] {
 	case Local:
@@ -74,6 +79,7 @@ var writersMap = map[string]utils.AnswerWriter{
 	IncludePatterns:                   utils.WriteStringAnswer,
 	ExcludePatterns:                   utils.WriteStringAnswer,
 	RepoLayoutRef:                     utils.WriteStringAnswer,
+	ProjectKey:                        utils.WriteStringAnswer,
 	HandleReleases:                    utils.WriteBoolAnswer,
 	HandleSnapshots:                   utils.WriteBoolAnswer,
 	MaxUniqueSnapshots:                utils.WriteIntAnswer,

--- a/artifactory/commands/repository/template.go
+++ b/artifactory/commands/repository/template.go
@@ -576,7 +576,7 @@ func projectKeyCallback(iq *utils.InteractiveQuestionnaire, projectKey string) (
 
 	if !strings.HasPrefix(currentRepoKey, requiredProjectPrefix) {
 		newRepoKey := requiredProjectPrefix + currentRepoKey
-		log.Info("Repository key should start with the projectKey and a dash. Modifying repo key to: '" + newRepoKey + "'.")
+		log.Info("Repository key should start with the projectKey followed by a dash. Modifying repo key to: '" + newRepoKey + "'.")
 		iq.AnswersMap[Key] = newRepoKey
 	}
 	return "", nil

--- a/artifactory/commands/repository/template.go
+++ b/artifactory/commands/repository/template.go
@@ -40,6 +40,7 @@ const (
 	IncludePatterns = "includesPattern"
 	ExcludePatterns = "excludesPattern"
 	RepoLayoutRef   = "repoLayoutRef"
+	ProjectKey      = "projectKey"
 
 	// Mutual local and remote repository configuration JSON keys
 	HandleReleases               = "handleReleases"
@@ -221,6 +222,7 @@ var optionalSuggestsMap = map[string]prompt.Suggest{
 	IncludePatterns:                   {Text: IncludePatterns},
 	ExcludePatterns:                   {Text: ExcludePatterns},
 	RepoLayoutRef:                     {Text: RepoLayoutRef},
+	ProjectKey:                        {Text: ProjectKey},
 	HandleReleases:                    {Text: HandleReleases},
 	HandleSnapshots:                   {Text: HandleSnapshots},
 	MaxUniqueSnapshots:                {Text: MaxUniqueSnapshots},
@@ -291,7 +293,7 @@ var optionalSuggestsMap = map[string]prompt.Suggest{
 }
 
 var baseLocalRepoConfKeys = []string{
-	Description, Notes, IncludePatterns, ExcludePatterns, RepoLayoutRef, BlackedOut, XrayIndex,
+	Description, Notes, IncludePatterns, ExcludePatterns, RepoLayoutRef, ProjectKey, BlackedOut, XrayIndex,
 	PropertySets, ArchiveBrowsingEnabled, OptionalIndexCompressionFormats, DownloadRedirect, BlockPushingSchema1,
 }
 
@@ -316,7 +318,7 @@ var dockerLocalRepoConfKeys = []string{
 }
 
 var baseRemoteRepoConfKeys = []string{
-	Username, Password, Proxy, Description, Notes, IncludePatterns, ExcludePatterns, RepoLayoutRef, HardFail, Offline,
+	Username, Password, Proxy, Description, Notes, IncludePatterns, ExcludePatterns, RepoLayoutRef, ProjectKey, HardFail, Offline,
 	BlackedOut, XrayIndex, StoreArtifactsLocally, SocketTimeoutMillis, LocalAddress, RetrievalCachePeriodSecs, FailedRetrievalCachePeriodSecs,
 	MissedRetrievalCachePeriodSecs, UnusedArtifactsCleanupEnabled, UnusedArtifactsCleanupPeriodHours, AssumedOfflinePeriodSecs,
 	ShareConfiguration, SynchronizeProperties, BlockMismatchingMimeTypes, PropertySets, AllowAnyHostAuth, EnableCookieManagement,
@@ -385,7 +387,7 @@ var genericRemoteRepoConfKeys = []string{
 }
 
 var baseVirtualRepoConfKeys = []string{
-	Repositories, Description, Notes, IncludePatterns, ExcludePatterns, RepoLayoutRef, ArtifactoryRequestsCanRetrieveRemoteArtifacts,
+	Repositories, Description, Notes, IncludePatterns, ExcludePatterns, RepoLayoutRef, ProjectKey, ArtifactoryRequestsCanRetrieveRemoteArtifacts,
 	DefaultDeploymentRepo,
 }
 
@@ -558,6 +560,25 @@ func pkgTypeCallback(iq *utils.InteractiveQuestionnaire, pkgType string) (string
 	}
 	// We don't need the templateType value in the final configuration
 	delete(iq.AnswersMap, TemplateType)
+	return "", nil
+}
+
+// Repo key must have a prefix of "<projectKey>-". This callback adds the prefix to the repo key if it is missing.
+func projectKeyCallback(iq *utils.InteractiveQuestionnaire, projectKey string) (string, error) {
+	if _, ok := iq.AnswersMap[Key]; !ok {
+		return "", errorutils.CheckError(errors.New("repository key is missing in configuration map"))
+	}
+	requiredProjectPrefix := projectKey + "-"
+	currentRepoKey, ok := iq.AnswersMap[Key].(string)
+	if !ok {
+		return "", errorutils.CheckError(errors.New("template syntax error: the value for the repository key is not a string type"))
+	}
+
+	if !strings.HasPrefix(currentRepoKey, requiredProjectPrefix) {
+		newRepoKey := requiredProjectPrefix + currentRepoKey
+		log.Info("Repository key should start with the projectKey and a dash. Modifying repo key to: '" + newRepoKey + "'.")
+		iq.AnswersMap[Key] = newRepoKey
+	}
 	return "", nil
 }
 
@@ -761,6 +782,12 @@ var questionMap = map[string]utils.QuestionInfo{
 		},
 		AllowVars: true,
 		Writer:    utils.WriteStringAnswer,
+	},
+	ProjectKey: {
+		Options:   nil,
+		AllowVars: false,
+		Writer:    utils.WriteStringAnswer,
+		Callback:  projectKeyCallback,
 	},
 	HandleReleases:               BoolToStringQuestionInfo,
 	HandleSnapshots:              BoolToStringQuestionInfo,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Following [jfrog/jfrog-cli#1219](https://github.com/jfrog/jfrog-cli/issues/1219)
This commit adds support to the projectKey field in the repositories templates.
The `jfrog rt rpt` command will add the `<projectKey>-` prefix to the repository key if missing, to follow the requirement in Artifactory.