### PR TITLE
Add support for Xray's new DBSync V3 (offline updates) feature:

### DIFF
--- a/xray/commands/offlineupdate/offlineupdate.go
+++ b/xray/commands/offlineupdate/offlineupdate.go
@@ -398,8 +398,10 @@ type V3UpdateResponseItem struct {
 	DownloadUrl string `json:"download_url"`
 	Timestamp   int64  `json:"timestamp"`
 }
+
 type V3PeriodicUpdateResponse struct {
 	Update   []V3UpdateResponseItem `json:"update"`
 	Deletion []V3UpdateResponseItem `json:"deletion"`
 }
+
 type OnboardingResponse []V3UpdateResponseItem


### PR DESCRIPTION
* Download the packages using CLI
* Maintain backward compatability to existing DBSync feature
(offlineupdates)

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    