### PR TITLE
Dependencies in NuGet subprojects are mixed

### DIFF
--- a/artifactory/utils/dotnet/solution/solution.go
+++ b/artifactory/utils/dotnet/solution/solution.go
@@ -80,7 +80,11 @@ func (solution *solution) BuildInfo(moduleName string) (*buildinfo.BuildInfo, er
 
 		// Populate module dependencies
 		for _, dep := range dependencies {
-			module.Dependencies = append(module.Dependencies, *dep)
+			// If dependnecy has no RequestedBy field, it is not accessible in the current project -
+			// It is expected to be under a sub project.
+			if len(dep.RequestedBy) > 0 {
+				module.Dependencies = append(module.Dependencies, *dep)
+			}
 		}
 
 		modules = append(modules, module)

--- a/artifactory/utils/dotnet/solution/solution.go
+++ b/artifactory/utils/dotnet/solution/solution.go
@@ -80,8 +80,9 @@ func (solution *solution) BuildInfo(moduleName string) (*buildinfo.BuildInfo, er
 
 		// Populate module dependencies
 		for _, dep := range dependencies {
-			// If dependnecy has no RequestedBy field, it is not accessible in the current project -
-			// It is expected to be under a sub project.
+			// If dependency has no RequestedBy field, it means that the depedency not accessible in the current project.
+			// In that case, the dependency is assumed to be under a project which is referenced by this project.
+			// We therefore don't include the dependency in the build-info.
 			if len(dep.RequestedBy) > 0 {
 				module.Dependencies = append(module.Dependencies, *dep)
 			}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Resolves https://github.com/jfrog/jfrog-cli/issues/1281#issuecomment-1068892650
Test: https://github.com/jfrog/jfrog-cli/pull/1482

In NuGet projects, a possible scenario is that project A contains project B as a project reference (like sub-module).
Currently, all dependencies of B appear in A. Furthermore - the RequestedBy field of these dependencies is nil because there is no way to traverse them from A.

This PR suggests removing the unreachable dependencies.