### PR TITLE
Fix npm version parsing command

### DIFF
--- a/artifactory/commands/npm/installorci.go
+++ b/artifactory/commands/npm/installorci.go
@@ -317,7 +317,7 @@ func (nca *NpmCommandArgs) validateNpmVersion() error {
 	}
 	if npmVersion.Compare(minSupportedNpmVersion) > 0 {
 		return errorutils.CheckError(errors.New(fmt.Sprintf(
-			"JFrog CLI npm %s command requires npm client version " + minSupportedNpmVersion + " or higher.(Current version is: %s)", nca.command, npmVersion.GetVersion())))
+			"JFrog CLI npm %s command requires npm client version " + minSupportedNpmVersion + " or higher. The Current version is: %s", nca.command, npmVersion.GetVersion())))
 	}
 	nca.npmVersion = npmVersion
 	return nil

--- a/artifactory/commands/npm/installorci.go
+++ b/artifactory/commands/npm/installorci.go
@@ -317,7 +317,7 @@ func (nca *NpmCommandArgs) validateNpmVersion() error {
 	}
 	if npmVersion.Compare(minSupportedNpmVersion) > 0 {
 		return errorutils.CheckError(errors.New(fmt.Sprintf(
-			"JFrog CLI npm %s command requires npm client version "+minSupportedNpmVersion+" or higher", nca.command)))
+			"JFrog CLI npm %s command requires npm client version " + minSupportedNpmVersion + " or higher.(Current version is: %s)", nca.command, npmVersion.GetVersion())))
 	}
 	nca.npmVersion = npmVersion
 	return nil

--- a/utils/npm/version.go
+++ b/utils/npm/version.go
@@ -21,11 +21,16 @@ func Version(executablePath string) (*version.Version, error) {
 
 func getVersion(executablePath string) (string, error) {
 	command := exec.Command(executablePath, "-version")
-	buffer := bytes.NewBuffer([]byte{})
-	command.Stderr = buffer
-	command.Stdout = buffer
+	stderr := bytes.NewBuffer([]byte{})
+	stdout := bytes.NewBuffer([]byte{})
+	command.Stderr = stderr
+	command.Stdout = stdout
 	err := command.Run()
-	return buffer.String(), coreutils.ConvertExitCodeError(errorutils.CheckError(err))
+	if err != nil {
+		err = coreutils.ConvertExitCodeError(err)
+		return "", errorutils.CheckError(errors.New(stderr.String() + "-" + err.Error()))
+	}
+	return stdout.String(), nil
 }
 
 func GetNpmVersionAndExecPath() (*version.Version, string, error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Fix npm getVersion() function.
Parse only version string without warning lines and improve error log.