### PR TITLE
Bugfix - Release bundle recursive flag ignored

### DIFF
--- a/artifactory/commands/distribution/createbundle.go
+++ b/artifactory/commands/distribution/createbundle.go
@@ -53,6 +53,11 @@ func (cb *CreateBundleCommand) Run() error {
 		if err != nil {
 			return err
 		}
+		recursive, err := spec.IsRecursive(true)
+		if err != nil {
+			return err
+		}
+		params.Recursive = recursive
 		cb.releaseBundlesParams.SpecFiles = append(cb.releaseBundlesParams.SpecFiles, params)
 	}
 

--- a/artifactory/commands/distribution/updatebundle.go
+++ b/artifactory/commands/distribution/updatebundle.go
@@ -53,6 +53,11 @@ func (cb *UpdateBundleCommand) Run() error {
 		if err != nil {
 			return err
 		}
+		recursive, err := spec.IsRecursive(true)
+		if err != nil {
+			return err
+		}
+		params.Recursive = recursive
 		cb.releaseBundlesParams.SpecFiles = append(cb.releaseBundlesParams.SpecFiles, params)
 	}
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
  
Release bundle `create` and `update` commands ignore the recursive flag.

### Breaking change -
From now on, if the `recursive` flag is missing in the FileSpec, or if a pattern is used, recursive=true will be used. The reason for the breaking change is to be consistent with the other commands.
