### PR TITLE
Fix: Scanning password from console fails when run from script

### DIFF
--- a/general/envsetup/envsetup.go
+++ b/general/envsetup/envsetup.go
@@ -217,22 +217,34 @@ func (ftc *EnvSetupCommand) scanAndValidateJFrogPasswordFromConsole(server *conf
 	// User has limited number of retries to enter his correct password.
 	// Password validation is operated by Artifactory encryptedPassword API.
 	var artAuth auth.ServiceDetails
+	server.ArtifactoryUrl = clientutils.AddTrailingSlashIfNeeded(server.Url) + "artifactory/"
 	for i := 0; i < enterPasswordMaxRetries; i++ {
 		server.Password, err = ioutils.ScanJFrogPasswordFromConsole()
 		if err != nil {
 			return
 		}
-		server.ArtifactoryUrl = clientutils.AddTrailingSlashIfNeeded(server.Url) + "artifactory/"
 		artAuth, err = server.CreateArtAuthConfig()
 		if err != nil {
 			return
 		}
 		// Validate correct password by using Artifactory encryptedPassword API.
+		fmt.Println("ping password is:" + server.Password)
 		_, err = utils.GetEncryptedPasswordFromArtifactory(artAuth, false)
+
+		//// ping
+		//pingCmd := generic.NewPingCommand()
+		//pingCmd.SetServerDetails(server)
+		//err = commands.Exec(pingCmd)
+		////search
+		//searchCmd := generic.NewSearchCommand()
+		//searchCmd.SetServerDetails(server).SetSpec(spec.NewBuilder().Target("a/").BuildSpec())
+		//err = commands.Exec(searchCmd)
+
 		if err == nil {
 			// No error while encrypting password => correct password.
 			return
 		}
+		log.Output("error: " + err.Error())
 		if i != enterPasswordMaxRetries-1 {
 			log.Info("wrong password! please try again. ")
 		}

--- a/general/envsetup/envsetup.go
+++ b/general/envsetup/envsetup.go
@@ -229,12 +229,6 @@ func (ftc *EnvSetupCommand) scanAndValidateJFrogPasswordFromConsole(server *conf
 			// No error while encrypting password => correct password.
 			return
 		}
-		if strings.Contains(err.Error(), "Bad credentials") {
-			if i != enterPasswordMaxRetries-1 {
-				log.Info("The password entered is incorrect! please try again. ")
-				continue
-			}
-		}
 		log.Output(err.Error())
 	}
 	err = errorutils.CheckError(errors.New("bad credentials: Wrong password. "))

--- a/general/envsetup/envsetup.go
+++ b/general/envsetup/envsetup.go
@@ -215,7 +215,7 @@ func (ftc *EnvSetupCommand) setupExistingUser() (server *config.ServerDetails, e
 
 func (ftc *EnvSetupCommand) scanAndValidateJFrogPasswordFromConsole(server *config.ServerDetails) (err error) {
 	// User has limited number of retries to enter his correct password.
-	// Password validation is operated by Artifactory encryptedPassword API.
+	// Password validation is operated by Artifactory ping API.
 	server.ArtifactoryUrl = clientutils.AddTrailingSlashIfNeeded(server.Url) + "artifactory/"
 	for i := 0; i < enterPasswordMaxRetries; i++ {
 		server.Password, err = ioutils.ScanJFrogPasswordFromConsole()

--- a/utils/ioutils/ioutils.go
+++ b/utils/ioutils/ioutils.go
@@ -50,7 +50,7 @@ func ScanPasswordFromConsole(message string) (password string, err error) {
 		password = string(inputPass)
 	} else {
 		// Handling non-terminal sources.
-		// When command is running from external script - reading from terminal should be handled using buffer.
+		// When command is running from external script - reading input should be done using a buffer.
 		reader := bufio.NewReader(os.Stdin)
 		password, err = reader.ReadString('\n')
 		if err != nil {

--- a/utils/ioutils/ioutils.go
+++ b/utils/ioutils/ioutils.go
@@ -44,7 +44,7 @@ func ScanPasswordFromConsole(message string) (password string, err error) {
 	fmt.Print(message)
 	var fd int
 	var tty *os.File
-	if terminal.IsTerminal(int(syscall.Stdin)) {
+	if terminal.IsTerminal(0) {
 		fd = syscall.Stdin
 	} else {
 		tty, err = os.Open("/dev/tty")

--- a/utils/ioutils/ioutils.go
+++ b/utils/ioutils/ioutils.go
@@ -3,7 +3,7 @@ package ioutils
 import (
 	"bufio"
 	"fmt"
-	"golang.org/x/crypto/ssh/terminal"
+	terminal "golang.org/x/term"
 	"io"
 	"os"
 	"strings"
@@ -40,17 +40,20 @@ func ScanJFrogPasswordFromConsole() (string, error) {
 	return ScanPasswordFromConsole("JFrog password or API key: ")
 }
 
-func ScanPasswordFromConsole(message string) (string, error) {
+func ScanPasswordFromConsole(message string) (password string, err error) {
 	fmt.Print(message)
 	var fd int
-	if terminal.IsTerminal(syscall.Stdin) {
+	var tty *os.File
+	if terminal.IsTerminal(int(syscall.Stdin)) {
 		fd = syscall.Stdin
 	} else {
-		tty, err := os.Open("/dev/tty")
+		tty, err = os.Open("/dev/tty")
 		if err != nil {
 			return "", errorutils.CheckError(err)
 		}
-		defer tty.Close()
+		defer func() {
+			err = tty.Close()
+		}()
 		fd = int(tty.Fd())
 	}
 	bytePassword, err := terminal.ReadPassword(fd)

--- a/utils/ioutils/ioutils.go
+++ b/utils/ioutils/ioutils.go
@@ -43,20 +43,19 @@ func ScanPasswordFromConsole(message string) (password string, err error) {
 	stdin := 0
 	if terminal.IsTerminal(stdin) {
 		fileDescriptor = stdin
-		inputPass, err := terminal.ReadPassword(fileDescriptor)
-		if err != nil {
-			return "", err
+		inputPass, e := terminal.ReadPassword(fileDescriptor)
+		if e != nil {
+			return "", e
 		}
 		password = string(inputPass)
 	} else {
 		// Handling non-terminal sources.
 		// When command is running from external script - reading from terminal should be handled using buffer.
 		reader := bufio.NewReader(os.Stdin)
-		s, err := reader.ReadString('\n')
+		password, err = reader.ReadString('\n')
 		if err != nil {
 			return "", err
 		}
-		password = s
 	}
 	return
 }

--- a/utils/ioutils/ioutils.go
+++ b/utils/ioutils/ioutils.go
@@ -61,8 +61,6 @@ func ScanPasswordFromConsole(message string) (string, error) {
 
 	// New-line required after the password input:
 	log.Output()
-	// TODO: delete
-	fmt.Println("   " + string(bytePassword))
 	return string(bytePassword), nil
 }
 

--- a/utils/ioutils/ioutils.go
+++ b/utils/ioutils/ioutils.go
@@ -3,15 +3,13 @@ package ioutils
 import (
 	"bufio"
 	"fmt"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 	terminal "golang.org/x/term"
 	"io"
 	"os"
 	"strings"
-	"syscall"
-
-	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
-	"github.com/jfrog/jfrog-client-go/utils/errorutils"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 // disallowUsingSavedPassword - Prevent changing username or url without changing the password.
@@ -45,7 +43,7 @@ func ScanPasswordFromConsole(message string) (password string, err error) {
 	var fd int
 	var tty *os.File
 	if terminal.IsTerminal(0) {
-		fd = syscall.Stdin
+		fd = 0
 	} else {
 		tty, err = os.Open("/dev/tty")
 		if err != nil {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
When running a CLI command from a bash script (for example setup command) and trying to read a password from the console we get this error:"inappropriate ioctl for device". 