### PR TITLE
Bugfix - Panic in Dotnet and NuGet commands

### DIFF
--- a/artifactory/utils/dotnet/solution/solution.go
+++ b/artifactory/utils/dotnet/solution/solution.go
@@ -73,9 +73,11 @@ func (solution *solution) BuildInfo(moduleName string) (*buildinfo.BuildInfo, er
 
 		// Populate requestedBy field
 		for _, directDepName := range directDeps {
-			directDep := dependencies[directDepName]
-			directDep.RequestedBy = [][]string{{module.Id}}
-			populateRequestedBy(*directDep, dependencies, childrenMap)
+			// Populate the direct dependency requested by only if the dependency exist in the cache
+			if directDep, exist := dependencies[directDepName]; exist {
+				directDep.RequestedBy = [][]string{{module.Id}}
+				populateRequestedBy(*directDep, dependencies, childrenMap)
+			}
 		}
 
 		// Populate module dependencies


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Resolves https://github.com/jfrog/jfrog-cli/issues/1463

In some cases, a dependency may not appear in the NuGet cache and the CLI returned the following message:

> The file C:\Users\username\.nuget\packages\microsoft.netcore.platforms\1.1.0\microsoft.netcore.platforms.1.1.0.nupkg doesn't exist in the NuGet cache directory but it does exist as a target in the assets files. Skipping adding this dependency to the build info. This might be because the package already exists in a different NuGet cache, possibly the SDK's NuGetFallbackFolder cache. Removing the package from this cache may resolve the issue.

The change introduced in https://github.com/jfrog/jfrog-cli-core/pull/303 didn't take this into consideration.