### PR TITLE
Config transfer - fail if errors found in the logs

### DIFF
--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/jfrog/gofrog/version"
@@ -353,6 +354,9 @@ func (tcc *TransferConfigCommand) waitForImportCompletion(targetServicesManager 
 		return err
 	}
 	log.Info(fmt.Sprintf("Logs from Artifactory:\n%s", body))
+	if strings.Contains(string(body), "[ERROR]") {
+		return errorutils.CheckErrorf("Errors detected during config import. Hint: To skip failed repositories, please refer to the '--exclude-repos' flag.")
+	}
 	return nil
 }
 

--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -355,7 +355,7 @@ func (tcc *TransferConfigCommand) waitForImportCompletion(targetServicesManager 
 	}
 	log.Info(fmt.Sprintf("Logs from Artifactory:\n%s", body))
 	if strings.Contains(string(body), "[ERROR]") {
-		return errorutils.CheckErrorf("Errors detected during config import. Hint: To skip failed repositories, please refer to the '--exclude-repos' flag.")
+		return errorutils.CheckErrorf("Errors detected during config import. Hint: You can skip transferring some Artifactory repositories by using the '--exclude-repos' command option. Run 'jf rt transfer-config -h' for more information.")
 	}
 	return nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
* Fail the transfer-config command if `[ERROR]` exists in the import logs.
* Add a hint to use the `--exclude-repos` flag.

Example:
![image](https://user-images.githubusercontent.com/11367982/179777039-208025bf-86c0-4ac7-876a-86b22a60691e.png)
