### PR TITLE
Bugfix - Docker fail to get repository name

### DIFF
--- a/artifactory/utils/container/image.go
+++ b/artifactory/utils/container/image.go
@@ -132,6 +132,7 @@ func (image *Image) GetRemoteRepo(serviceManager artifactory.ArtifactoryServices
 	// Build the request URL.
 	endpoint := buildRequestUrl(longImageName, imageTag, containerRegistryUrl, isSecure)
 	artHttpDetails := serviceManager.GetConfig().GetServiceDetails().CreateHttpClientDetails()
+	artHttpDetails.Headers["accept"] = "application/vnd.docker.distribution.manifest.v1+prettyjws, application/json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json"
 	resp, _, err := serviceManager.Client().SendHead(endpoint, &artHttpDetails)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
The Artifactory response regarding the Docker repository returns 400 due to the missing header. This PR adds the correct header to resolve the issue.