### PR TITLE
New scan/audit pretty-json output format

### DIFF
--- a/artifactory/commands/utils/conditionaluploadutils.go
+++ b/artifactory/commands/utils/conditionaluploadutils.go
@@ -61,10 +61,10 @@ func GetXrayOutputFormat(formatFlagVal string) (format xrutils.OutputFormat, err
 			format = xrutils.Table
 		case string(xrutils.Json):
 			format = xrutils.Json
-		case string(xrutils.Pretty):
-			format = xrutils.Pretty
+		case string(xrutils.SimpleJson):
+			format = xrutils.SimpleJson
 		default:
-			err = errorutils.CheckErrorf("only the following output formats are supported: " + coreutils.GetExplicitListByNumber(xrutils.OutputFormats))
+			err = errorutils.CheckErrorf("only the following output formats are supported: " + coreutils.ListToText(xrutils.OutputFormats))
 		}
 	}
 	return

--- a/artifactory/commands/utils/conditionaluploadutils.go
+++ b/artifactory/commands/utils/conditionaluploadutils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	xraycommands "github.com/jfrog/jfrog-cli-core/v2/xray/commands/scan"
 	xrutils "github.com/jfrog/jfrog-cli-core/v2/xray/utils"
 	"strings"
@@ -60,8 +61,10 @@ func GetXrayOutputFormat(formatFlagVal string) (format xrutils.OutputFormat, err
 			format = xrutils.Table
 		case string(xrutils.Json):
 			format = xrutils.Json
+		case string(xrutils.Pretty):
+			format = xrutils.Pretty
 		default:
-			err = errorutils.CheckErrorf("only the following output formats are supported: table or json")
+			err = errorutils.CheckErrorf("only the following output formats are supported: " + coreutils.GetExplicitListByNumber(xrutils.OutputFormats))
 		}
 	}
 	return

--- a/utils/coreutils/tableutils_test.go
+++ b/utils/coreutils/tableutils_test.go
@@ -7,9 +7,9 @@ import (
 
 func TestCountLinesInCell(t *testing.T) {
 	tests := []struct {
-		content                string
-		maxWidth               int
-		expenctedNumberOfLines int
+		content               string
+		maxWidth              int
+		expectedNumberOfLines int
 	}{
 		{
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
@@ -33,6 +33,6 @@ func TestCountLinesInCell(t *testing.T) {
 	}
 	for _, test := range tests {
 		actualNumberOfLines := countLinesInCell(test.content, test.maxWidth)
-		assert.Equal(t, test.expenctedNumberOfLines, actualNumberOfLines)
+		assert.Equal(t, test.expectedNumberOfLines, actualNumberOfLines)
 	}
 }

--- a/utils/coreutils/utils.go
+++ b/utils/coreutils/utils.go
@@ -400,3 +400,17 @@ func SetCliExecutableName(executableName string) {
 func GetCliExecutableName() string {
 	return cliExecutableName
 }
+
+// Get the explicit list by number of elements.
+// For example for multiple elements: "one, two and three".
+// For a single element: "one".
+func GetExplicitListByNumber(list []string) string {
+	if len(list) == 1 {
+		return list[0]
+	}
+	return strings.Join(list[0:len(list)-1], ", ") + " and " + list[len(list)-1]
+}
+
+func RemoveAllWhiteSpaces(input string) string {
+	return strings.Join(strings.Fields(input), "")
+}

--- a/utils/coreutils/utils.go
+++ b/utils/coreutils/utils.go
@@ -401,10 +401,10 @@ func GetCliExecutableName() string {
 	return cliExecutableName
 }
 
-// Get the explicit list by number of elements.
-// For example for multiple elements: "one, two and three".
+// Turn a list of strings into a sentence.
+// For example, turn ["one", "two", "three"] into "one, two and three".
 // For a single element: "one".
-func GetExplicitListByNumber(list []string) string {
+func ListToText(list []string) string {
 	if len(list) == 1 {
 		return list[0]
 	}

--- a/utils/coreutils/utils_test.go
+++ b/utils/coreutils/utils_test.go
@@ -156,3 +156,9 @@ func TestParseYesNo(t *testing.T) {
 		})
 	}
 }
+
+func TestGetExplicitListByNumber(t *testing.T) {
+	assert.Equal(t, GetExplicitListByNumber([]string{"one"}), "one")
+	assert.Equal(t, GetExplicitListByNumber([]string{"one", "two"}), "one and two")
+	assert.Equal(t, GetExplicitListByNumber([]string{"one", "two", "three"}), "one, two and three")
+}

--- a/utils/coreutils/utils_test.go
+++ b/utils/coreutils/utils_test.go
@@ -157,8 +157,8 @@ func TestParseYesNo(t *testing.T) {
 	}
 }
 
-func TestGetExplicitListByNumber(t *testing.T) {
-	assert.Equal(t, GetExplicitListByNumber([]string{"one"}), "one")
-	assert.Equal(t, GetExplicitListByNumber([]string{"one", "two"}), "one and two")
-	assert.Equal(t, GetExplicitListByNumber([]string{"one", "two", "three"}), "one, two and three")
+func TestListToText(t *testing.T) {
+	assert.Equal(t, ListToText([]string{"one"}), "one")
+	assert.Equal(t, ListToText([]string{"one", "two"}), "one and two")
+	assert.Equal(t, ListToText([]string{"one", "two", "three"}), "one, two and three")
 }

--- a/xray/commands/audit/commonutils.go
+++ b/xray/commands/audit/commonutils.go
@@ -115,7 +115,7 @@ func (auditCmd *AuditCommand) ScanDependencyTree(modulesDependencyTrees []*servi
 		// if all scans failed, fail the audit command
 		return errorutils.CheckErrorf("Audit command failed due to Xray internal error")
 	}
-	err = xrutils.PrintScanResults(results, auditCmd.outputFormat == xrutils.Table, auditCmd.includeVulnerabilities, auditCmd.includeLicenses, len(modulesDependencyTrees) > 1, auditCmd.printExtendedTable)
+	err = xrutils.PrintScanResults(results, auditCmd.outputFormat, auditCmd.includeVulnerabilities, auditCmd.includeLicenses, len(modulesDependencyTrees) > 1, auditCmd.printExtendedTable)
 	if err != nil {
 		return err
 	}

--- a/xray/commands/scan/buildscan.go
+++ b/xray/commands/scan/buildscan.go
@@ -118,7 +118,7 @@ func (bsc *BuildScanCommand) runBuildScanAndPrintResults(xrayManager *xray.XrayS
 		XrayDataUrl:     buildScanResults.MoreDetailsUrl,
 	}}
 
-	if bsc.outputFormat == xrutils.Json || bsc.outputFormat == xrutils.Pretty {
+	if bsc.outputFormat == xrutils.Json || bsc.outputFormat == xrutils.SimpleJson {
 		// Print the violations and/or vulnerabilities as part of one JSON.
 		err = xrutils.PrintScanResults(scanResponse, bsc.outputFormat, false, false, false, bsc.printExtendedTable)
 	} else {

--- a/xray/commands/scan/buildscan.go
+++ b/xray/commands/scan/buildscan.go
@@ -118,21 +118,21 @@ func (bsc *BuildScanCommand) runBuildScanAndPrintResults(xrayManager *xray.XrayS
 		XrayDataUrl:     buildScanResults.MoreDetailsUrl,
 	}}
 
-	if bsc.outputFormat == xrutils.Json {
+	if bsc.outputFormat == xrutils.Json || bsc.outputFormat == xrutils.Pretty {
 		// Print the violations and/or vulnerabilities as part of one JSON.
-		err = xrutils.PrintScanResults(scanResponse, false, false, false, false, bsc.printExtendedTable)
+		err = xrutils.PrintScanResults(scanResponse, bsc.outputFormat, false, false, false, bsc.printExtendedTable)
 	} else {
 		// Print two different tables for violations and vulnerabilities (if needed)
 
 		// If "No Xray Fail build policy...." error received, no need to print violations
 		if !noFailBuildPolicy {
-			err = xrutils.PrintScanResults(scanResponse, true, false, false, false, bsc.printExtendedTable)
+			err = xrutils.PrintScanResults(scanResponse, bsc.outputFormat, false, false, false, bsc.printExtendedTable)
 			if err != nil {
 				return false, err
 			}
 		}
 		if bsc.includeVulnerabilities {
-			err = xrutils.PrintScanResults(scanResponse, true, true, false, false, bsc.printExtendedTable)
+			err = xrutils.PrintScanResults(scanResponse, bsc.outputFormat, true, false, false, bsc.printExtendedTable)
 			if err != nil {
 				return false, err
 			}

--- a/xray/commands/scan/scan.go
+++ b/xray/commands/scan/scan.go
@@ -188,7 +188,7 @@ func (scanCmd *ScanCommand) Run() (err error) {
 	if scanCmd.progress != nil {
 		scanCmd.progress.ClearHeadlineMsg()
 	}
-	err = xrutils.PrintScanResults(flatResults, scanCmd.outputFormat == xrutils.Table, scanCmd.includeVulnerabilities, scanCmd.includeLicenses, true, scanCmd.printExtendedTable)
+	err = xrutils.PrintScanResults(flatResults, scanCmd.outputFormat, scanCmd.includeVulnerabilities, scanCmd.includeLicenses, true, scanCmd.printExtendedTable)
 	if err != nil {
 		return err
 	}

--- a/xray/utils/resultstable.go
+++ b/xray/utils/resultstable.go
@@ -258,7 +258,8 @@ type cveRow struct {
 	cvssV3 string `col-name:"CVSS\nv3" extended:"true"`
 }
 
-type ResultsJsonTable struct {
+// This struct holds the sorted results of the simple-json output.
+type ResultsSimpleJson struct {
 	Vulnerabilities    []map[string]interface{}
 	SecurityViolations []map[string]interface{}
 	LicensesViolations []map[string]interface{}

--- a/xray/utils/resultstable.go
+++ b/xray/utils/resultstable.go
@@ -11,21 +11,52 @@ import (
 	"github.com/jfrog/jfrog-client-go/xray/services"
 )
 
+const noContextMessage = "Note: no context was provided, so no policy could be determined to scan against.\n" +
+	"You can get a list of custom violations by providing one of the command options: --watches, --repo-path or --project.\n" +
+	"Read more about configuring Xray policies here: https://www.jfrog.com/confluence/display/JFROG/Creating+Xray+Policies+and+Rules\n"
+
 // PrintViolationsTable prints the violations in 3 tables: security violations, license compliance violations and ignore rule URLs.
 // Set multipleRoots to true in case the given violations array contains (or may contain) results of several different projects or files (like in binary scan).
 // In case multipleRoots is true, the field Component will show the root of each impact path, otherwise it will show the root's child.
 // In case one (or more) of the violations contains the field FailBuild set to true, CliError with exit code 3 will be returned.
 // Set printExtended to true to print fields with 'extended' tag.
 func PrintViolationsTable(violations []services.Violation, multipleRoots, printExtended bool) error {
+	securityViolationsRows, licenseViolationsRows, err := PrepareViolationsTable(violations, multipleRoots, coreutils.IsTerminal())
+	if err != nil {
+		return err
+	}
+
+	// Print tables
+	err = coreutils.PrintTable(securityViolationsRows, "Security Violations", "No security violations were found", printExtended)
+	if err != nil {
+		return err
+	}
+	return coreutils.PrintTable(licenseViolationsRows, "License Compliance Violations", "No license compliance violations were found", printExtended)
+}
+
+// Same as PrintViolationsTable, but table is returned as a json map array.
+func CreateJsonViolationsTable(violations []services.Violation, multipleRoots bool) ([]map[string]interface{}, []map[string]interface{}, error) {
+	securityViolationsRows, licenseViolationsRows, err := PrepareViolationsTable(violations, multipleRoots, false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secViolationsJsonTable, err := coreutils.CreateJsonTable(securityViolationsRows)
+	if err != nil {
+		return nil, nil, err
+	}
+	licViolationsJsonTable, err := coreutils.CreateJsonTable(licenseViolationsRows)
+	return secViolationsJsonTable, licViolationsJsonTable, err
+}
+
+func PrepareViolationsTable(violations []services.Violation, multipleRoots, coloredOutput bool) ([]vulnerabilityRow, []licenseViolationRow, error) {
 	var securityViolationsRows []vulnerabilityRow
 	var licenseViolationsRows []licenseViolationRow
-
-	coloredOutput := coreutils.IsTerminal()
 
 	for _, violation := range violations {
 		impactedPackagesNames, impactedPackagesVersions, impactedPackagesTypes, fixedVersions, components, err := splitComponents(violation.Components, multipleRoots)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		currSeverity := getSeverity(violation.Severity)
 		if violation.ViolationType == "security" {
@@ -74,12 +105,7 @@ func PrintViolationsTable(violations []services.Violation, multipleRoots, printE
 		return licenseViolationsRows[i].severityNumValue > licenseViolationsRows[j].severityNumValue
 	})
 
-	// Print tables
-	err := coreutils.PrintTable(securityViolationsRows, "Security Violations", "No security violations were found", printExtended)
-	if err != nil {
-		return err
-	}
-	return coreutils.PrintTable(licenseViolationsRows, "License Compliance Violations", "No license compliance violations were found", printExtended)
+	return securityViolationsRows, licenseViolationsRows, nil
 }
 
 // PrintVulnerabilitiesTable prints the vulnerabilities in a table.
@@ -87,19 +113,33 @@ func PrintViolationsTable(violations []services.Violation, multipleRoots, printE
 // In case multipleRoots is true, the field Component will show the root of each impact path, otherwise it will show the root's child.
 // Set printExtended to true to print fields with 'extended' tag.
 func PrintVulnerabilitiesTable(vulnerabilities []services.Vulnerability, multipleRoots, printExtended bool) error {
-	fmt.Println("Note: no context was provided, so no policy could be determined to scan against.\n" +
-		"You can get a list of custom violations by providing one of the command options: --watches, --repo-path or --project.\n" +
-		"Read more about configuring Xray policies here: https://www.jfrog.com/confluence/display/JFROG/Creating+Xray+Policies+and+Rules\n" +
-		"Below are all vulnerabilities detected.")
+	fmt.Println(noContextMessage + "Below are all vulnerabilities detected.")
 
-	coloredOutput := coreutils.IsTerminal()
+	vulnerabilitiesRows, err := PrepareVulnerabilitiesTable(vulnerabilities, multipleRoots, coreutils.IsTerminal())
+	if err != nil {
+		return err
+	}
 
+	return coreutils.PrintTable(vulnerabilitiesRows, "Vulnerabilities", "No vulnerabilities were found", printExtended)
+}
+
+// Same as PrintVulnerabilitiesTable, but table is returned as a json map array.
+func CreateJsonVulnerabilitiesTable(vulnerabilities []services.Vulnerability, multipleRoots bool) ([]map[string]interface{}, error) {
+	vulnerabilitiesRows, err := PrepareVulnerabilitiesTable(vulnerabilities, multipleRoots, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return coreutils.CreateJsonTable(vulnerabilitiesRows)
+}
+
+func PrepareVulnerabilitiesTable(vulnerabilities []services.Vulnerability, multipleRoots, coloredOutput bool) ([]vulnerabilityRow, error) {
 	var vulnerabilitiesRows []vulnerabilityRow
 
 	for _, vulnerability := range vulnerabilities {
 		impactedPackagesNames, impactedPackagesVersions, impactedPackagesTypes, fixedVersions, components, err := splitComponents(vulnerability.Components, multipleRoots)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		cves := convertCves(vulnerability.Cves)
 		currSeverity := getSeverity(vulnerability.Severity)
@@ -126,9 +166,7 @@ func PrintVulnerabilitiesTable(vulnerabilities []services.Vulnerability, multipl
 		}
 		return vulnerabilitiesRows[i].fixedVersions != "" && vulnerabilitiesRows[j].fixedVersions == ""
 	})
-
-	err := coreutils.PrintTable(vulnerabilitiesRows, "Vulnerabilities", "No vulnerabilities were found", printExtended)
-	return err
+	return vulnerabilitiesRows, nil
 }
 
 // PrintLicensesTable prints the licenses in a table.
@@ -136,12 +174,31 @@ func PrintVulnerabilitiesTable(vulnerabilities []services.Vulnerability, multipl
 // In case multipleRoots is true, the field Component will show the root of each impact path, otherwise it will show the root's child.
 // Set printExtended to true to print fields with 'extended' tag.
 func PrintLicensesTable(licenses []services.License, multipleRoots, printExtended bool) error {
+	licensesRows, err := PrepareJsonLicensesTable(licenses, multipleRoots)
+	if err != nil {
+		return err
+	}
+
+	return coreutils.PrintTable(licensesRows, "Licenses", "No licenses were found", printExtended)
+}
+
+// Same as PrintLicensesTable, but table is returned as a json map array.
+func CreateJsonLicensesTable(licenses []services.License, multipleRoots bool) ([]map[string]interface{}, error) {
+	licensesRows, err := PrepareJsonLicensesTable(licenses, multipleRoots)
+	if err != nil {
+		return nil, err
+	}
+
+	return coreutils.CreateJsonTable(licensesRows)
+}
+
+func PrepareJsonLicensesTable(licenses []services.License, multipleRoots bool) ([]licenseRow, error) {
 	var licensesRows []licenseRow
 
 	for _, license := range licenses {
 		impactedPackagesNames, impactedPackagesVersions, impactedPackagesTypes, _, components, err := splitComponents(license.Components, multipleRoots)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for compIndex := 0; compIndex < len(impactedPackagesNames); compIndex++ {
 			licensesRows = append(licensesRows,
@@ -156,8 +213,7 @@ func PrintLicensesTable(licenses []services.License, multipleRoots, printExtende
 		}
 	}
 
-	err := coreutils.PrintTable(licensesRows, "Licenses", "No licenses were found", printExtended)
-	return err
+	return licensesRows, nil
 }
 
 // Used for vulnerabilities and security violations
@@ -200,6 +256,13 @@ type cveRow struct {
 	id     string `col-name:"CVE"`
 	cvssV2 string `col-name:"CVSS\nv2" extended:"true"`
 	cvssV3 string `col-name:"CVSS\nv3" extended:"true"`
+}
+
+type ResultsJsonTable struct {
+	Vulnerabilities    []map[string]interface{}
+	SecurityViolations []map[string]interface{}
+	LicensesViolations []map[string]interface{}
+	Licenses           []map[string]interface{}
 }
 
 func convertCves(cves []services.Cve) []cveRow {

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -8,6 +8,7 @@ import (
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
 )
 
@@ -15,20 +16,18 @@ type OutputFormat string
 
 const (
 	// OutputFormat values
-	Table OutputFormat = "table"
-	Json  OutputFormat = "json"
+	Table  OutputFormat = "table"
+	Json   OutputFormat = "json"
+	Pretty OutputFormat = "pretty-json"
 )
 
-func PrintScanResults(results []services.ScanResponse, isTableFormat, includeVulnerabilities, includeLicenses, isMultipleRoots, printExtended bool) (err error) {
-	if isTableFormat {
-		var violations []services.Violation
-		var vulnerabilities []services.Vulnerability
-		var licenses []services.License
-		for _, result := range results {
-			violations = append(violations, result.Violations...)
-			vulnerabilities = append(vulnerabilities, result.Vulnerabilities...)
-			licenses = append(licenses, result.Licenses...)
-		}
+var OutputFormats = []string{string(Table), string(Json), string(Pretty)}
+
+func PrintScanResults(results []services.ScanResponse, format OutputFormat, includeVulnerabilities, includeLicenses, isMultipleRoots, printExtended bool) error {
+	switch format {
+	case Table:
+		var err error
+		violations, vulnerabilities, licenses := splitScanResults(results)
 
 		if len(results) > 0 {
 			resultsPath, err := writeJsonResults(results)
@@ -48,13 +47,50 @@ func PrintScanResults(results []services.ScanResponse, isTableFormat, includeVul
 		if includeLicenses {
 			err = PrintLicensesTable(licenses, isMultipleRoots, printExtended)
 		}
-		if err != nil {
-			return err
+		return err
+	case Pretty:
+		violations, vulnerabilities, licenses := splitScanResults(results)
+		jsonTable := ResultsJsonTable{}
+		if includeVulnerabilities {
+			log.Info(noContextMessage + "All vulnerabilities detected will be included in the output JSON.")
+			vulJsonTable, err := CreateJsonVulnerabilitiesTable(vulnerabilities, isMultipleRoots)
+			if err != nil {
+				return err
+			}
+			jsonTable.Vulnerabilities = vulJsonTable
+		} else {
+			secViolationsJsonTable, licViolationsJsonTable, err := CreateJsonViolationsTable(violations, isMultipleRoots)
+			if err != nil {
+				return err
+			}
+			jsonTable.SecurityViolations = secViolationsJsonTable
+			jsonTable.LicensesViolations = licViolationsJsonTable
 		}
-	} else {
-		err = printJson(results)
+
+		if includeLicenses {
+			licJsonTable, err := CreateJsonLicensesTable(licenses, isMultipleRoots)
+			if err != nil {
+				return err
+			}
+			jsonTable.Licenses = licJsonTable
+		}
+		return printJson(jsonTable)
+	case Json:
+		return printJson(results)
 	}
-	return err
+	return nil
+}
+
+func splitScanResults(results []services.ScanResponse) ([]services.Violation, []services.Vulnerability, []services.License) {
+	var violations []services.Violation
+	var vulnerabilities []services.Vulnerability
+	var licenses []services.License
+	for _, result := range results {
+		violations = append(violations, result.Violations...)
+		vulnerabilities = append(vulnerabilities, result.Vulnerabilities...)
+		licenses = append(licenses, result.Licenses...)
+	}
+	return violations, vulnerabilities, licenses
 }
 
 func writeJsonResults(results []services.ScanResponse) (resultsPath string, err error) {
@@ -89,8 +125,8 @@ func writeJsonResults(results []services.ScanResponse) (resultsPath string, err 
 	return
 }
 
-func printJson(jsonRes []services.ScanResponse) error {
-	results, err := json.Marshal(&jsonRes)
+func printJson(output interface{}) error {
+	results, err := json.Marshal(output)
 	if err != nil {
 		return errorutils.CheckError(err)
 	}

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -16,12 +16,12 @@ type OutputFormat string
 
 const (
 	// OutputFormat values
-	Table  OutputFormat = "table"
-	Json   OutputFormat = "json"
-	Pretty OutputFormat = "pretty-json"
+	Table      OutputFormat = "table"
+	Json       OutputFormat = "json"
+	SimpleJson OutputFormat = "simple-json"
 )
 
-var OutputFormats = []string{string(Table), string(Json), string(Pretty)}
+var OutputFormats = []string{string(Table), string(Json), string(SimpleJson)}
 
 func PrintScanResults(results []services.ScanResponse, format OutputFormat, includeVulnerabilities, includeLicenses, isMultipleRoots, printExtended bool) error {
 	switch format {
@@ -48,9 +48,9 @@ func PrintScanResults(results []services.ScanResponse, format OutputFormat, incl
 			err = PrintLicensesTable(licenses, isMultipleRoots, printExtended)
 		}
 		return err
-	case Pretty:
+	case SimpleJson:
 		violations, vulnerabilities, licenses := splitScanResults(results)
-		jsonTable := ResultsJsonTable{}
+		jsonTable := ResultsSimpleJson{}
 		if includeVulnerabilities {
 			log.Info(noContextMessage + "All vulnerabilities detected will be included in the output JSON.")
 			vulJsonTable, err := CreateJsonVulnerabilitiesTable(vulnerabilities, isMultipleRoots)
@@ -81,6 +81,7 @@ func PrintScanResults(results []services.ScanResponse, format OutputFormat, incl
 	return nil
 }
 
+// Splits scan responses into aggregated lists of violations, vulnerabilities and licenses.
 func splitScanResults(results []services.ScanResponse) ([]services.Violation, []services.Vulnerability, []services.License) {
 	var violations []services.Violation
 	var vulnerabilities []services.Vulnerability


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
The new format transforms the raw scan results into a "table like" json.
```
{
  "Vulnerabilities": [],
  "SecurityViolations": [],
  "LicensesViolations": [],
  "Licenses": []
}
```
Each table is an array of key:value objects, with the keys corresponding to the column names in the `table` format.