### PR TITLE
Log response after failure in encrypting password

### DIFF
--- a/artifactory/utils/utils.go
+++ b/artifactory/utils/utils.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/jfrog/build-info-go/build"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 
 	"github.com/jfrog/jfrog-client-go/utils/io"
@@ -80,7 +81,7 @@ func GetEncryptedPasswordFromArtifactory(artifactoryAuth auth.ServiceDetails, in
 		return "", errorutils.CheckErrorf(message)
 	}
 
-	return "", errorutils.CheckErrorf("Artifactory response: " + resp.Status)
+	return "", errorutils.CheckErrorf("Artifactory response: " + resp.Status + "\n" + clientutils.IndentJson(body))
 }
 
 func CreateServiceManager(serverDetails *config.ServerDetails, httpRetries, httpRetryWaitMilliSecs int, isDryRun bool) (artifactory.ArtifactoryServicesManager, error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
An attempt to encrypt the password during `jf config add` command may fail for various reasons. Currently, we only print the HTTP code.

However, sometimes it would be helpful to print the response from Artifactory. For example:
![image](https://user-images.githubusercontent.com/11367982/155526845-406c89d0-095d-4975-981a-e91c3aaa9cde.png)
