### PR TITLE
Delete generatedBuildInfo on errors in Maven and Gradle

### DIFF
--- a/utils/mvn/utils.go
+++ b/utils/mvn/utils.go
@@ -45,9 +45,17 @@ func RunMvn(configPath, deployableArtifactsFile string, buildConf *utils.BuildCo
 	if err != nil {
 		return err
 	}
-
 	defer os.Remove(mvnRunConfig.buildInfoProperties)
-	return mvnRunConfig.runCmd()
+
+	if err = mvnRunConfig.runCmd(); err != nil {
+		// Delete empty generatedBuildInfo file in case of an error
+		if mvnRunConfig.generatedBuildInfoPath != "" {
+			if removeErr := os.Remove(mvnRunConfig.generatedBuildInfoPath); removeErr != nil {
+				log.Error("Couldn't delete file "+mvnRunConfig.generatedBuildInfoPath, removeErr)
+			}
+		}
+	}
+	return err
 }
 
 func getMavenHomeAndValidateVersion() (string, error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Resolves https://github.com/jfrog/jfrog-cli/issues/1276

Before running `jf mvn ...` and `jf gradle ...` commands, we create an empty `generatedBuildInfo` file to be populated with the generated build info of Maven and Gradle. In case of a failure during the Maven or Gradle commands, the file does not populate with the generated build info. As a result, `jf rt bp` throws `unexpected end of JSON input` on the empty file.