### PR TITLE
Exclude metadata on config export

### DIFF
--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -253,9 +253,10 @@ func (tcc *TransferConfigCommand) exportSourceArtifactory(sourceServicesManager 
 
 	// Do export
 	trueValue := true
+	falseValue := false
 	exportParams := services.ExportParams{
 		ExportPath:      tempDir,
-		IncludeMetadata: &trueValue,
+		IncludeMetadata: &falseValue,
 		Verbose:         &tcc.verbose,
 		ExcludeContent:  &trueValue,
 	}

--- a/artifactory/commands/transferconfig/transferconfig_test.go
+++ b/artifactory/commands/transferconfig/transferconfig_test.go
@@ -31,7 +31,7 @@ func TestExportSourceArtifactory(t *testing.T) {
 		assert.NoError(t, json.Unmarshal(content, &actual))
 
 		// Make sure all parameters as expected
-		assert.True(t, *actual.IncludeMetadata)
+		assert.False(t, *actual.IncludeMetadata)
 		assert.False(t, *actual.Verbose)
 		assert.True(t, *actual.ExcludeContent)
 		assert.Nil(t, actual.CreateArchive)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
During the transfer config command, we don't need the metadata, since the hybrid migration import already excludes it by default.
Let's remove it from the export. 