### PR TITLE
Refine usage of defer in config

### DIFF
--- a/common/commands/config.go
+++ b/common/commands/config.go
@@ -91,12 +91,11 @@ func (cc *ConfigCommand) Run() (err error) {
 
 	lockDirPath, err := coreutils.GetJfrogConfigLockDir()
 	if err != nil {
-		return
+		return err
 	}
-
 	lockFile, err := lock.CreateLock(lockDirPath)
 	if err != nil {
-		return
+		return err
 	}
 	defer func() {
 		e := lockFile.Unlock()
@@ -107,18 +106,16 @@ func (cc *ConfigCommand) Run() (err error) {
 
 	switch cc.cmdType {
 	case AddOrEdit:
-		err = cc.config()
+		return cc.config()
 	case Delete:
-		err = cc.delete()
+		return cc.delete()
 	case Use:
-		err = cc.use()
+		return cc.use()
 	case Clear:
-		err = cc.clear()
+		return cc.clear()
 	default:
-		err = fmt.Errorf("Not supported config command type: " + string(cc.cmdType))
+		return fmt.Errorf("Not supported config command type: " + string(cc.cmdType))
 	}
-
-	return
 }
 
 func (cc *ConfigCommand) ServerDetails() (*config.ServerDetails, error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Refine atomic config command changes in `common/commands/ConfigCommand.Run()`, int https://github.com/jfrog/jfrog-cli-core/pull/367, and also mentioned in https://github.com/jfrog/jfrog-cli-core/pull/352.

Change Details

- The unlock and debug logging are more clean (IMO) when performed in an anonymous function rather than stacking `defer` statements when possible. Note that I've accounted for `defer` executing in LIFO order.
- The `defer` of the anonymous functon containing the `lockFile.Unlock()` gets executed _after_ the return but _before_ the function returns to the caller (https://go.dev/ref/spec#Defer_statements). This means the setting and check for `e` not being `nil` and setting `err` have no effect on what is returned as might be the intention. See below for more. This change refines the code while leaving the current behavior in place because I know a lot of work went into shoring up the file lock race conditions. If returning an error from `lockFile.Unlock()` is the intention, more invasive changes must be made, and this isn't the only usage of this pattern (again, see below).
- My `gofmt` that's part of `1.17.11` _really_ wants to reorganize the imports so I left those changes in since the README explicity states to use `gofmt`.
- Fixed an extra `/` in the comment as mentioned in https://github.com/jfrog/jfrog-cli-core/pull/352#discussion_r872979948.

For bullet point number 2, I see this pattern scattered throughout the code base:

```go
defer func() {
  e := funcThatCanReturnError()
  if err == nil {
    err = e
  }
}()
```

Where it is expected that when the surrounding function returns `err`, could contain the `err` value set in the `defer`. This is not correct. You can observe the true behavior by running the following code which I've also placed in the Go Playground at https://go.dev/play/p/gOQB-jPRu4B:

```go
func deferTest() error {
  err := errors.New("top")
  defer func() { err = errors.New("defer") }()
  return err
}

func deferPatternTest() error {
  var err error = nil
  defer func() {
    e := func() error { return errors.New("defer") }()
    if err == nil {
      err = e
    }
  }()
  return err
}

func main() {
  fmt.Println(deferTest())
  fmt.Println(deferPatternTest())
}
```

which outputs

```shell
$ go run deferdemo.go 
top
<nil>
```
