### PR TITLE
Fix: Missing "ForceNugetAuthentication" in repository template

### DIFF
--- a/artifactory/commands/repository/repository.go
+++ b/artifactory/commands/repository/repository.go
@@ -150,6 +150,7 @@ var writersMap = map[string]utils.AnswerWriter{
 	PomRepositoryReferencesCleanupPolicy: utils.WriteStringAnswer,
 	DefaultDeploymentRepo:                utils.WriteStringAnswer,
 	ForceMavenAuthentication:             utils.WriteBoolAnswer,
+	ForceNugetAuthentication:             utils.WriteBoolAnswer,
 	ExternalDependenciesRemoteRepo:       utils.WriteStringAnswer,
 }
 

--- a/artifactory/commands/repository/template.go
+++ b/artifactory/commands/repository/template.go
@@ -290,6 +290,7 @@ var optionalSuggestsMap = map[string]prompt.Suggest{
 	PomRepositoryReferencesCleanupPolicy: {Text: PomRepositoryReferencesCleanupPolicy},
 	DefaultDeploymentRepo:                {Text: DefaultDeploymentRepo},
 	ForceMavenAuthentication:             {Text: ForceMavenAuthentication},
+	ForceNugetAuthentication:             {Text: ForceNugetAuthentication},
 	ExternalDependenciesRemoteRepo:       {Text: ExternalDependenciesRemoteRepo},
 }
 
@@ -921,5 +922,6 @@ var questionMap = map[string]utils.QuestionInfo{
 	},
 	DefaultDeploymentRepo:          utils.FreeStringQuestionInfo,
 	ForceMavenAuthentication:       BoolToStringQuestionInfo,
+	ForceNugetAuthentication:       BoolToStringQuestionInfo,
 	ExternalDependenciesRemoteRepo: utils.FreeStringQuestionInfo,
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fix this issue: https://github.com/jfrog/jfrog-cli-core/issues/330
Not possible to create a nuget local or remote repository with the "ForceNugetAuthentication" option enabled.

Approved in this PR: https://github.com/jfrog/jfrog-cli-core/pull/408    