### PR TITLE
Add support for fat-manifest & buildx

### DIFF
--- a/artifactory/commands/container/buildcreate.go
+++ b/artifactory/commands/container/buildcreate.go
@@ -46,7 +46,7 @@ func (bdc *BuildDockerCreateCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	builder, err := container.NewBuildInfoBuilderForKanikoOrOpenShift(image, bdc.Repo(), buildName, buildNumber, project, serviceManager, container.Push, bdc.manifestSha256)
+	builder, err := container.NewRemoteAgentBuildInfoBuilder(image, bdc.Repo(), buildName, buildNumber, project, serviceManager, bdc.manifestSha256)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/container/pull.go
+++ b/artifactory/commands/container/pull.go
@@ -59,7 +59,7 @@ func (pc *PullCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	builder, err := container.NewBuildInfoBuilderForDockerOrPodman(image, pc.Repo(), buildName, buildNumber, project, serviceManager, container.Pull, cm)
+	builder, err := container.NewLocalAgentBuildInfoBuilder(image, pc.Repo(), buildName, buildNumber, project, serviceManager, container.Pull, cm)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/container/push.go
+++ b/artifactory/commands/container/push.go
@@ -114,8 +114,9 @@ func (pc *PushCommand) Run() error {
 	// Save detailed summary if needed
 	if pc.IsDetailedSummary() {
 		if !toCollect {
-			// If we saved buildinfo earlier, this update already happened.
-			builder.SetDryRun(true)
+			// Collect build-info wasn't trigger at this point and we do need it to print the detailed summary.
+			// As a result, we are skipping the 'set image build name/number props' before running collect build-info.
+			builder.SetSkipTaggingLayers(true)
 			_, err = builder.Build("")
 			if err != nil {
 				return err

--- a/artifactory/commands/container/push.go
+++ b/artifactory/commands/container/push.go
@@ -96,7 +96,7 @@ func (pc *PushCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	builder, err := container.NewBuildInfoBuilderForDockerOrPodman(image, pc.Repo(), buildName, buildNumber, pc.BuildConfiguration().GetProject(), serviceManager, container.Push, cm)
+	builder, err := container.NewLocalAgentBuildInfoBuilder(image, pc.Repo(), buildName, buildNumber, pc.BuildConfiguration().GetProject(), serviceManager, container.Push, cm)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,8 @@ func (pc *PushCommand) Run() error {
 	if pc.IsDetailedSummary() {
 		if !toCollect {
 			// If we saved buildinfo earlier, this update already happened.
-			err = builder.UpdateArtifactsAndDependencies()
+			builder.SetDryRun(true)
+			_, err = builder.Build("")
 			if err != nil {
 				return err
 			}

--- a/artifactory/commands/oc/startbuild.go
+++ b/artifactory/commands/oc/startbuild.go
@@ -87,7 +87,7 @@ func (osb *OcStartBuildCommand) Run() error {
 		return err
 	}
 	image := container.NewImage(imageTag)
-	builder, err := container.NewBuildInfoBuilderForKanikoOrOpenShift(image, osb.repo, buildName, buildNumber, project, serviceManager, container.Push, manifestSha256)
+	builder, err := container.NewRemoteAgentBuildInfoBuilder(image, osb.repo, buildName, buildNumber, project, serviceManager, manifestSha256)
 	if err != nil {
 		return err
 	}

--- a/artifactory/utils/container/buildinfo.go
+++ b/artifactory/utils/container/buildinfo.go
@@ -1,12 +1,12 @@
 package container
 
 import (
-	"fmt"
-	buildinfo "github.com/jfrog/build-info-go/entities"
+	"encoding/json"
 	"io/ioutil"
-	"net/http"
 	"path"
 	"strings"
+
+	buildinfo "github.com/jfrog/build-info-go/entities"
 
 	artutils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-client-go/artifactory"
@@ -39,42 +39,14 @@ type buildInfoBuilder struct {
 	buildNumber       string
 	project           string
 	serviceManager    artifactory.ArtifactoryServicesManager
-
-	// For Docker and Podman builds
-	containerManager ContainerManager
-
-	// For Kaniko and OpenShift CLI (oc) builds
-	manifestSha256 string
-
-	// internal fields
-	imageId      string
-	layers       []utils.ResultItem
-	artifacts    []buildinfo.Artifact
-	dependencies []buildinfo.Dependency
-	commandType  CommandType
-}
-
-func NewBuildInfoBuilderForDockerOrPodman(image *Image, repository, buildName, buildNumber, project string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType, containerManager ContainerManager) (Builder, error) {
-	builder, err := newBuildInfoBuilder(image, repository, buildName, buildNumber, project, serviceManager, commandType)
-	if err != nil {
-		return nil, err
-	}
-	builder.containerManager = containerManager
-	builder.imageId, err = builder.containerManager.Id(builder.image)
-	return builder, err
-}
-
-func NewBuildInfoBuilderForKanikoOrOpenShift(image *Image, repository, buildName, buildNumber, project string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType, manifestSha256 string) (Builder, error) {
-	builder, err := newBuildInfoBuilder(image, repository, buildName, buildNumber, project, serviceManager, commandType)
-	if err != nil {
-		return nil, err
-	}
-	builder.manifestSha256 = manifestSha256
-	return builder, err
+	imageSha2         string
+	// If true, don't set layers props in Artifactory.
+	dryRun            bool
+	imageLayers       []utils.ResultItem
 }
 
 // Create instance of docker build info builder.
-func newBuildInfoBuilder(image *Image, repository, buildName, buildNumber, project string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType) (*buildInfoBuilder, error) {
+func newBuildInfoBuilder(image *Image, repository, buildName, buildNumber, project string, serviceManager artifactory.ArtifactoryServicesManager) (*buildInfoBuilder, error) {
 	var err error
 	builder := &buildInfoBuilder{}
 	builder.repositoryDetails.key = repository
@@ -87,7 +59,6 @@ func newBuildInfoBuilder(image *Image, repository, buildName, buildNumber, proje
 	builder.buildNumber = buildNumber
 	builder.project = project
 	builder.serviceManager = serviceManager
-	builder.commandType = commandType
 	return builder, nil
 }
 
@@ -96,28 +67,16 @@ type RepositoryDetails struct {
 	isRemote bool
 }
 
-func (builder *buildInfoBuilder) GetLayers() *[]utils.ResultItem {
-	return &builder.layers
+func (builder *buildInfoBuilder) setImageSha2(imageSha2 string) {
+	builder.imageSha2 = imageSha2
 }
 
-// Create build info for a docker image.
-func (builder *buildInfoBuilder) Build(module string) (*buildinfo.BuildInfo, error) {
-	if err := builder.UpdateArtifactsAndDependencies(); err != nil {
-		log.Warn(`Failed to collect build-info, couldn't find image "` + builder.image.tag + `" in Artifactory`)
-		// Don't generate an empty build-info for build-docker-create and oc start-build if the image manifest was not found in Artifactory.
-		if builder.containerManager == nil {
-			return nil, err
-		} else {
-			log.Error("Failed populating the build-info module with docker artifacts and dependencies. Reason: " + err.Error())
-		}
-	}
-	// Set build properties only when pushing image.
-	if builder.commandType == Push {
-		if _, err := builder.setBuildProperties(); err != nil {
-			return nil, err
-		}
-	}
-	return builder.createBuildInfo(module)
+func (builder *buildInfoBuilder) setDryRun(dryRun bool) {
+	builder.dryRun = dryRun
+}
+
+func (builder *buildInfoBuilder) GetLayers() *[]utils.ResultItem {
+	return &builder.imageLayers
 }
 
 func (builder *buildInfoBuilder) getSearchableRepo() string {
@@ -127,145 +86,30 @@ func (builder *buildInfoBuilder) getSearchableRepo() string {
 	return builder.repositoryDetails.key
 }
 
-// Search, validate and create image's artifacts and dependencies.
-func (builder *buildInfoBuilder) UpdateArtifactsAndDependencies() error {
-	// Search for image's manifest and layers.
-	manifestLayers, manifestContent, err := builder.getManifestAndLayersDetails()
-	if err != nil {
-		return err
-	}
-	log.Debug("Found manifest.json. Proceeding to collect build-info.")
-	// Manifest may hold 'empty layers'. As a result, promotion will fail to promote the same layer more than once.
-	manifestContent.Layers = removeDuplicateLayers(manifestContent.Layers)
-	manifestArtifact, manifestDependency := getManifestArtifact(manifestLayers), getManifestDependency(manifestLayers)
-	configLayer, configLayerArtifact, configLayerDependency, err := builder.getConfigLayer(manifestLayers)
-	if err != nil {
-		return err
-	}
-	if builder.commandType == Push {
-		return builder.handlePush(manifestArtifact, configLayerArtifact, manifestContent, configLayer, manifestLayers)
-	}
-	return builder.handlePull(manifestDependency, configLayerDependency, manifestContent, manifestLayers)
-}
-
-// Return all the search patterns in which manifest can be found.
-func getManifestPaths(imagePath, repo string, commandType CommandType) []string {
-	// pattern 1: reverse proxy e.g. ecosysjfrog-docker-local.jfrog.io.
-	paths := []string{path.Join(repo, imagePath, "*")}
-	// pattern 2: proxy-less e.g. orgab.jfrog.team/docker-local.
-	endOfRepoNameIndex := strings.Index(imagePath[1:], "/")
-	proxylessTag := imagePath[endOfRepoNameIndex+1:]
-	paths = append(paths, path.Join(repo, proxylessTag, "*"))
-	// If image path includes more than 3 slashes, Artifactory doesn't store this image under 'library', thus we should not look further.
-	if commandType != Push && strings.Count(imagePath, "/") <= 3 {
-		// pattern 3: reverse proxy - this time with 'library' as part of the path.
-		paths = append(paths, path.Join(repo, "library", imagePath, "*"))
-		// pattern 4: Assume proxy-less - this time with 'library' as part of the path.
-		paths = append(paths, path.Join(repo, "library", proxylessTag, "*"))
-	}
-	return paths
-}
-
-// Search for image manifest and layers in Artifactory.
-func (builder *buildInfoBuilder) getManifestAndLayersDetails() (layers map[string]*utils.ResultItem, manifestContent *manifest, err error) {
-	imagePath, err := builder.image.Path()
-	if err != nil {
-		return nil, nil, err
-	}
-	manifestPathsCandidates := getManifestPaths(imagePath, builder.getSearchableRepo(), builder.commandType)
-	log.Debug("Start searching for image manifest.json")
-	for _, path := range manifestPathsCandidates {
-		log.Debug(`Searching in:"` + path + `"`)
-		layers, manifestContent, err = searchManifestAndLayersDetails(builder, path)
-		if err != nil || manifestContent != nil {
-			return layers, manifestContent, err
-		}
-	}
-	return nil, nil, errorutils.CheckErrorf(imageNotFoundErrorMessage, builder.image.tag)
-}
-
-func (builder *buildInfoBuilder) handlePull(manifestDependency, configLayerDependency buildinfo.Dependency, imageManifest *manifest, searchResults map[string]*utils.ResultItem) error {
-	// Add dependencies.
-	builder.dependencies = append(builder.dependencies, manifestDependency)
-	builder.dependencies = append(builder.dependencies, configLayerDependency)
-	// Add image layers as dependencies.
-	for i := 0; i < len(imageManifest.Layers); i++ {
-		layerFileName := digestToLayer(imageManifest.Layers[i].Digest)
-		item, layerExists := searchResults[layerFileName]
-		if !layerExists {
-			err := builder.handleMissingLayer(imageManifest.Layers[i].MediaType, layerFileName)
-			if err != nil {
-				return err
-			}
-			continue
-		}
-		builder.dependencies = append(builder.dependencies, item.ToDependency())
-	}
-	return nil
-}
-
-func (builder *buildInfoBuilder) handlePush(manifestArtifact, configLayerArtifact buildinfo.Artifact, imageManifest *manifest, configurationLayer *configLayer, searchResults map[string]*utils.ResultItem) error {
-	// Add artifacts.
-	builder.artifacts = append(builder.artifacts, manifestArtifact)
-	builder.artifacts = append(builder.artifacts, configLayerArtifact)
-	// Add layers.
-	builder.layers = append(builder.layers, *searchResults["manifest.json"])
-	builder.layers = append(builder.layers, *searchResults[digestToLayer(builder.imageId)])
-	totalLayers := len(imageManifest.Layers)
-	totalDependencies := configurationLayer.getNumberOfDependentLayers()
-	// Add image layers as artifacts and dependencies.
-	for i := 0; i < totalLayers; i++ {
-		layerFileName := digestToLayer(imageManifest.Layers[i].Digest)
-		item, layerExists := searchResults[layerFileName]
-		if !layerExists {
-			err := builder.handleMissingLayer(imageManifest.Layers[i].MediaType, layerFileName)
-			if err != nil {
-				return err
-			}
-			continue
-		}
-		// Decide if the layer is also a dependency.
-		if i < totalDependencies {
-			builder.dependencies = append(builder.dependencies, item.ToDependency())
-		}
-		builder.artifacts = append(builder.artifacts, item.ToArtifact())
-		builder.layers = append(builder.layers, *item)
-	}
-	return nil
-}
-
-func (builder *buildInfoBuilder) handleMissingLayer(layerMediaType, layerFileName string) error {
-	// Allow missing layer to be of a foreign type.
-	if layerMediaType == foreignLayerMediaType {
-		log.Info(fmt.Sprintf("Foreign layer: %s is missing in Artifactory and therefore will not be added to the build-info.", layerFileName))
-		return nil
-	}
-	return errorutils.CheckErrorf("Could not find layer: " + layerFileName + " in Artifactory")
-}
-
 // Set build properties on image layers in Artifactory.
-func (builder *buildInfoBuilder) setBuildProperties() (int, error) {
-	props, err := artutils.CreateBuildProperties(builder.buildName, builder.buildNumber, builder.project)
+func setBuildProperties(buildName, buildNumber, project string, imageLayers []utils.ResultItem, serviceManager artifactory.ArtifactoryServicesManager) error {
+	props, err := artutils.CreateBuildProperties(buildName, buildNumber, project)
 	if err != nil {
-		return 0, err
+		return err
 	}
-	pathToFile, err := writeLayersToFile(builder.layers)
+	pathToFile, err := writeLayersToFile(imageLayers)
 	if err != nil {
-		return 0, err
+		return err
 	}
 	reader := content.NewContentReader(pathToFile, content.DefaultKey)
 	defer reader.Close()
-	return builder.serviceManager.SetProps(services.PropsParams{Reader: reader, Props: props})
+	_, err = serviceManager.SetProps(services.PropsParams{Reader: reader, Props: props})
+	return err
 }
 
 // Download the content of layer search result.
-func (builder *buildInfoBuilder) downloadLayer(searchResult utils.ResultItem, result interface{}) error {
+func downloadLayer(searchResult utils.ResultItem, result interface{}, serviceManager artifactory.ArtifactoryServicesManager, repo string) error {
 	// Search results may include artifacts from the remote-cache repository.
 	// When artifact is expired, it cannot be downloaded from the remote-cache.
 	// To solve this, change back the search results' repository, to its origin remote/virtual.
-	searchResult.Repo = builder.repositoryDetails.key
+	searchResult.Repo = repo
 	path := searchResult.GetItemRelativePath()
-	return artutils.RemoteUnmarshal(builder.serviceManager, path, result)
+	return artutils.RemoteUnmarshal(serviceManager, path, result)
 }
 
 func writeLayersToFile(layers []utils.ResultItem) (filePath string, err error) {
@@ -283,145 +127,35 @@ func writeLayersToFile(layers []utils.ResultItem) (filePath string, err error) {
 	return
 }
 
-// Create a docker build info.
-func (builder *buildInfoBuilder) createBuildInfo(module string) (*buildinfo.BuildInfo, error) {
-	imageProperties := map[string]string{}
-	imageProperties["docker.image.id"] = builder.imageId
-	imageProperties["docker.image.tag"] = builder.image.Tag()
-	if module == "" {
-		imageName, err := builder.image.Name()
-		if err != nil {
-			return nil, err
-		}
-		module = imageName
-	}
-	buildInfo := &buildinfo.BuildInfo{Modules: []buildinfo.Module{{
-		Id:           module,
-		Type:         buildinfo.Docker,
-		Properties:   imageProperties,
-		Artifacts:    builder.artifacts,
-		Dependencies: builder.dependencies,
-	}}}
-	return buildInfo, nil
-}
-
 // Return - manifest artifacts as buildinfo.Artifact struct.
-func getManifestArtifact(searchResults map[string]*utils.ResultItem) (artifact buildinfo.Artifact) {
-	item := searchResults["manifest.json"]
-	return buildinfo.Artifact{Name: "manifest.json", Type: "json", Checksum: &buildinfo.Checksum{Sha1: item.Actual_Sha1, Md5: item.Actual_Md5}, Path: path.Join(item.Repo, item.Path, item.Name)}
+func getManifestArtifact(manifest *utils.ResultItem) (artifact buildinfo.Artifact) {
+	return buildinfo.Artifact{Name: "manifest.json", Type: "json", Checksum: &buildinfo.Checksum{Sha1: manifest.Actual_Sha1, Md5: manifest.Actual_Md5}, Path: path.Join(manifest.Path, manifest.Name)}
+}
+// Return - fat manifest artifacts as buildinfo.Artifact struct.
+func getFatManifestArtifact(fatManifest *utils.ResultItem) (artifact buildinfo.Artifact) {
+	return buildinfo.Artifact{Name: "list.manifest.json", Type: "json", Checksum: &buildinfo.Checksum{Sha1: fatManifest.Actual_Sha1, Md5: fatManifest.Actual_Md5}, Path: path.Join(fatManifest.Path, fatManifest.Name)}
 }
 
 // Return - manifest dependency as buildinfo.Dependency struct.
-func getManifestDependency(searchResults map[string]*utils.ResultItem) (dependency buildinfo.Dependency) {
-	item := searchResults["manifest.json"]
-	return buildinfo.Dependency{Id: "manifest.json", Type: "json", Checksum: &buildinfo.Checksum{Sha1: item.Actual_Sha1, Md5: item.Actual_Md5}}
-}
-
-// Download and read the config layer from Artifactory.
-// Returned values:
-// configurationLayer - pointer to the configuration layer struct, retrieved from Artifactory.
-// artifact - configuration layer as buildinfo.Artifact struct.
-// dependency - configuration layer as buildinfo.Dependency struct.
-func (builder *buildInfoBuilder) getConfigLayer(searchResults map[string]*utils.ResultItem) (configurationLayer *configLayer, artifact buildinfo.Artifact, dependency buildinfo.Dependency, err error) {
-	item := searchResults[digestToLayer(builder.imageId)]
-	configurationLayer = new(configLayer)
-	if err := builder.downloadLayer(*item, &configurationLayer); err != nil {
-		return nil, buildinfo.Artifact{}, buildinfo.Dependency{}, err
-	}
-	artifact = buildinfo.Artifact{Name: digestToLayer(builder.imageId), Checksum: &buildinfo.Checksum{Sha1: item.Actual_Sha1, Md5: item.Actual_Md5}, Path: path.Join(item.Repo, item.Path, item.Name)}
-	dependency = buildinfo.Dependency{Id: digestToLayer(builder.imageId), Checksum: &buildinfo.Checksum{Sha1: item.Actual_Sha1, Md5: item.Actual_Md5}}
-	return
-}
-
-// Search for manifest in Artifactory, If not found, returns 'manifestContent' as nil.
-func searchManifestAndLayersDetails(builder *buildInfoBuilder, imagePathPattern string) (resultMap map[string]*utils.ResultItem, manifestContent *manifest, err error) {
-	resultMap, err = searchHandler(imagePathPattern, builder)
-	if err != nil || len(resultMap) == 0 {
-		log.Debug("Couldn't find manifest.json. Image path pattern: ", imagePathPattern, ".")
-		return
-	}
-	// Check if search results contain manifest.json
-	searchResult, ok := resultMap["manifest.json"]
-	if ok {
-		// Found a manifest. Verify manifest is the same as the builder image.
-		if builder.containerManager == nil {
-			manifestContent, err = verifyManifestBySha256(*searchResult, builder)
-		} else {
-			manifestContent, err = verifyManifestByDigest(*searchResult, builder)
-		}
-	} else {
-		if builder.containerManager == nil {
-			err = errorutils.CheckErrorf("build info collection for multi-architecture images is not supported in build-docker-create and oc start-build commands")
-			return
-		}
-		// Check if search results contain multi-architecture images (fat-manifest).
-		if searchResult, ok := resultMap["list.manifest.json"]; ok {
-			// In case of a fat-manifest, Artifactory will create two folders.
-			// One folder named as the image tag, which contains the fat manifest.
-			// The second folder, named as image's manifest digest, contains the image layers and the image's manifest.
-			log.Debug("Found list.manifest.json (fat-manifest). Searching for the image manifest digest in list.manifest.json")
-			var digest string
-			digest, err = getImageDigestFromFatManifest(*searchResult, builder)
-			if err == nil && digest != "" {
-				// Remove tag from pattern, place the manifest digest instead.
-				imagePathPattern = strings.Replace(imagePathPattern, "/*", "", 1)
-				imagePathPattern = path.Join(imagePathPattern[:strings.LastIndex(imagePathPattern, "/")], strings.Replace(digest, ":", "__", 1), "*")
-				// Retry search.
-				return searchManifestAndLayersDetails(builder, imagePathPattern)
-			}
-			log.Debug("Couldn't find matching digest in list.manifest.json")
-		}
-	}
-	return
-}
-
-func getImageDigestFromFatManifest(fatManifest utils.ResultItem, builder *buildInfoBuilder) (string, error) {
-	var fatManifestContent *FatManifest
-	if err := builder.downloadLayer(fatManifest, &fatManifestContent); err != nil {
-		log.Debug(`failed to unmarshal fat-manifest`)
-		return "", err
-	}
-	imageOs, imageArch, err := builder.containerManager.OsCompatibility(builder.image)
-	if err != nil {
-		return "", err
-	}
-	return searchManifestDigest(imageOs, imageArch, fatManifestContent.Manifests), nil
-}
-
-// Verify manifest contains the builder image digest. If there is no match, return nil.
-func verifyManifestBySha256(manifestSearchResult utils.ResultItem, builder *buildInfoBuilder) (imageManifest *manifest, err error) {
-	if manifestSearchResult.GetProperty("docker.manifest.digest") != builder.manifestSha256 {
-		log.Debug(`Found incorrect manifest.json file. Expects sha256 "` + builder.manifestSha256 + `" found "` + manifestSearchResult.GetProperty("sha256"))
-		return
-	}
-	log.Debug(`Found manifest.json with expected sha256: "` + builder.manifestSha256)
-	if err = builder.downloadLayer(manifestSearchResult, &imageManifest); err != nil || imageManifest == nil {
-		return
-	}
-	builder.imageId = imageManifest.Config.Digest
-	return
-}
-
-// Verify manifest by comparing config digest, which references to the image digest. If there is no match, return nil.
-func verifyManifestByDigest(manifestSearchResult utils.ResultItem, builder *buildInfoBuilder) (imageManifest *manifest, err error) {
-	if err = builder.downloadLayer(manifestSearchResult, &imageManifest); err != nil {
-		return
-	}
-	if imageManifest.Config.Digest != builder.imageId {
-		log.Debug(`Found incorrect manifest.json file. Expects digest "` + builder.imageId + `" found "` + imageManifest.Config.Digest)
-		imageManifest = nil
-	}
-	return
+func getManifestDependency(searchResults *utils.ResultItem) (dependency buildinfo.Dependency) {
+	return buildinfo.Dependency{Id: "manifest.json", Type: "json", Checksum: &buildinfo.Checksum{Sha1: searchResults.Actual_Sha1, Md5: searchResults.Actual_Md5}}
 }
 
 // Read the file which contains the following format: 'IMAGE-TAG-IN-ARTIFACTORY'@sha256'SHA256-OF-THE-IMAGE-MANIFEST'.
 func GetImageTagWithDigest(filePath string) (tag string, sha256 string, err error) {
+	var buildxMetaData buildxMetaData
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		log.Debug("ioutil.ReadFile failed with '%s'\n", err)
 		err = errorutils.CheckError(err)
 		return
 	}
+	json.Unmarshal(data, &buildxMetaData)
+	// Try to read buildx metadata file.
+	if buildxMetaData.ImageName != "" && buildxMetaData.ImageSha256 != "" {
+		return buildxMetaData.ImageName, buildxMetaData.ImageSha256, nil
+	}
+	// Try read Kaniko/oc file.
 	splittedData := strings.Split(string(data), `@`)
 	if len(splittedData) != 2 {
 		err = errorutils.CheckErrorf(`unexpected file format "` + filePath + `". The file should include one line in the following format: image-tag@sha256`)
@@ -432,6 +166,11 @@ func GetImageTagWithDigest(filePath string) (tag string, sha256 string, err erro
 		err = errorutils.CheckErrorf(`missing image-tag/sha256 in file: "` + filePath + `"`)
 	}
 	return
+}
+
+type buildxMetaData struct {
+	ImageName   string `json:"image.name"`
+	ImageSha256 string `json:"containerimage.digest"`
 }
 
 // Search for manifest digest in fat manifest, which contains specific platforms.
@@ -445,25 +184,13 @@ func searchManifestDigest(imageOs, imageArch string, manifestList []ManifestDeta
 	return
 }
 
-func searchHandler(imagePathPattern string, builder *buildInfoBuilder) (resultMap map[string]*utils.ResultItem, err error) {
-	resultMap, err = performSearch(imagePathPattern, builder.serviceManager)
-	if err != nil {
-		return
-	}
-	// Validate there are no .marker layers.
-	if totalDownloaded, err := downloadMarkerLayersToRemoteCache(resultMap, builder); err != nil || totalDownloaded == 0 {
-		return resultMap, err
-	}
-	log.Debug("Marker layers were found, updating search results.")
-	return performSearch(imagePathPattern, builder.serviceManager)
-}
-
 // return a map of: layer-digest -> layer-search-result
 func performSearch(imagePathPattern string, serviceManager artifactory.ArtifactoryServicesManager) (resultMap map[string]*utils.ResultItem, err error) {
 	searchParams := services.NewSearchParams()
 	searchParams.CommonParams = &utils.CommonParams{}
 	searchParams.Pattern = imagePathPattern
-	reader, err := serviceManager.SearchFiles(searchParams)
+	var reader *content.ContentReader
+	reader, err = serviceManager.SearchFiles(searchParams)
 	if err != nil {
 		return nil, err
 	}
@@ -472,11 +199,44 @@ func performSearch(imagePathPattern string, serviceManager artifactory.Artifacto
 			err = deferErr
 		}
 	}()
-	resultMap = map[string]*utils.ResultItem{}
+	resultMap = make(map[string]*utils.ResultItem)
 	for resultItem := new(utils.ResultItem); reader.NextRecord(resultItem) == nil; resultItem = new(utils.ResultItem) {
 		resultMap[resultItem.Name] = resultItem
 	}
-	return resultMap, reader.GetError()
+	err = reader.GetError()
+	return
+}
+
+// return a map of: image-sha2 -> image-layers
+func performMultiPlatformImageSearch(imagePathPattern string, serviceManager artifactory.ArtifactoryServicesManager) (resultMap map[string][]*utils.ResultItem, err error) {
+	searchParams := services.NewSearchParams()
+	searchParams.CommonParams = &utils.CommonParams{}
+	searchParams.Pattern = imagePathPattern
+	searchParams.Recursive = true
+	var reader *content.ContentReader
+	reader, err = serviceManager.SearchFiles(searchParams)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if deferErr := reader.Close(); err == nil {
+			err = deferErr
+		}
+	}()
+	pathToSha2 := make(map[string]string)
+	pathToImageLayers := make(map[string][]*utils.ResultItem)
+	resultMap = make(map[string][]*utils.ResultItem)
+	for resultItem := new(utils.ResultItem); reader.NextRecord(resultItem) == nil; resultItem = new(utils.ResultItem) {
+		pathToImageLayers[resultItem.Path] = append(pathToImageLayers[resultItem.Path], resultItem)
+		if resultItem.Name == "manifest.json" {
+			pathToSha2[resultItem.Path] = "sha256:" + resultItem.Sha256
+		}
+	}
+	for k, v := range pathToSha2 {
+		resultMap[v] = append(resultMap[v], pathToImageLayers[k]...)
+	}
+	err = reader.GetError()
+	return
 }
 
 // Digest of type sha256:30daa5c11544632449b01f450bebfef6b89644e9e683258ed05797abe7c32a6e to
@@ -517,73 +277,154 @@ func removeDuplicateLayers(imageMLayers []layer) []layer {
 	return res
 }
 
-// When a client tries to pull an image from a remote repository in Artifactory and the client has some the layers cached locally on the disk,
-// then Artifactory will not download these layers into the remote repository cache. Instead, it will mark the layer artifacts with .marker suffix files in the remote cache.
-// This function download all the marker layers into the remote cache repository.
-func downloadMarkerLayersToRemoteCache(resultMap map[string]*utils.ResultItem, builder *buildInfoBuilder) (int, error) {
-	if !builder.repositoryDetails.isRemote || len(resultMap) == 0 {
-		return 0, nil
-	}
-	totalDownloaded := 0
-	remoteRepo := builder.repositoryDetails.key
-	imageName := getImageName(builder.image.Tag())
-	clientDetails := builder.serviceManager.GetConfig().GetServiceDetails().CreateHttpClientDetails()
-	// Search for marker layers
-	for _, layerData := range resultMap {
-		if strings.HasSuffix(layerData.Name, markerLayerSuffix) {
-			log.Debug(fmt.Sprintf("Downloading %s layer into remote repository cache...", layerData.Name))
-			baseUrl := builder.serviceManager.GetConfig().GetServiceDetails().GetUrl()
-			endpoint := "api/docker/" + remoteRepo + "/v2/" + imageName + "/blobs/" + toNoneMarkerLayer(layerData.Name)
-			resp, body, err := builder.serviceManager.Client().SendHead(baseUrl+endpoint, &clientDetails)
-			if err != nil {
-				return totalDownloaded, err
-			}
-			if resp.StatusCode != http.StatusOK {
-				return totalDownloaded, errorutils.CheckErrorf("Artifactory response: " + resp.Status + "for" + string(body))
-			}
-			totalDownloaded++
-		}
-	}
-	return totalDownloaded, nil
-}
-
-func getImageName(image string) string {
-	imageId, tag := strings.LastIndex(image, "/"), strings.LastIndex(image, ":")
-	if imageId == -1 || tag == -1 {
-		return ""
-	}
-	return image[imageId+1 : tag]
-}
-
 func toNoneMarkerLayer(layer string) string {
 	imageId := strings.Replace(layer, "__", ":", 1)
 	return strings.Replace(imageId, ".marker", "", 1)
 }
 
-// To unmarshal config layer file
-type configLayer struct {
-	History []history `json:"history,omitempty"`
-}
-
-type history struct {
-	Created    string `json:"created,omitempty"`
-	CreatedBy  string `json:"created_by,omitempty"`
-	EmptyLayer bool   `json:"empty_layer,omitempty"`
-}
-
-// To unmarshal manifest.json file
-type manifest struct {
-	Config manifestConfig `json:"config,omitempty"`
-	Layers []layer        `json:"layers,omitempty"`
-}
-
-type manifestConfig struct {
-	Digest string `json:"digest,omitempty"`
-}
-
-type layer struct {
-	Digest    string `json:"digest,omitempty"`
-	MediaType string `json:"mediaType,omitempty"`
-}
-
 type CommandType string
+
+// Create a image's build info from manifest.json.
+func (builder *buildInfoBuilder) createBuildInfo(commandType CommandType, manifest *manifest, candidateLayers map[string]*utils.ResultItem, module string) (*buildinfo.BuildInfo, error) {
+	imageProperties := map[string]string{
+		"docker.image.id":  builder.imageSha2,
+		"docker.image.tag": builder.image.Name(),
+	}
+	if module == "" {
+		imageName, err := builder.image.GetImageBaseNameWithTag()
+		if err != nil {
+			return nil, err
+		}
+		module = imageName
+	}
+	// Manifest may hold 'empty layers'. As a result, promotion will fail to promote the same layer more than once.
+	manifest.Layers = removeDuplicateLayers(manifest.Layers)
+	var artifacts []buildinfo.Artifact
+	var dependencies []buildinfo.Dependency
+	var err error
+	switch commandType {
+	case Pull:
+		dependencies, err = builder.createPullBuildProperties(manifest, candidateLayers)
+	case Push:
+		artifacts, dependencies, builder.imageLayers, err = builder.createPushBuildProperties(manifest, candidateLayers)
+		if err != nil {
+			return nil, err
+		}
+		if !builder.dryRun {
+			if err := setBuildProperties(builder.buildName, builder.buildNumber, builder.project, builder.imageLayers, builder.serviceManager); err != nil {
+				return nil, err
+			}
+		}
+	}
+	buildInfo := &buildinfo.BuildInfo{Modules: []buildinfo.Module{{
+		Id:           module,
+		Type:         buildinfo.Docker,
+		Properties:   imageProperties,
+		Artifacts:    artifacts,
+		Dependencies: dependencies,
+	}}}
+	return buildInfo, nil
+}
+
+// Create a image's build info from list.manifest.json.
+func (builder *buildInfoBuilder) createMultiPlatformBuildInfo(fatManifest *FatManifest, searchRultFatManifest *utils.ResultItem, candidateimages map[string][]*utils.ResultItem, module string) (*buildinfo.BuildInfo, error) {
+	imageProperties := map[string]string{
+		"docker.image.tag": builder.image.Name(),
+	}
+	if module == "" {
+		imageName, err := builder.image.GetImageBaseNameWithTag()
+		if err != nil {
+			return nil, err
+		}
+		module = imageName
+	}
+	// Add layers.
+	builder.imageLayers = append(builder.imageLayers, *searchRultFatManifest)
+	// create fat-manifest module
+	buildInfo := &buildinfo.BuildInfo{Modules: []buildinfo.Module{{
+		Id:         module,
+		Type:       buildinfo.Docker,
+		Properties: imageProperties,
+		Artifacts:  []buildinfo.Artifact{getFatManifestArtifact(searchRultFatManifest)},
+	}}}
+	// Create all image arch modules
+	for _, manifest := range fatManifest.Manifests {
+		image := candidateimages[manifest.Digest]
+		var artifacts []buildinfo.Artifact
+		for _, layer := range image {
+			builder.imageLayers = append(builder.imageLayers, *layer)
+			if layer.Name == "manifest.json" {
+				artifacts = append(artifacts, getManifestArtifact(layer))
+			} else {
+				artifacts = append(artifacts, layer.ToArtifact())
+			}
+		}
+		buildInfo.Modules = append(buildInfo.Modules, buildinfo.Module{
+			Id:        manifest.Platform.Os + "/" + manifest.Platform.Architecture + "/" + module,
+			Type:      buildinfo.Docker,
+			Artifacts: artifacts,
+		})
+	}
+	return buildInfo, setBuildProperties(builder.buildName, builder.buildNumber, builder.project, builder.imageLayers, builder.serviceManager)
+}
+
+func (builder *buildInfoBuilder) createPushBuildProperties(imageManifest *manifest, candidateLayers map[string]*utils.ResultItem) (artifacts []buildinfo.Artifact, dependencies []buildinfo.Dependency, imageLayers []utils.ResultItem, err error) {
+	// Add artifacts.
+	artifacts = append(artifacts, getManifestArtifact(candidateLayers["manifest.json"]))
+	artifacts = append(artifacts, candidateLayers[digestToLayer(builder.imageSha2)].ToArtifact())
+	// Add layers.
+	imageLayers = append(imageLayers, *candidateLayers["manifest.json"])
+	imageLayers = append(imageLayers, *candidateLayers[digestToLayer(builder.imageSha2)])
+
+	totalLayers := len(imageManifest.Layers)
+	totalDependencies, err := builder.totalDependencies(candidateLayers[digestToLayer(builder.imageSha2)])
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	// Add image layers as artifacts and dependencies.
+	for i := 0; i < totalLayers; i++ {
+		layerFileName := digestToLayer(imageManifest.Layers[i].Digest)
+		item, layerExists := candidateLayers[layerFileName]
+		if !layerExists {
+			err := handleMissingLayer(imageManifest.Layers[i].MediaType, layerFileName)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			continue
+		}
+		// Decide if the layer is also a dependency.
+		if i < totalDependencies {
+			dependencies = append(dependencies, item.ToDependency())
+		}
+		artifacts = append(artifacts, item.ToArtifact())
+		imageLayers = append(imageLayers, *item)
+	}
+	return
+}
+
+func (builder *buildInfoBuilder) createPullBuildProperties(imageManifest *manifest, candidateLayers map[string]*utils.ResultItem) (dependencies []buildinfo.Dependency, err error) {
+	// Add dependencies.
+	dependencies = append(dependencies, getManifestDependency(candidateLayers["manifest.json"]))
+	dependencies = append(dependencies, candidateLayers[digestToLayer(builder.imageSha2)].ToDependency())
+	// Add image layers as dependencies.
+	for i := 0; i < len(imageManifest.Layers); i++ {
+		layerFileName := digestToLayer(imageManifest.Layers[i].Digest)
+		item, layerExists := candidateLayers[layerFileName]
+		if !layerExists {
+			if err := handleMissingLayer(imageManifest.Layers[i].MediaType, layerFileName); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		dependencies = append(dependencies, item.ToDependency())
+	}
+	return
+}
+
+func (builder *buildInfoBuilder) totalDependencies(image *utils.ResultItem) (int, error) {
+	configurationLayer := new(configLayer)
+	if err := downloadLayer(*image, &configurationLayer, builder.serviceManager, builder.repositoryDetails.key); err != nil {
+		return 0, err
+	}
+	return configurationLayer.getNumberOfDependentLayers(), nil
+}

--- a/artifactory/utils/container/image.go
+++ b/artifactory/utils/container/image.go
@@ -9,45 +9,56 @@ import (
 )
 
 type Image struct {
-	tag string
+	// Image name includes the registry domain and image name and image tag.
+	name string
 }
 
-// Get image tag
-func (image *Image) Tag() string {
-	return image.tag
+// Get image name
+func (image *Image) Name() string {
+	return image.name
 }
 
 // Get image relative path in Artifactory.
-func (image *Image) Path() (string, error) {
+func (image *Image) GetPath() (string, error) {
 	if err := image.validateTag(); err != nil {
 		return "", err
 	}
-	indexOfFirstSlash := strings.Index(image.tag, "/")
-	indexOfLastColon := strings.LastIndex(image.tag, ":")
+	indexOfFirstSlash := strings.Index(image.name, "/")
+	indexOfLastColon := strings.LastIndex(image.name, ":")
 	if indexOfLastColon < 0 || indexOfLastColon < indexOfFirstSlash {
-		log.Info("The image '" + image.tag + "' does not include tag. Using the 'latest' tag.")
-		return path.Join(image.tag[indexOfFirstSlash:], "latest"), nil
+		log.Info("The image '" + image.name + "' does not include tag. Using the 'latest' tag.")
+		return path.Join(image.name[indexOfFirstSlash:], "latest"), nil
 	}
-	return path.Join(image.tag[indexOfFirstSlash:indexOfLastColon], image.tag[indexOfLastColon+1:]), nil
+	return path.Join(image.name[indexOfFirstSlash:indexOfLastColon], image.name[indexOfLastColon+1:]), nil
 }
 
-// Get image name.
-func (image *Image) Name() (string, error) {
+// Get image name from tag by removing the prefixed registry hostname.
+func (image *Image) GetImageBaseNameWithTag() (string, error) {
 	if err := image.validateTag(); err != nil {
 		return "", err
 	}
-	indexOfLastSlash := strings.LastIndex(image.tag, "/")
-	indexOfLastColon := strings.LastIndex(image.tag, ":")
+	indexOfLastSlash := strings.LastIndex(image.name, "/")
+	indexOfLastColon := strings.LastIndex(image.name, ":")
 	if indexOfLastColon < 0 || indexOfLastColon < indexOfLastSlash {
-		log.Info("The image '" + image.tag + "' does not include tag. Using the 'latest' tag.")
-		return image.tag[indexOfLastSlash+1:] + ":latest", nil
+		log.Info("The image '" + image.name + "' does not include tag. Using the 'latest' tag.")
+		return image.name[indexOfLastSlash+1:] + ":latest", nil
 	}
-	return image.tag[indexOfLastSlash+1:], nil
+	return image.name[indexOfLastSlash+1:], nil
 }
 
 func (image *Image) validateTag() error {
-	if !strings.Contains(image.tag, "/") {
-		return errorutils.CheckErrorf("The image '%s' is missing '/' which indicates the image name/tag", image.tag)
+	if !strings.Contains(image.name, "/") {
+		return errorutils.CheckErrorf("The image '%s' is missing '/' which indicates the image name/tag", image.name)
 	}
 	return nil
+}
+
+func (image *Image) GetImageBaseName() (string, error) {
+	imageName, err := image.GetImageBaseNameWithTag()
+	if err != nil {
+		return "", err
+	}
+	tagIndex := strings.LastIndex(imageName, ":")
+
+	return imageName[:tagIndex], nil
 }

--- a/artifactory/utils/container/image.go
+++ b/artifactory/utils/container/image.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Image struct {
-	// Image name includes the registry domain and image name and image tag.
+	// Image name includes the registry domain, image base name and image tag e.g.: https://my-registry/docker-local/hello-world:latest.
 	name string
 }
 
@@ -53,6 +53,8 @@ func (image *Image) validateTag() error {
 	return nil
 }
 
+// Get image base name by removing the prefixed registry hostname and the tag.
+// e.g.: https://my-registry/docker-local/hello-world:latest. -> hello-world
 func (image *Image) GetImageBaseName() (string, error) {
 	imageName, err := image.GetImageBaseNameWithTag()
 	if err != nil {

--- a/artifactory/utils/container/image_test.go
+++ b/artifactory/utils/container/image_test.go
@@ -20,19 +20,19 @@ func TestGetImagePath(t *testing.T) {
 	}
 
 	for _, v := range imageTags {
-		result, err := NewImage(v.in).Path()
+		result, err := NewImage(v.in).GetPath()
 		assert.NoError(t, err)
 		if result != v.expected {
 			t.Errorf("Path(\"%s\") => '%s', want '%s'", v.in, result, v.expected)
 		}
 	}
 	// Validate failure upon missing image name
-	_, err := NewImage("domain").Path()
+	_, err := NewImage("domain").GetPath()
 	assert.Error(t, err)
 
 }
 
-func TestGetImageName(t *testing.T) {
+func TestGetImageBaseNameWithTag(t *testing.T) {
 	var imageTags = []struct {
 		in       string
 		expected string
@@ -46,14 +46,14 @@ func TestGetImageName(t *testing.T) {
 	}
 
 	for _, v := range imageTags {
-		result, err := NewImage(v.in).Name()
+		result, err := NewImage(v.in).GetImageBaseNameWithTag()
 		assert.NoError(t, err)
 		if result != v.expected {
 			t.Errorf("Name(\"%s\") => '%s', want '%s'", v.in, result, v.expected)
 		}
 	}
 	// Validate failure upon missing image name
-	_, err := NewImage("domain").Name()
+	_, err := NewImage("domain").GetImageBaseNameWithTag()
 	assert.Error(t, err)
 }
 

--- a/artifactory/utils/container/localagent.go
+++ b/artifactory/utils/container/localagent.go
@@ -1,0 +1,186 @@
+package container
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+
+	buildinfo "github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+type localAgentbuildInfoBuilder struct {
+	buildInfoBuilder *buildInfoBuilder
+	// Name of the container CLI tool e.g. docker
+	containerManager ContainerManager
+	commandType      CommandType
+}
+
+// Create new build info builder container CLI tool
+func NewLocalAgentBuildInfoBuilder(image *Image, repository, buildName, buildNumber, project string, serviceManager artifactory.ArtifactoryServicesManager, commandType CommandType, containerManager ContainerManager) (*localAgentbuildInfoBuilder, error) {
+	imageSha2, err := containerManager.Id(image)
+	if err != nil {
+		return nil, err
+	}
+	builder, err := newBuildInfoBuilder(image, repository, buildName, buildNumber, project, serviceManager)
+	if err != nil {
+		return nil, err
+	}
+	builder.setImageSha2(imageSha2)
+	return &localAgentbuildInfoBuilder{
+		buildInfoBuilder: builder,
+		containerManager: containerManager,
+		commandType:      commandType,
+	}, err
+}
+
+func (labib *localAgentbuildInfoBuilder) GetLayers() *[]utils.ResultItem {
+	return &labib.buildInfoBuilder.imageLayers
+}
+
+func (labib *localAgentbuildInfoBuilder) SetDryRun(dryRun bool) {
+	labib.buildInfoBuilder.dryRun = dryRun
+}
+
+// Create build-info for a docker image.
+func (labib *localAgentbuildInfoBuilder) Build(module string) (*buildinfo.BuildInfo, error) {
+	// Search for image build-info.
+	candidateLayers, manifest, err := labib.searchImage()
+	if err != nil {
+		log.Warn(`Failed to collect build-info, couldn't find image "` + labib.buildInfoBuilder.image.name + `" in Artifactory`)
+	} else {
+		log.Debug("Found manifest.json. Proceeding to create build-info.")
+	}
+	// Create build-info from search results.
+	return labib.buildInfoBuilder.createBuildInfo(labib.commandType, manifest, candidateLayers, module)
+}
+
+// Search an image in Artifactory and validate its sha2 with local image.
+func (labib *localAgentbuildInfoBuilder) searchImage() (map[string]*utils.ResultItem, *manifest, error) {
+	imagePath, err := labib.buildInfoBuilder.image.GetPath()
+	if err != nil {
+		return nil, nil, err
+	}
+	manifestPathsCandidates := getManifestPaths(imagePath, labib.buildInfoBuilder.getSearchableRepo(), labib.commandType)
+	log.Debug("Start searching for image manifest.json")
+	for _, path := range manifestPathsCandidates {
+		log.Debug(`Searching in:"` + path + `"`)
+		resultMap, err := labib.search(path)
+		if err != nil {
+			return nil, nil, err
+		}
+		manifest, err := getManifest(resultMap, labib.buildInfoBuilder.serviceManager, labib.buildInfoBuilder.repositoryDetails.key)
+		if err != nil {
+			return nil, nil, err
+		}
+		if manifest != nil && labib.isVerifiedManifest(manifest) {
+			return resultMap, manifest, nil
+		}
+	}
+	return nil, nil, errorutils.CheckErrorf(imageNotFoundErrorMessage, labib.buildInfoBuilder.image.name)
+}
+
+func (labib *localAgentbuildInfoBuilder) search(imagePathPattern string) (resultMap map[string]*utils.ResultItem, err error) {
+	resultMap, err = performSearch(imagePathPattern, labib.buildInfoBuilder.serviceManager)
+	if err != nil {
+		return
+	}
+
+	// Validate there are no .marker layers.
+	totalDownloaded, err := downloadMarkerLayersToRemoteCache(resultMap, labib.buildInfoBuilder)
+	if err != nil {
+		return nil, err
+	}
+	if totalDownloaded > 0 {
+		// Search again after .marker layer were downloaded.
+		if resultMap, err = performSearch(imagePathPattern, labib.buildInfoBuilder.serviceManager); err != nil {
+			return
+		}
+	}
+	// Check if search results contain multi-architecture images (fat-manifest).
+	if searchResult, ok := resultMap["list.manifest.json"]; labib.commandType == Pull && ok {
+		// In case of a fat-manifest, Artifactory will create two folders.
+		// One folder named as the image tag, which contains the fat manifest.
+		// The second folder, named as image's manifest digest, contains the image layers and the image's manifest.
+		log.Debug("Found list.manifest.json (fat-manifest). Searching for the image manifest digest in list.manifest.json")
+		var digest string
+		digest, err = labib.getImageDigestFromFatManifest(*searchResult)
+		if err == nil && digest != "" {
+			// Remove tag from pattern, place the manifest digest instead.
+			imagePathPattern = strings.Replace(imagePathPattern, "/*", "", 1)
+			imagePathPattern = path.Join(imagePathPattern[:strings.LastIndex(imagePathPattern, "/")], strings.Replace(digest, ":", "__", 1), "*")
+			// Retry search.
+			return labib.search(imagePathPattern)
+		}
+		log.Debug("Couldn't find matching digest in list.manifest.json")
+	}
+	return resultMap, err
+}
+
+// Verify manifest by comparing sha256, which references to the image digest. If there is no match, return nil.
+func (labib *localAgentbuildInfoBuilder) isVerifiedManifest(imageManifest *manifest) bool {
+	if imageManifest.Config.Digest != labib.buildInfoBuilder.imageSha2 {
+		log.Debug(`Found incorrect manifest.json file. Expects digest "` + labib.buildInfoBuilder.imageSha2 + `" found "` + imageManifest.Config.Digest)
+		return false
+	}
+	return true
+}
+
+func (labib *localAgentbuildInfoBuilder) getImageDigestFromFatManifest(fatManifest utils.ResultItem) (string, error) {
+	var fatManifestContent *FatManifest
+	if err := downloadLayer(fatManifest, &fatManifestContent, labib.buildInfoBuilder.serviceManager, labib.buildInfoBuilder.repositoryDetails.key); err != nil {
+		log.Debug(`failed to unmarshal fat-manifest`)
+		return "", err
+	}
+	imageOs, imageArch, err := labib.containerManager.OsCompatibility(labib.buildInfoBuilder.image)
+	if err != nil {
+		return "", err
+	}
+	return searchManifestDigest(imageOs, imageArch, fatManifestContent.Manifests), nil
+}
+
+// When a client tries to pull an image from a remote repository in Artifactory and the client has some the layers cached locally on the disk,
+// then Artifactory will not download these layers into the remote repository cache. Instead, it will mark the layer artifacts with .marker suffix files in the remote cache.
+// This function download all the marker layers into the remote cache repository.
+func downloadMarkerLayersToRemoteCache(resultMap map[string]*utils.ResultItem, builder *buildInfoBuilder) (int, error) {
+	if !builder.repositoryDetails.isRemote || len(resultMap) == 0 {
+		return 0, nil
+	}
+	totalDownloaded := 0
+	remoteRepo := builder.repositoryDetails.key
+	imageName, err := builder.image.GetImageBaseName()
+	if err != nil {
+		return 0, err
+	}
+	clientDetails := builder.serviceManager.GetConfig().GetServiceDetails().CreateHttpClientDetails()
+	// Search for marker layers
+	for _, layerData := range resultMap {
+		if strings.HasSuffix(layerData.Name, markerLayerSuffix) {
+			log.Debug(fmt.Sprintf("Downloading %s layer into remote repository cache...", layerData.Name))
+			baseUrl := builder.serviceManager.GetConfig().GetServiceDetails().GetUrl()
+			endpoint := "api/docker/" + remoteRepo + "/v2/" + imageName + "/blobs/" + toNoneMarkerLayer(layerData.Name)
+			resp, body, err := builder.serviceManager.Client().SendHead(baseUrl+endpoint, &clientDetails)
+			if err != nil {
+				return totalDownloaded, err
+			}
+			if resp.StatusCode != http.StatusOK {
+				return totalDownloaded, errorutils.CheckErrorf("Artifactory response: " + resp.Status + "for" + string(body))
+			}
+			totalDownloaded++
+		}
+	}
+	return totalDownloaded, nil
+}
+
+func handleMissingLayer(layerMediaType, layerFileName string) error {
+	// Allow missing layer to be of a foreign type.
+	if layerMediaType == foreignLayerMediaType {
+		log.Info(fmt.Sprintf("Foreign layer: %s is missing in Artifactory and therefore will not be added to the build-info.", layerFileName))
+		return nil
+	}
+	return errorutils.CheckErrorf("Could not find layer: " + layerFileName + " in Artifactory")
+}

--- a/artifactory/utils/container/localagent.go
+++ b/artifactory/utils/container/localagent.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
+// Build-info builder for local agents tools such as: Docker or Podman.
 type localAgentbuildInfoBuilder struct {
 	buildInfoBuilder *buildInfoBuilder
 	// Name of the container CLI tool e.g. docker
@@ -42,8 +43,8 @@ func (labib *localAgentbuildInfoBuilder) GetLayers() *[]utils.ResultItem {
 	return &labib.buildInfoBuilder.imageLayers
 }
 
-func (labib *localAgentbuildInfoBuilder) SetDryRun(dryRun bool) {
-	labib.buildInfoBuilder.dryRun = dryRun
+func (labib *localAgentbuildInfoBuilder) SetSkipTaggingLayers(skipTaggingLayers bool) {
+	labib.buildInfoBuilder.skipTaggingLayers = skipTaggingLayers
 }
 
 // Create build-info for a docker image.
@@ -84,12 +85,13 @@ func (labib *localAgentbuildInfoBuilder) searchImage() (map[string]*utils.Result
 	return nil, nil, errorutils.CheckErrorf(imageNotFoundErrorMessage, labib.buildInfoBuilder.image.name)
 }
 
+// Search image layers in artifactory by the provided image path in artifactory.
+// If fat-manifest is found, use it to find our image in Artifactory.
 func (labib *localAgentbuildInfoBuilder) search(imagePathPattern string) (resultMap map[string]*utils.ResultItem, err error) {
 	resultMap, err = performSearch(imagePathPattern, labib.buildInfoBuilder.serviceManager)
 	if err != nil {
 		return
 	}
-
 	// Validate there are no .marker layers.
 	totalDownloaded, err := downloadMarkerLayersToRemoteCache(resultMap, labib.buildInfoBuilder)
 	if err != nil {

--- a/artifactory/utils/container/manifest.go
+++ b/artifactory/utils/container/manifest.go
@@ -1,0 +1,91 @@
+package container
+
+import (
+	"path"
+	"strings"
+
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+)
+
+// To unmarshal config layer file
+type configLayer struct {
+	History []history `json:"history,omitempty"`
+}
+
+type history struct {
+	Created    string `json:"created,omitempty"`
+	CreatedBy  string `json:"created_by,omitempty"`
+	EmptyLayer bool   `json:"empty_layer,omitempty"`
+}
+
+// To unmarshal manifest.json file
+type manifest struct {
+	Config manifestConfig `json:"config,omitempty"`
+	Layers []layer        `json:"layers,omitempty"`
+}
+
+type manifestConfig struct {
+	Digest string `json:"digest,omitempty"`
+}
+
+type layer struct {
+	Digest    string `json:"digest,omitempty"`
+	MediaType string `json:"mediaType,omitempty"`
+}
+
+type FatManifest struct {
+	Manifests []ManifestDetails `json:"manifests"`
+}
+
+type ManifestDetails struct {
+	Digest   string   `json:"digest"`
+	Platform Platform `json:"platform"`
+}
+
+type Platform struct {
+	Architecture string `json:"architecture"`
+	Os           string `json:"os"`
+}
+
+// Return all the search patterns in which manifest can be found.
+func getManifestPaths(imagePath, repo string, commandType CommandType) []string {
+	// pattern 1: reverse proxy e.g. ecosysjfrog-docker-local.jfrog.io.
+	paths := []string{path.Join(repo, imagePath, "*")}
+	// pattern 2: proxy-less e.g. orgab.jfrog.team/docker-local.
+	endOfRepoNameIndex := strings.Index(imagePath[1:], "/")
+	proxylessTag := imagePath[endOfRepoNameIndex+1:]
+	paths = append(paths, path.Join(repo, proxylessTag, "*"))
+	// If image path includes more than 3 slashes, Artifactory doesn't store this image under 'library', thus we should not look further.
+	if commandType != Push && strings.Count(imagePath, "/") <= 3 {
+		// pattern 3: reverse proxy - this time with 'library' as part of the path.
+		paths = append(paths, path.Join(repo, "library", imagePath, "*"))
+		// pattern 4: Assume proxy-less - this time with 'library' as part of the path.
+		paths = append(paths, path.Join(repo, "library", proxylessTag, "*"))
+	}
+	return paths
+}
+
+func getManifest(resultMap map[string]*utils.ResultItem, serviceManager artifactory.ArtifactoryServicesManager, repo string) (imageManifest *manifest, err error) {
+	if len(resultMap) == 0 {
+		return
+	}
+	manifestSearchResult, ok := resultMap["manifest.json"]
+	if !ok {
+		return
+	}
+	err = downloadLayer(*manifestSearchResult, &imageManifest, serviceManager, repo)
+	return
+}
+
+func getFatManifest(resultMap map[string]*utils.ResultItem, serviceManager artifactory.ArtifactoryServicesManager, repo string) (imageFatManifest *FatManifest, err error) {
+	if len(resultMap) == 0 {
+		return
+	}
+	manifestSearchResult, ok := resultMap["list.manifest.json"]
+	if !ok {
+		return
+	}
+	err = downloadLayer(*manifestSearchResult, &imageFatManifest, serviceManager, repo)
+	return
+}

--- a/artifactory/utils/container/remoteagent.go
+++ b/artifactory/utils/container/remoteagent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
+// Build-info builder for remote agents tools such as: Kaniko, OpenShift CLI (oc), or buildx.
 type remoteAgentbuildInfoBuilder struct {
 	buildInfoBuilder *buildInfoBuilder
 	manifestSha2     string

--- a/artifactory/utils/container/remoteagent.go
+++ b/artifactory/utils/container/remoteagent.go
@@ -1,0 +1,122 @@
+package container
+
+import (
+	"strings"
+
+	buildinfo "github.com/jfrog/build-info-go/entities"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+type remoteAgentbuildInfoBuilder struct {
+	buildInfoBuilder *buildInfoBuilder
+	manifestSha2     string
+}
+
+func NewRemoteAgentBuildInfoBuilder(image *Image, repository, buildName, buildNumber, project string, serviceManager artifactory.ArtifactoryServicesManager, manifestSha256 string) (*remoteAgentbuildInfoBuilder, error) {
+	builder, err := newBuildInfoBuilder(image, repository, buildName, buildNumber, project, serviceManager)
+	return &remoteAgentbuildInfoBuilder{
+		buildInfoBuilder: builder,
+		manifestSha2:     manifestSha256,
+	}, err
+}
+
+func (rabib *remoteAgentbuildInfoBuilder) GetLayers() *[]utils.ResultItem {
+	return &rabib.buildInfoBuilder.imageLayers
+}
+
+func (rabib *remoteAgentbuildInfoBuilder) Build(module string) (*buildinfo.BuildInfo, error) {
+	// Search for and image in Artifactory.
+	results, resultsPath, err := rabib.searchImage()
+	if err != nil {
+		return nil, err
+	}
+	// Create build-info based on image manifest.
+	if results["manifest.json"] != nil {
+		searchResults, manifest, err := rabib.handleManifest(results)
+		if err != nil {
+			return nil, err
+		}
+		return rabib.buildInfoBuilder.createBuildInfo(Push, manifest, searchResults, module)
+	}
+	// Create build-info based on image fat-manifest.
+	multiPlatformImages, fatManifestDetails, fatManifest, err := rabib.handleFatManifestImage(results, resultsPath)
+	if err != nil {
+		return nil, err
+	}
+	return rabib.buildInfoBuilder.createMultiPlatformBuildInfo(fatManifest, fatManifestDetails, multiPlatformImages, module)
+}
+
+// Search for image manifest and layers in Artifactory.
+func (rabib *remoteAgentbuildInfoBuilder) handleManifest(resultMap map[string]*utils.ResultItem) (map[string]*utils.ResultItem, *manifest, error) {
+	if manifest, ok := resultMap["manifest.json"]; ok {
+		err := rabib.isVerifiedManifest(manifest)
+		if err != nil {
+			return nil, nil, err
+
+		}
+		manifest, err := getManifest(resultMap, rabib.buildInfoBuilder.serviceManager, rabib.buildInfoBuilder.repositoryDetails.key)
+		if err != nil {
+			return nil, nil, err
+		}
+		// // Manifest may hold 'empty layers'. As a result, promotion will fail to promote the same layer more than once.
+		rabib.buildInfoBuilder.imageSha2 = manifest.Config.Digest
+		log.Debug("Found manifest.json. Proceeding to create build-info.")
+		return resultMap, manifest, nil
+	}
+	return nil, nil, errorutils.CheckErrorf(`couldn't find image "` + rabib.buildInfoBuilder.image.name + `" manifest in Artifactory`)
+}
+
+func (rabib *remoteAgentbuildInfoBuilder) handleFatManifestImage(results map[string]*utils.ResultItem, resultPath string) (map[string][]*utils.ResultItem, *utils.ResultItem, *FatManifest, error) {
+	if fatManifestResult, ok := results["list.manifest.json"]; ok {
+		log.Debug("Found list.manifest.json. Proceeding to create build-info.")
+		fatManifestRootPath := getFatManifestRoot(fatManifestResult.GetItemRelativeLocation()) + "/*"
+		fatManifest, err := getFatManifest(results, rabib.buildInfoBuilder.serviceManager, rabib.buildInfoBuilder.repositoryDetails.key)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		multiPlatformImages, err := performMultiPlatformImageSearch(fatManifestRootPath, rabib.buildInfoBuilder.serviceManager)
+		return multiPlatformImages, fatManifestResult, fatManifest, err
+	}
+	return nil, nil, nil, errorutils.CheckErrorf(`couldn't find image "` + rabib.buildInfoBuilder.image.name + `" fat manifest in Artifactory`)
+}
+
+// Search image manifest or fat-manifest of and image.
+func (rabib *remoteAgentbuildInfoBuilder) searchImage() (resultMap map[string]*utils.ResultItem, path string, err error) {
+	imagePath, err := rabib.buildInfoBuilder.image.GetPath()
+	if err != nil {
+		return nil, "", err
+	}
+	// Search image's manifest.
+	manifestPathsCandidates := getManifestPaths(imagePath, rabib.buildInfoBuilder.getSearchableRepo(), Push)
+	log.Debug("Start searching for image manifest.json")
+	for _, path := range manifestPathsCandidates {
+		log.Debug(`Searching in:"` + path + `"`)
+		resultMap, err := performSearch(path, rabib.buildInfoBuilder.serviceManager)
+		if err != nil {
+			return nil, "", err
+		}
+		if resultMap == nil {
+			continue
+		}
+		if resultMap["list.manifest.json"] != nil || resultMap["manifest.json"] != nil {
+			return resultMap, path, nil
+		}
+	}
+	return nil, "", errorutils.CheckErrorf(imageNotFoundErrorMessage, rabib.buildInfoBuilder.image.name)
+}
+
+// Verify manifest's sha256. If there is no match, return nil.
+func (rabib *remoteAgentbuildInfoBuilder) isVerifiedManifest(imageManifest *utils.ResultItem) error {
+	if imageManifest.GetProperty("docker.manifest.digest") != rabib.manifestSha2 {
+		return errorutils.CheckErrorf(`Found incorrect manifest.json file. Expects digest "` + rabib.manifestSha2 + `" found "` + imageManifest.GetProperty("docker.manifest.digest"))
+	}
+	return nil
+}
+
+func getFatManifestRoot(fatManifestPath string) string {
+	fatManifestPath = strings.TrimSuffix(fatManifestPath, "/")
+	return fatManifestPath[:strings.LastIndex(fatManifestPath, "/")]
+}

--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,8 @@ exclude (
 	github.com/pkg/sftp v1.10.1
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.6.7-0.20211229150323-7d6d021195e3
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.6.7-0.20211230131506-ac1ecc25d046
 
-//replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v0.1.5-0.20211209071650-c5f4d2e581c3
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v0.1.6-0.20211230154728-26895b661a58
 
 //replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.0.7-0.20211128152632-e218c460d703

--- a/go.sum
+++ b/go.sum
@@ -219,12 +219,12 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jedib0t/go-pretty/v6 v6.2.2 h1:o3McN0rQ4X+IU+HduppSp9TwRdGLRW2rhJXy9CJaCRw=
 github.com/jedib0t/go-pretty/v6 v6.2.2/go.mod h1:+nE9fyyHGil+PuISTCrp7avEdo6bqoMwqZnuiK2r2a0=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/build-info-go v0.1.5 h1:dcLTX+3+KIclp1NsUS4Lobh4Sutzsym2eCQWsKxGTGs=
-github.com/jfrog/build-info-go v0.1.5/go.mod h1:MBrjdmZ6c7Q/otzFwx6dFrbNIjd/mcYDiEwn6nOUhcs=
+github.com/jfrog/build-info-go v0.1.6-0.20211230154728-26895b661a58 h1:ezhr/AjaOGk45iWT1MHGzQ2bBmI5gj3Se6HgLd/zxWU=
+github.com/jfrog/build-info-go v0.1.6-0.20211230154728-26895b661a58/go.mod h1:MBrjdmZ6c7Q/otzFwx6dFrbNIjd/mcYDiEwn6nOUhcs=
 github.com/jfrog/gofrog v1.1.1 h1:uRjeZWidQl4FmKP4Zpj5hSKJp3gSIWW9VUwbQdVEVRU=
 github.com/jfrog/gofrog v1.1.1/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
-github.com/jfrog/jfrog-client-go v1.6.7-0.20211229150323-7d6d021195e3 h1:VrP8amQxQWvDK8sgXM19OpJaLIQc5VL1S2DJHEJ8ypQ=
-github.com/jfrog/jfrog-client-go v1.6.7-0.20211229150323-7d6d021195e3/go.mod h1:ChLhyylHfiDwsgBiWdEohyeILCUJbyyV2gCd6mzceb8=
+github.com/jfrog/jfrog-client-go v1.6.7-0.20211230131506-ac1ecc25d046 h1:iIDiazkqsWbVX1yeh+3jopZm6Dap3E2iSuCzFyL7t/4=
+github.com/jfrog/jfrog-client-go v1.6.7-0.20211230131506-ac1ecc25d046/go.mod h1:ChLhyylHfiDwsgBiWdEohyeILCUJbyyV2gCd6mzceb8=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
*   Add support for collecting build-info for fat-manifest images.
*   Add support for [buildx](https://github.com/docker/buildx) in `build-docker-create` command.

[Buildx](https://github.com/docker/buildx) is a Docker CLI plugin for extended build capabilities with BuildKit. 
To collect build-info with buildx CLI, add [--metadata-file](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md) flag to the buildx build command and a meta-data file will be generated at the end of the build. 
This file can be used with `build-docker-create` to collect build-info either for images or multi platform images.

Related PRs:
* https://github.com/jfrog/jfrog-cli/pull/1364
* https://github.com/jfrog/jfrog-client-go/pull/500
* https://github.com/jfrog/build-info-go/pull/27