### PR TITLE
Separate emoji from severity title

### DIFF
--- a/xray/utils/resultstable.go
+++ b/xray/utils/resultstable.go
@@ -462,20 +462,24 @@ type severity struct {
 	title    string
 	numValue int
 	style    color.Style
+	emoji    string
 }
 
 func (s *severity) printableTitle(colored bool) string {
-	if !colored || len(s.style) == 0 {
+	if !colored {
 		return s.title
 	}
-	return s.style.Render(s.title)
+	if len(s.style) == 0 {
+		return s.emoji + s.title
+	}
+	return s.style.Render(s.emoji + s.title)
 }
 
 var severities = map[string]*severity{
-	"Critical": {title: "💀Critical", numValue: 4, style: color.New(color.BgLightRed, color.LightWhite)},
-	"High":     {title: "🔥High", numValue: 3, style: color.New(color.Red)},
-	"Medium":   {title: "🎃Medium", numValue: 2, style: color.New(color.Yellow)},
-	"Low":      {title: "👻Low", numValue: 1},
+	"Critical": {emoji: "💀", title: "Critical", numValue: 4, style: color.New(color.BgLightRed, color.LightWhite)},
+	"High":     {emoji: "🔥", title: "High", numValue: 3, style: color.New(color.Red)},
+	"Medium":   {emoji: "🎃", title: "Medium", numValue: 2, style: color.New(color.Yellow)},
+	"Low":      {emoji: "👻", title: "Low", numValue: 1},
 }
 
 func getSeverity(severityTitle string) *severity {


### PR DESCRIPTION
The emoji will only be displayed if colored output is requested.

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    