### PR TITLE
Add .csproj file as an indicator for NuGet/Dotnet technology

### DIFF
--- a/utils/coreutils/techutils.go
+++ b/utils/coreutils/techutils.go
@@ -55,11 +55,11 @@ var technologiesData = map[Technology]TechData{
 	},
 	Nuget: {
 		PackageType: "nuget",
-		indicators:  []string{".sln"},
+		indicators:  []string{".sln", ".csproj"},
 	},
 	Dotnet: {
 		PackageType: "nuget",
-		indicators:  []string{".sln"},
+		indicators:  []string{".sln", ".csproj"},
 	},
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
 According to the [official dotnet project samples ](https://github.com/dotnet/samples) we should consider a *.csproj file as an indicator for Nuget/Dotnet project.