### PR TITLE
Remove any prerequisites for generic npm cmds

### DIFF
--- a/artifactory/commands/npm/common.go
+++ b/artifactory/commands/npm/common.go
@@ -38,14 +38,16 @@ type CommonArgs struct {
 	NpmCommand
 }
 
-func (com *CommonArgs) preparePrerequisites(repo string) error {
+func (com *CommonArgs) preparePrerequisites(repo string, overrideNpmrc bool) error {
 	log.Debug("Preparing prerequisites...")
 	var err error
 	com.npmVersion, com.executablePath, err = biutils.GetNpmVersionAndExecPath(log.Logger)
 	if err != nil {
 		return err
 	}
-
+	if !overrideNpmrc {
+		return nil
+	}
 	if com.npmVersion.Compare(minSupportedNpmVersion) > 0 {
 		return errorutils.CheckErrorf(
 			"JFrog CLI npm %s command requires npm client version "+minSupportedNpmVersion+" or higher. The Current version is: %s", com.cmdName, com.npmVersion.GetVersion())
@@ -60,7 +62,6 @@ func (com *CommonArgs) preparePrerequisites(repo string) error {
 		return err
 	}
 	log.Debug("Working directory set to:", com.workingDirectory)
-
 	if err = com.setArtifactoryAuth(); err != nil {
 		return err
 	}

--- a/artifactory/commands/npm/generic.go
+++ b/artifactory/commands/npm/generic.go
@@ -2,14 +2,13 @@ package npm
 
 import (
 	"fmt"
-	commandUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/utils"
-	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	"os"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	npmutils "github.com/jfrog/jfrog-cli-core/v2/utils/npm"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"os"
 )
 
 type GenericCommandArgs struct {
@@ -18,7 +17,6 @@ type GenericCommandArgs struct {
 
 // GenericCommand represents any npm command which is not "install", "ci" or "publish".
 type GenericCommand struct {
-	configFilePath string
 	*GenericCommandArgs
 }
 
@@ -32,77 +30,15 @@ func (gc *GenericCommand) CommandName() string {
 	return "rt_npm_generic"
 }
 
-func (gc *GenericCommand) SetConfigFilePath(configFilePath string) *GenericCommand {
-	gc.configFilePath = configFilePath
-	return gc
-}
-
-func (gc *GenericCommand) SetServerDetails(serverDetails *config.ServerDetails) *GenericCommand {
-	gc.serverDetails = serverDetails
-	return gc
-}
-
-func (gc *GenericCommand) Init() error {
-	// Filter out JFrog CLI's specific flags.
-	_, _, _, filteredCmd, _, err := commandUtils.ExtractNpmOptionsFromArgs(gc.npmArgs)
-	if err != nil {
-		return err
-	}
-
-	err = gc.setServerDetailsAndRepo()
-	if err != nil {
-		return err
-	}
-	gc.SetNpmArgs(filteredCmd).SetBuildConfiguration(&utils.BuildConfiguration{})
-	return nil
+func (gca *GenericCommandArgs) ServerDetails() (*config.ServerDetails, error) {
+	return gca.serverDetails, nil
 }
 
 func (gc *GenericCommand) Run() (err error) {
-	if err = gc.preparePrerequisites(gc.repo); err != nil {
+	if err = gc.preparePrerequisites("", false); err != nil {
 		return
 	}
-	defer func() {
-		e := gc.restoreNpmrcFunc()
-		if err == nil {
-			err = e
-		}
-	}()
-	if err = gc.createTempNpmrc(); err != nil {
-		return
-	}
-	err = gc.runNpmGenericCommand()
-	return
-}
-
-func (gc *GenericCommand) setServerDetailsAndRepo() error {
-	// Read config file.
-	log.Debug("Preparing to read the config file", gc.configFilePath)
-	vConfig, err := utils.ReadConfigFile(gc.configFilePath, utils.YAML)
-	if err != nil {
-		return err
-	}
-
-	// Set server details if exists, with priority to deployer.
-	for _, prefix := range []string{utils.ProjectConfigDeployerPrefix, utils.ProjectConfigResolverPrefix} {
-		if vConfig.IsSet(prefix) {
-			params, err := utils.GetRepoConfigByPrefix(gc.configFilePath, prefix, vConfig)
-			if err != nil {
-				return err
-			}
-			rtDetails, err := params.ServerDetails()
-			if err != nil {
-				return errorutils.CheckError(err)
-			}
-			gc.SetServerDetails(rtDetails)
-			gc.repo = params.TargetRepo()
-			return nil
-		}
-	}
-	return nil
-}
-
-func (gca *GenericCommandArgs) ServerDetails() (*config.ServerDetails, error) {
-	return gca.serverDetails, nil
+	return gc.runNpmGenericCommand()
 }
 
 func (gca *GenericCommandArgs) runNpmGenericCommand() error {

--- a/artifactory/commands/npm/installorci.go
+++ b/artifactory/commands/npm/installorci.go
@@ -83,7 +83,7 @@ func (nic *NpmInstallOrCiCommand) ServerDetails() (*config.ServerDetails, error)
 }
 
 func (nic *NpmInstallOrCiCommand) Run() (err error) {
-	if err = nic.preparePrerequisites(nic.repo); err != nil {
+	if err = nic.preparePrerequisites(nic.repo, true); err != nil {
 		return
 	}
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Running generic npm cmds such as `jf npm --version` should not look up for config file nor override local npmrc (used by `jf npm i/ci`).
