### PR TITLE
Expose transfer variables to allow testing

### DIFF
--- a/artifactory/commands/transferfiles/api.go
+++ b/artifactory/commands/transferfiles/api.go
@@ -101,7 +101,7 @@ type UuidTokenResponse struct {
 
 // Fill tokens batch till full. Return if no new tokens are available.
 func (ucs *UploadChunksStatusBody) fillTokensBatch(uploadTokensChan chan string) {
-	for len(ucs.UuidTokens) < getThreads() {
+	for len(ucs.UuidTokens) < GetThreads() {
 		select {
 		case token := <-uploadTokensChan:
 			ucs.UuidTokens = append(ucs.UuidTokens, token)

--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -3,6 +3,10 @@ package transferfiles
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"os"
+	"time"
+
 	"github.com/jfrog/gofrog/parallel"
 	coreConfig "github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/progressbar"
@@ -10,9 +14,6 @@ import (
 	clientUtils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"math"
-	"os"
-	"time"
 )
 
 // When handling files diff, we split the whole time range being handled by searchTimeFramesMinutes in order to receive smaller results from the AQLs.
@@ -185,7 +186,7 @@ func (f *filesDiffPhase) handleTimeFrameFilesDiff(params timeFrameParams, logMsg
 			return err
 		}
 
-		if len(result.Results) < aqlPaginationLimit {
+		if len(result.Results) < AqlPaginationLimit {
 			break
 		}
 		paginationI++
@@ -220,7 +221,7 @@ func (f *filesDiffPhase) getTimeFrameFilesDiff(repoKey, fromTimestamp, toTimesta
 func generateDiffAqlQuery(repoKey, fromTimestamp, toTimestamp string, paginationOffset int) string {
 	query := fmt.Sprintf(`items.find({"$and":[{"modified":{"$gte":"%s"}},{"modified":{"$lt":"%s"}},{"repo":"%s","path":{"$match":"*"},"name":{"$match":"*"}}]})`, fromTimestamp, toTimestamp, repoKey)
 	query += `.include("repo","path","name","modified")`
-	query += fmt.Sprintf(`.sort({"$asc":["modified"]}).offset(%d).limit(%d)`, paginationOffset*aqlPaginationLimit, aqlPaginationLimit)
+	query += fmt.Sprintf(`.sort({"$asc":["modified"]}).offset(%d).limit(%d)`, paginationOffset*AqlPaginationLimit, AqlPaginationLimit)
 	return query
 }
 

--- a/artifactory/commands/transferfiles/fulltransfer.go
+++ b/artifactory/commands/transferfiles/fulltransfer.go
@@ -2,14 +2,15 @@ package transferfiles
 
 import (
 	"fmt"
+	"path"
+	"time"
+
 	"github.com/jfrog/gofrog/parallel"
 	coreConfig "github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/progressbar"
 	servicesUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	clientUtils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"path"
-	"time"
 )
 
 // Manages the phase of performing a full transfer of the repository.
@@ -213,7 +214,7 @@ func (m *fullTransferPhase) transferFolder(params folderParams, logMsgPrefix str
 			}
 		}
 
-		if len(result.Results) < aqlPaginationLimit {
+		if len(result.Results) < AqlPaginationLimit {
 			break
 		}
 		paginationI++
@@ -244,6 +245,6 @@ func (m *fullTransferPhase) getDirectoryContentsAql(repoKey, relativePath string
 func generateFolderContentsAqlQuery(repoKey, relativePath string, paginationOffset int) string {
 	query := fmt.Sprintf(`items.find({"type":"any","$or":[{"$and":[{"repo":"%s","path":{"$match":"%s"},"name":{"$match":"*"}}]}]})`, repoKey, relativePath)
 	query += `.include("repo","path","name","type")`
-	query += fmt.Sprintf(`.sort({"$asc":["name"]}).offset(%d).limit(%d)`, paginationOffset*aqlPaginationLimit, aqlPaginationLimit)
+	query += fmt.Sprintf(`.sort({"$asc":["name"]}).offset(%d).limit(%d)`, paginationOffset*AqlPaginationLimit, AqlPaginationLimit)
 	return query
 }

--- a/artifactory/commands/transferfiles/manager.go
+++ b/artifactory/commands/transferfiles/manager.go
@@ -2,11 +2,12 @@ package transferfiles
 
 import (
 	"fmt"
+	"sync"
+
 	"github.com/jfrog/gofrog/parallel"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/progressbar"
 	clientUtils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"sync"
 )
 
 const totalNumberPollingGoRoutines = 2
@@ -186,7 +187,7 @@ func (ptm *PollingTasksManager) stop() {
 }
 
 func initProducerConsumer() producerConsumerDetails {
-	producerConsumer := parallel.NewRunner(getThreads(), tasksMaxCapacity, false)
+	producerConsumer := parallel.NewRunner(GetThreads(), tasksMaxCapacity, false)
 	errorsQueue := clientUtils.NewErrorsQueue(1)
 
 	return producerConsumerDetails{

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -2,6 +2,11 @@ package transferfiles
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"strconv"
+	"sync"
+	"time"
+
 	"github.com/jfrog/gofrog/parallel"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	coreConfig "github.com/jfrog/jfrog-cli-core/v2/utils/config"
@@ -9,19 +14,16 @@ import (
 	serviceUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"io/ioutil"
-	"strconv"
-	"sync"
-	"time"
 )
 
 const (
 	waitTimeBetweenChunkStatusSeconds            = 3
 	waitTimeBetweenThreadsUpdateSeconds          = 20
 	assumeProducerConsumerDoneWhenIdleForSeconds = 15
-	aqlPaginationLimit                           = 10000
+	DefaultAqlPaginationLimit                    = 10000
 )
 
+var AqlPaginationLimit = DefaultAqlPaginationLimit
 var curThreads int
 
 func createSrcRtUserPluginServiceManager(sourceRtDetails *coreConfig.ServerDetails) (*srcUserPluginService, error) {
@@ -132,7 +134,7 @@ func pollUploads(srcUpService *srcUserPluginService, uploadTokensChan chan strin
 func incrCurProcessedChunksWhenPossible() bool {
 	processedUploadChunksMutex.Lock()
 	defer processedUploadChunksMutex.Unlock()
-	if curProcessedUploadChunks < getThreads() {
+	if curProcessedUploadChunks < GetThreads() {
 		curProcessedUploadChunks++
 		return true
 	}
@@ -239,7 +241,7 @@ func verifyRepoExistsInTarget(targetRepos []string, srcRepoKey string) bool {
 	return false
 }
 
-func getThreads() int {
+func GetThreads() int {
 	return curThreads
 }
 

--- a/artifactory/utils/transfersettings_test.go
+++ b/artifactory/utils/transfersettings_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoConfig(t *testing.T) {
+	// Set testing environment
+	cleanUpJfrogHome, err := tests.SetJfrogHome()
+	assert.NoError(t, err)
+	defer cleanUpJfrogHome()
+
+	// Load transfer settings and make sure nil is returned
+	settings, err := LoadTransferSettings()
+	assert.NoError(t, err)
+	assert.Nil(t, settings)
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	// Set testing environment
+	cleanUpJfrogHome, err := tests.SetJfrogHome()
+	assert.NoError(t, err)
+	defer cleanUpJfrogHome()
+
+	// Save transfer settings with 10 threads
+	conf := &TransferSettings{ThreadsNumber: 10}
+	assert.NoError(t, SaveTransferSettings(conf))
+
+	// Load transfer settings and make sure the number of threads is 10
+	settings, err := LoadTransferSettings()
+	assert.NoError(t, err)
+	assert.Equal(t, 10, settings.ThreadsNumber)
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Required for https://github.com/jfrog/jfrog-cli/pull/1632
To help with the integration tests in the jfrog-cli, expose the following variables:
* Rename aqlPaginationLimit -> AqlPaginationLimit 
* Rename getThreads() -> GetThreads

Add missing unit test of `transfersettings.go`.