### PR TITLE
Generic audit - return an error if no package manager was detected

### DIFF
--- a/xray/commands/audit/generic/auditmanager.go
+++ b/xray/commands/audit/generic/auditmanager.go
@@ -62,8 +62,7 @@ func detectedTechnologies() (technologies []string, err error) {
 	}
 	detectedTechnologiesString := coreutils.DetectedTechnologiesToString(detectedTechnologies)
 	if detectedTechnologiesString == "" {
-		log.Info("Could not determine the package manager / build tool used by this project.")
-		return
+		return nil, errorutils.CheckErrorf("could not determine the package manager / build tool used by this project.")
 	}
 	log.Info("Detected: " + detectedTechnologiesString)
 	return coreutils.DetectedTechnologiesToSlice(detectedTechnologies), nil


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
  Suggested by Frogbot users, if no package manager was detected, no actual scan was performed and therefore an error is expected. 