### PR TITLE
Hash build dir with sha256

### DIFF
--- a/artifactory/utils/buildutils.go
+++ b/artifactory/utils/buildutils.go
@@ -2,7 +2,8 @@ package utils
 
 import (
 	"bytes"
-	"encoding/base64"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,8 +26,8 @@ const BuildInfoDetails = "details"
 const BuildTempPath = "jfrog/builds/"
 
 func GetBuildDir(buildName, buildNumber, projectKey string) (string, error) {
-	encodedDirName := base64.StdEncoding.EncodeToString([]byte(buildName + "_" + buildNumber + "_" + projectKey))
-	buildsDir := filepath.Join(coreutils.GetCliPersistentTempDirPath(), BuildTempPath, encodedDirName)
+	hash := sha256.Sum256([]byte(buildName + "_" + buildNumber + "_" + projectKey))
+	buildsDir := filepath.Join(coreutils.GetCliPersistentTempDirPath(), BuildTempPath, hex.EncodeToString(hash[:]))
 	err := os.MkdirAll(buildsDir, 0777)
 	if errorutils.CheckError(err) != nil {
 		return "", err


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Currently, upon saving the build-info in the file system, we encode `buildName_buildNumber_projectKey` using base64. The value is the unique directory name of the build. 
In some cases, there are very long build names or build numbers. As a symmetric encoding, base64 results size directly depends on the length of the string.

To support big build names and numbers, we should prefer to use a hash function that doesn't depend on the size of the input. The solution suggested in this PR is to use sha256, which always produces 64 long characters hash value.