### PR TITLE
Transfer - Increase graceful-stop attempts

### DIFF
--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -194,7 +194,7 @@ func (tdc *TransferFilesCommand) handleStop(shouldStop *bool, newPhase *transfer
 		if err != nil {
 			log.Error(err)
 		} else {
-			stopAllRunningNodes(srcUpService, runningNodes)
+			stopTransferOnArtifactoryNodes(srcUpService, runningNodes)
 		}
 	}()
 

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -372,15 +372,16 @@ func getRunningNodes(sourceRtDetails *coreConfig.ServerDetails) ([]string, error
 	return serviceManager.GetRunningNodes()
 }
 
-func stopAllRunningNodes(srcUpService *srcUserPluginService, runningNodes []string) {
+func stopTransferOnArtifactoryNodes(srcUpService *srcUserPluginService, runningNodes []string) {
 	remainingNodesToStop := make(map[string]string)
 	for _, s := range runningNodes {
 		remainingNodesToStop[s] = s
 	}
-	log.Debug("Running nodes to stop:", remainingNodesToStop)
-	for i := 0; i < len(runningNodes)*3; i++ {
+	log.Debug("Running Artifactory nodes to stop transfer on:", remainingNodesToStop)
+	// Send a stop command up to 5 times the number of Artifactory nodes, to make sure we reach out to all nodes
+	for i := 0; i < len(runningNodes)*5; i++ {
 		if len(remainingNodesToStop) == 0 {
-			log.Debug("All running nodes stopped successfully")
+			log.Debug("Transfer on all Artifactory nodes stopped successfully")
 			return
 		}
 		nodeId, err := srcUpService.stop()

--- a/artifactory/commands/transferfiles/utils_test.go
+++ b/artifactory/commands/transferfiles/utils_test.go
@@ -85,7 +85,7 @@ func TestGetRunningNodes(t *testing.T) {
 	assert.ElementsMatch(t, runningNodes, []string{"node-1", "node-2", "node-3"})
 }
 
-func TestStopAllRunningNodes(t *testing.T) {
+func TestStopTransferOnArtifactoryNodes(t *testing.T) {
 	stoppedNodeOne, stoppedNodeTwo := false, false
 	requestNumber := 0
 	testServer, _, srcUpService := createMockServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -104,7 +104,7 @@ func TestStopAllRunningNodes(t *testing.T) {
 	})
 	defer testServer.Close()
 
-	stopAllRunningNodes(srcUpService, []string{"node-1", "node-2"})
+	stopTransferOnArtifactoryNodes(srcUpService, []string{"node-1", "node-2"})
 	assert.True(t, stoppedNodeOne)
 	assert.True(t, stoppedNodeTwo)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
* Increase the number of stop attempts in graceful stopping to (5 X Artifactory nodes).
* Implement @eyalbe4 comments in https://github.com/jfrog/jfrog-cli-core/pull/452