### PR TITLE
Add verbose flag in the TransferConfig command

### DIFF
--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -3,6 +3,11 @@ package transferconfig
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
 	"github.com/jfrog/gofrog/version"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/generic"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferconfig/configxmlutils"
@@ -18,10 +23,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"io"
-	"net/http"
-	"os"
-	"time"
 )
 
 const (
@@ -37,6 +38,7 @@ type TransferConfigCommand struct {
 	targetServerDetails  *config.ServerDetails
 	dryRun               bool
 	force                bool
+	verbose              bool
 	includeReposPatterns []string
 	excludeReposPatterns []string
 }
@@ -56,6 +58,11 @@ func (tcc *TransferConfigCommand) SetDryRun(dryRun bool) *TransferConfigCommand 
 
 func (tcc *TransferConfigCommand) SetForce(force bool) *TransferConfigCommand {
 	tcc.force = force
+	return tcc
+}
+
+func (tcc *TransferConfigCommand) SetVerbose(verbose bool) *TransferConfigCommand {
+	tcc.verbose = verbose
 	return tcc
 }
 
@@ -249,7 +256,7 @@ func (tcc *TransferConfigCommand) exportSourceArtifactory(sourceServicesManager 
 	exportParams := services.ExportParams{
 		ExportPath:      tempDir,
 		IncludeMetadata: &trueValue,
-		Verbose:         &trueValue,
+		Verbose:         &tcc.verbose,
 		ExcludeContent:  &trueValue,
 	}
 	cleanUp := func() error { return fileutils.RemoveTempDir(tempDir) }

--- a/artifactory/commands/transferconfig/transferconfig_test.go
+++ b/artifactory/commands/transferconfig/transferconfig_test.go
@@ -32,7 +32,7 @@ func TestExportSourceArtifactory(t *testing.T) {
 
 		// Make sure all parameters as expected
 		assert.True(t, *actual.IncludeMetadata)
-		assert.True(t, *actual.Verbose)
+		assert.False(t, *actual.Verbose)
 		assert.True(t, *actual.ExcludeContent)
 		assert.Nil(t, actual.CreateArchive)
 		assert.Nil(t, actual.M2)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Currently, the import shows lots of unnecessary data:
<img width="1731" alt="image" src="https://user-images.githubusercontent.com/11367982/178445377-0fbdd252-e99e-415b-aec6-d3ad9c2b6997.png">

Let's make the verbosity of the import command optional:
<img width="1774" alt="image" src="https://user-images.githubusercontent.com/11367982/178445593-aefc8e4b-1089-4829-b00a-225bc53ffba3.png">
