### PR TITLE
Improve error when target repo is not empty on transfer-config

### DIFF
--- a/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-all.xml
+++ b/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-all.xml
@@ -389,6 +389,85 @@
             <propagateQueryParams>false</propagateQueryParams>
             <disableUrlNormalization>false</disableUrlNormalization>
         </remoteRepository>
+        <remoteRepository>
+            <key>default-go-remote</key>
+            <type>go</type>
+            <description>(local file cache)</description>
+            <notes></notes>
+            <includesPattern>**/*</includesPattern>
+            <excludesPattern></excludesPattern>
+            <repoLayoutRef>maven-2-default</repoLayoutRef>
+            <dockerApiVersion>V2</dockerApiVersion>
+            <forceNugetAuthentication>false</forceNugetAuthentication>
+            <forceConanAuthentication>false</forceConanAuthentication>
+            <ddebSupported>false</ddebSupported>
+            <signedUrlTtl>90</signedUrlTtl>
+            <blackedOut>false</blackedOut>
+            <handleReleases>true</handleReleases>
+            <handleSnapshots>true</handleSnapshots>
+            <maxUniqueSnapshots>0</maxUniqueSnapshots>
+            <maxUniqueTags>0</maxUniqueTags>
+            <blockPushingSchema1>true</blockPushingSchema1>
+            <suppressPomConsistencyChecks>false</suppressPomConsistencyChecks>
+            <propertySets/>
+            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
+            <xray>
+                <enabled>false</enabled>
+                <dataTtl>90</dataTtl>
+            </xray>
+            <downloadRedirect>
+                <enabled>false</enabled>
+            </downloadRedirect>
+            <priorityResolution>false</priorityResolution>
+            <cdnRedirect>
+                <enabled>false</enabled>
+            </cdnRedirect>
+            <url>https://gocenter.io/</url>
+            <offline>false</offline>
+            <hardFail>false</hardFail>
+            <storeArtifactsLocally>true</storeArtifactsLocally>
+            <fetchJarsEagerly>false</fetchJarsEagerly>
+            <fetchSourcesEagerly>false</fetchSourcesEagerly>
+            <retrievalCachePeriodSecs>7200</retrievalCachePeriodSecs>
+            <metadataRetrievalTimeoutSecs>60</metadataRetrievalTimeoutSecs>
+            <assumedOfflinePeriodSecs>300</assumedOfflinePeriodSecs>
+            <missedRetrievalCachePeriodSecs>600</missedRetrievalCachePeriodSecs>
+            <remoteRepoChecksumPolicyType>generate-if-absent</remoteRepoChecksumPolicyType>
+            <unusedArtifactsCleanupPeriodHours>0</unusedArtifactsCleanupPeriodHours>
+            <shareConfiguration>false</shareConfiguration>
+            <synchronizeProperties>false</synchronizeProperties>
+            <listRemoteFolderItems>true</listRemoteFolderItems>
+            <rejectInvalidJars>false</rejectInvalidJars>
+            <vcs>
+                <type>git</type>
+                <git>
+                    <provider>github</provider>
+                </git>
+            </vcs>
+            <contentSynchronisation>
+                <enabled>false</enabled>
+                <statistics>
+                    <enabled>false</enabled>
+                </statistics>
+                <properties>
+                    <enabled>false</enabled>
+                </properties>
+                <source>
+                    <originAbsenceDetection>false</originAbsenceDetection>
+                </source>
+            </contentSynchronisation>
+            <blockMismatchingMimeTypes>false</blockMismatchingMimeTypes>
+            <bypassHeadRequests>false</bypassHeadRequests>
+            <username></username>
+            <password></password>
+            <allowAnyHostAuth>false</allowAnyHostAuth>
+            <socketTimeoutMillis>15000</socketTimeoutMillis>
+            <enableCookieManagement>false</enableCookieManagement>
+            <enableTokenAuthentication>false</enableTokenAuthentication>
+            <localAddress></localAddress>
+            <propagateQueryParams>false</propagateQueryParams>
+            <disableUrlNormalization>false</disableUrlNormalization>
+        </remoteRepository>
     </remoteRepositories>
     <virtualRepositories>
         <virtualRepository>

--- a/artifactory/commands/testdata/config_xmls_exclude_repos/input/artifactory.config.xml
+++ b/artifactory/commands/testdata/config_xmls_exclude_repos/input/artifactory.config.xml
@@ -389,6 +389,85 @@
             <propagateQueryParams>false</propagateQueryParams>
             <disableUrlNormalization>false</disableUrlNormalization>
         </remoteRepository>
+        <remoteRepository>
+            <key>default-go-remote</key>
+            <type>go</type>
+            <description>(local file cache)</description>
+            <notes></notes>
+            <includesPattern>**/*</includesPattern>
+            <excludesPattern></excludesPattern>
+            <repoLayoutRef>maven-2-default</repoLayoutRef>
+            <dockerApiVersion>V2</dockerApiVersion>
+            <forceNugetAuthentication>false</forceNugetAuthentication>
+            <forceConanAuthentication>false</forceConanAuthentication>
+            <ddebSupported>false</ddebSupported>
+            <signedUrlTtl>90</signedUrlTtl>
+            <blackedOut>false</blackedOut>
+            <handleReleases>true</handleReleases>
+            <handleSnapshots>true</handleSnapshots>
+            <maxUniqueSnapshots>0</maxUniqueSnapshots>
+            <maxUniqueTags>0</maxUniqueTags>
+            <blockPushingSchema1>true</blockPushingSchema1>
+            <suppressPomConsistencyChecks>false</suppressPomConsistencyChecks>
+            <propertySets/>
+            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
+            <xray>
+                <enabled>false</enabled>
+                <dataTtl>90</dataTtl>
+            </xray>
+            <downloadRedirect>
+                <enabled>false</enabled>
+            </downloadRedirect>
+            <priorityResolution>false</priorityResolution>
+            <cdnRedirect>
+                <enabled>false</enabled>
+            </cdnRedirect>
+            <url>https://gocenter.io/</url>
+            <offline>false</offline>
+            <hardFail>false</hardFail>
+            <storeArtifactsLocally>true</storeArtifactsLocally>
+            <fetchJarsEagerly>false</fetchJarsEagerly>
+            <fetchSourcesEagerly>false</fetchSourcesEagerly>
+            <retrievalCachePeriodSecs>7200</retrievalCachePeriodSecs>
+            <metadataRetrievalTimeoutSecs>60</metadataRetrievalTimeoutSecs>
+            <assumedOfflinePeriodSecs>300</assumedOfflinePeriodSecs>
+            <missedRetrievalCachePeriodSecs>600</missedRetrievalCachePeriodSecs>
+            <remoteRepoChecksumPolicyType>generate-if-absent</remoteRepoChecksumPolicyType>
+            <unusedArtifactsCleanupPeriodHours>0</unusedArtifactsCleanupPeriodHours>
+            <shareConfiguration>false</shareConfiguration>
+            <synchronizeProperties>false</synchronizeProperties>
+            <listRemoteFolderItems>true</listRemoteFolderItems>
+            <rejectInvalidJars>false</rejectInvalidJars>
+            <vcs>
+                <type>git</type>
+                <git>
+                    <provider>github</provider>
+                </git>
+            </vcs>
+            <contentSynchronisation>
+                <enabled>false</enabled>
+                <statistics>
+                    <enabled>false</enabled>
+                </statistics>
+                <properties>
+                    <enabled>false</enabled>
+                </properties>
+                <source>
+                    <originAbsenceDetection>false</originAbsenceDetection>
+                </source>
+            </contentSynchronisation>
+            <blockMismatchingMimeTypes>false</blockMismatchingMimeTypes>
+            <bypassHeadRequests>false</bypassHeadRequests>
+            <username></username>
+            <password></password>
+            <allowAnyHostAuth>false</allowAnyHostAuth>
+            <socketTimeoutMillis>15000</socketTimeoutMillis>
+            <enableCookieManagement>false</enableCookieManagement>
+            <enableTokenAuthentication>false</enableTokenAuthentication>
+            <localAddress></localAddress>
+            <propagateQueryParams>false</propagateQueryParams>
+            <disableUrlNormalization>false</disableUrlNormalization>
+        </remoteRepository>
     </remoteRepositories>
     <virtualRepositories>
         <virtualRepository>

--- a/artifactory/commands/transferconfig/configxmlutils/includerepos_test.go
+++ b/artifactory/commands/transferconfig/configxmlutils/includerepos_test.go
@@ -17,7 +17,7 @@ var testCases = []struct {
 	{"select-remote", []string{"default-maven-remote"}},
 	{"select-one-from-all", []string{"default-libs-release-local", "default-maven-remote", "default-libs-release"}},
 	{"select-all", []string{"default-libs-release-local", "default-libs-snapshot-local", "default-maven-remote",
-		"ecosys-generic-local", "default-libs-release", "example-repo-local", "ecosys-npm-remote", "default-libs-snapshot"}},
+		"ecosys-generic-local", "default-libs-release", "example-repo-local", "ecosys-npm-remote", "default-go-remote", "default-libs-snapshot"}},
 }
 
 func TestRemoveNonIncludedRepositories(t *testing.T) {

--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -178,7 +178,7 @@ func (tcc *TransferConfigCommand) validateArtifactoryServers(targetServicesManag
 	}
 	// We consider an "empty" Artifactory as an Artifactory server that contains 2 users: the admin user and the anonymous.
 	if len(users) > 2 {
-		return errorutils.CheckErrorf("cowardly refusing to import the config to the target server, because it contains more than 2 users. You can bypass this rule by providing the --force flag.")
+		return errorutils.CheckErrorf("cowardly refusing to import the config to the target server, because it contains more than 2 users. By default, this command avoids transferring the config to a server which isn't empty. You can bypass this rule by providing the --force flag to the transfer-config command.")
 	}
 	return nil
 }

--- a/artifactory/commands/transferconfig/transferconfig_test.go
+++ b/artifactory/commands/transferconfig/transferconfig_test.go
@@ -133,7 +133,7 @@ func TestSanityVerifications(t *testing.T) {
 
 	// Test 3 users
 	err = transferConfigCmd.validateArtifactoryServers(serviceManager, minArtifactoryVersion)
-	assert.ErrorContains(t, err, "cowardly refusing to import the config to the target server, because it contains more than 2 users. You can bypass this rule by providing the --force flag")
+	assert.ErrorContains(t, err, "cowardly refusing to import the config to the target server, because it contains more than 2 users.")
 
 	// Assert force = true
 	transferConfigCmd.force = true


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Improved log in transfer-config command when the target repository is not empty.
Test parsing config descriptor with remote Go repository that includes VCS configuration.