### PR TITLE
Revert "Fix URI calculation on Xray and Artifcatory CURL commands."

### DIFF
--- a/common/commands/curl.go
+++ b/common/commands/curl.go
@@ -144,13 +144,39 @@ func (curlCmd *CurlCommand) GetServerDetails() (*config.ServerDetails, error) {
 }
 
 // Find the URL argument in the Curl Command.
-// By convention, all the Artifactory and Xray URIs starts with /api/ or api/
+// A command flag is prefixed by '-' or '--'.
+// Use this method ONLY after removing all JFrog-CLI flags, i.e. flags in the form: '--my-flag=value' are not allowed.
+// An argument is any provided candidate which is not a flag or a flag value.
 func (curlCmd *CurlCommand) findUriValueAndIndex() (int, string) {
+	skipThisArg := false
 	for index, arg := range curlCmd.arguments {
-		if strings.HasPrefix(arg, "/api/") || strings.HasPrefix(arg, "api/") {
-			return index, arg
+		// Check if shouldn't check current arg.
+		if skipThisArg {
+			skipThisArg = false
+			continue
 		}
+
+		// If starts with '--', meaning a flag which its value is at next slot.
+		if strings.HasPrefix(arg, "--") {
+			skipThisArg = true
+			continue
+		}
+
+		// Check if '-'.
+		if strings.HasPrefix(arg, "-") {
+			if len(arg) > 2 {
+				// Meaning that this flag also contains its value.
+				continue
+			}
+			// If reached here, means that the flag value is at the next arg.
+			skipThisArg = true
+			continue
+		}
+
+		// Found an argument
+		return index, arg
 	}
+
 	// If reached here, didn't find an argument.
 	return -1, ""
 }

--- a/common/commands/curl_test.go
+++ b/common/commands/curl_test.go
@@ -7,18 +7,18 @@ import (
 func TestFindNextArg(t *testing.T) {
 	command := &CurlCommand{}
 	args := [][]string{
-		{"-X", "GET", "/api/arg1", "--foo", "bar"},
+		{"-X", "GET", "arg1", "--foo", "bar"},
 		{"-X", "GET", "--server-idea", "foo", "/api/arg2"},
-		{"-XGET", "--foo", "bar", "--foo-bar", "meow", "/api/arg3"},
+		{"-XGET", "--foo", "bar", "--foo-bar", "meow", "arg3"},
 	}
 
 	expected := []struct {
 		int
 		string
 	}{
-		{2, "/api/arg1"},
+		{2, "arg1"},
 		{4, "/api/arg2"},
-		{5, "/api/arg3"},
+		{5, "arg3"},
 	}
 
 	for index, test := range args {


### PR DESCRIPTION
Reverts jfrog/jfrog-cli-core#435

Reverted because of unexpected breaking changes.