### PR TITLE
Transfer - support build-info and rb repositories

### DIFF
--- a/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-all.xml
+++ b/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-all.xml
@@ -524,7 +524,37 @@
         </virtualRepository>
     </virtualRepositories>
     <federatedRepositories/>
-    <releaseBundlesRepositories/>
+    <releaseBundlesRepositories>
+        <releaseBundlesRepository>
+            <key>release-bundles</key>
+            <type>releasebundles</type>
+            <includesPattern>**/*</includesPattern>
+            <dockerApiVersion>V2</dockerApiVersion>
+            <forceNugetAuthentication>false</forceNugetAuthentication>
+            <forceConanAuthentication>false</forceConanAuthentication>
+            <ddebSupported>false</ddebSupported>
+            <signedUrlTtl>90</signedUrlTtl>
+            <blackedOut>false</blackedOut>
+            <handleReleases>true</handleReleases>
+            <handleSnapshots>true</handleSnapshots>
+            <maxUniqueSnapshots>0</maxUniqueSnapshots>
+            <maxUniqueTags>0</maxUniqueTags>
+            <blockPushingSchema1>true</blockPushingSchema1>
+            <suppressPomConsistencyChecks>true</suppressPomConsistencyChecks>
+            <propertySets/>
+            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
+            <priorityResolution>false</priorityResolution>
+            <snapshotVersionBehavior>unique</snapshotVersionBehavior>
+            <localRepoChecksumPolicyType>client-checksums</localRepoChecksumPolicyType>
+            <calculateYumMetadata>false</calculateYumMetadata>
+            <yumRootDepth>0</yumRootDepth>
+            <debianTrivialLayout>false</debianTrivialLayout>
+            <enableFileListsIndexing>false</enableFileListsIndexing>
+            <dockerTagRetention>1</dockerTagRetention>
+            <enableComposerV1Indexing>false</enableComposerV1Indexing>
+            <terraformType>MODULE</terraformType>
+        </releaseBundlesRepository>
+    </releaseBundlesRepositories>
     <proxies/>
     <reverseProxies>
         <reverseProxy>

--- a/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-local.xml
+++ b/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-local.xml
@@ -74,41 +74,7 @@
         <enabled>false</enabled>
         <cronExp>0 23 5 * * ?</cronExp>
     </indexer>
-    <localRepositories>
-        <localRepository>
-            <key>artifactory-build-info</key>
-            <type>buildinfo</type>
-            <description>Build Info repository</description>
-            <includesPattern>**/*</includesPattern>
-            <repoLayoutRef>simple-default</repoLayoutRef>
-            <dockerApiVersion>V2</dockerApiVersion>
-            <forceNugetAuthentication>false</forceNugetAuthentication>
-            <forceConanAuthentication>false</forceConanAuthentication>
-            <ddebSupported>false</ddebSupported>
-            <signedUrlTtl>30</signedUrlTtl>
-            <blackedOut>false</blackedOut>
-            <handleReleases>true</handleReleases>
-            <handleSnapshots>true</handleSnapshots>
-            <maxUniqueSnapshots>0</maxUniqueSnapshots>
-            <maxUniqueTags>0</maxUniqueTags>
-            <blockPushingSchema1>true</blockPushingSchema1>
-            <suppressPomConsistencyChecks>true</suppressPomConsistencyChecks>
-            <propertySets>
-                <propertySetRef>artifactory</propertySetRef>
-            </propertySets>
-            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
-            <priorityResolution>false</priorityResolution>
-            <snapshotVersionBehavior>unique</snapshotVersionBehavior>
-            <localRepoChecksumPolicyType>client-checksums</localRepoChecksumPolicyType>
-            <calculateYumMetadata>false</calculateYumMetadata>
-            <yumRootDepth>0</yumRootDepth>
-            <debianTrivialLayout>false</debianTrivialLayout>
-            <enableFileListsIndexing>false</enableFileListsIndexing>
-            <dockerTagRetention>1</dockerTagRetention>
-            <enableComposerV1Indexing>false</enableComposerV1Indexing>
-            <terraformType>MODULE</terraformType>
-        </localRepository>
-        <localRepository>
+    <localRepositories><localRepository>
             <key>default-libs-release-local</key>
             <type>maven</type>
             <includesPattern>**/*</includesPattern>
@@ -138,40 +104,11 @@
             <enableComposerV1Indexing>false</enableComposerV1Indexing>
             <terraformType>MODULE</terraformType>
         </localRepository>
-        <localRepository>
-            <key>ecosys-build-info</key>
-            <type>buildinfo</type>
-            <includesPattern>**/*</includesPattern>
-            <dockerApiVersion>V2</dockerApiVersion>
-            <forceNugetAuthentication>false</forceNugetAuthentication>
-            <forceConanAuthentication>false</forceConanAuthentication>
-            <ddebSupported>false</ddebSupported>
-            <signedUrlTtl>90</signedUrlTtl>
-            <blackedOut>false</blackedOut>
-            <handleReleases>true</handleReleases>
-            <handleSnapshots>true</handleSnapshots>
-            <maxUniqueSnapshots>0</maxUniqueSnapshots>
-            <maxUniqueTags>0</maxUniqueTags>
-            <blockPushingSchema1>true</blockPushingSchema1>
-            <suppressPomConsistencyChecks>true</suppressPomConsistencyChecks>
-            <propertySets/>
-            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
-            <priorityResolution>false</priorityResolution>
-            <snapshotVersionBehavior>unique</snapshotVersionBehavior>
-            <localRepoChecksumPolicyType>client-checksums</localRepoChecksumPolicyType>
-            <calculateYumMetadata>false</calculateYumMetadata>
-            <yumRootDepth>0</yumRootDepth>
-            <debianTrivialLayout>false</debianTrivialLayout>
-            <enableFileListsIndexing>false</enableFileListsIndexing>
-            <dockerTagRetention>1</dockerTagRetention>
-            <enableComposerV1Indexing>false</enableComposerV1Indexing>
-            <terraformType>MODULE</terraformType>
-        </localRepository>
         </localRepositories>
     <remoteRepositories></remoteRepositories>
     <virtualRepositories></virtualRepositories>
     <federatedRepositories/>
-    <releaseBundlesRepositories/>
+    <releaseBundlesRepositories></releaseBundlesRepositories>
     <proxies/>
     <reverseProxies>
         <reverseProxy>

--- a/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-one-from-all.xml
+++ b/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-one-from-all.xml
@@ -74,41 +74,7 @@
         <enabled>false</enabled>
         <cronExp>0 23 5 * * ?</cronExp>
     </indexer>
-    <localRepositories>
-        <localRepository>
-            <key>artifactory-build-info</key>
-            <type>buildinfo</type>
-            <description>Build Info repository</description>
-            <includesPattern>**/*</includesPattern>
-            <repoLayoutRef>simple-default</repoLayoutRef>
-            <dockerApiVersion>V2</dockerApiVersion>
-            <forceNugetAuthentication>false</forceNugetAuthentication>
-            <forceConanAuthentication>false</forceConanAuthentication>
-            <ddebSupported>false</ddebSupported>
-            <signedUrlTtl>30</signedUrlTtl>
-            <blackedOut>false</blackedOut>
-            <handleReleases>true</handleReleases>
-            <handleSnapshots>true</handleSnapshots>
-            <maxUniqueSnapshots>0</maxUniqueSnapshots>
-            <maxUniqueTags>0</maxUniqueTags>
-            <blockPushingSchema1>true</blockPushingSchema1>
-            <suppressPomConsistencyChecks>true</suppressPomConsistencyChecks>
-            <propertySets>
-                <propertySetRef>artifactory</propertySetRef>
-            </propertySets>
-            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
-            <priorityResolution>false</priorityResolution>
-            <snapshotVersionBehavior>unique</snapshotVersionBehavior>
-            <localRepoChecksumPolicyType>client-checksums</localRepoChecksumPolicyType>
-            <calculateYumMetadata>false</calculateYumMetadata>
-            <yumRootDepth>0</yumRootDepth>
-            <debianTrivialLayout>false</debianTrivialLayout>
-            <enableFileListsIndexing>false</enableFileListsIndexing>
-            <dockerTagRetention>1</dockerTagRetention>
-            <enableComposerV1Indexing>false</enableComposerV1Indexing>
-            <terraformType>MODULE</terraformType>
-        </localRepository>
-        <localRepository>
+    <localRepositories><localRepository>
             <key>default-libs-release-local</key>
             <type>maven</type>
             <includesPattern>**/*</includesPattern>
@@ -125,35 +91,6 @@
             <maxUniqueTags>0</maxUniqueTags>
             <blockPushingSchema1>true</blockPushingSchema1>
             <suppressPomConsistencyChecks>false</suppressPomConsistencyChecks>
-            <propertySets/>
-            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
-            <priorityResolution>false</priorityResolution>
-            <snapshotVersionBehavior>unique</snapshotVersionBehavior>
-            <localRepoChecksumPolicyType>client-checksums</localRepoChecksumPolicyType>
-            <calculateYumMetadata>false</calculateYumMetadata>
-            <yumRootDepth>0</yumRootDepth>
-            <debianTrivialLayout>false</debianTrivialLayout>
-            <enableFileListsIndexing>false</enableFileListsIndexing>
-            <dockerTagRetention>1</dockerTagRetention>
-            <enableComposerV1Indexing>false</enableComposerV1Indexing>
-            <terraformType>MODULE</terraformType>
-        </localRepository>
-        <localRepository>
-            <key>ecosys-build-info</key>
-            <type>buildinfo</type>
-            <includesPattern>**/*</includesPattern>
-            <dockerApiVersion>V2</dockerApiVersion>
-            <forceNugetAuthentication>false</forceNugetAuthentication>
-            <forceConanAuthentication>false</forceConanAuthentication>
-            <ddebSupported>false</ddebSupported>
-            <signedUrlTtl>90</signedUrlTtl>
-            <blackedOut>false</blackedOut>
-            <handleReleases>true</handleReleases>
-            <handleSnapshots>true</handleSnapshots>
-            <maxUniqueSnapshots>0</maxUniqueSnapshots>
-            <maxUniqueTags>0</maxUniqueTags>
-            <blockPushingSchema1>true</blockPushingSchema1>
-            <suppressPomConsistencyChecks>true</suppressPomConsistencyChecks>
             <propertySets/>
             <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
             <priorityResolution>false</priorityResolution>
@@ -258,7 +195,37 @@
         </virtualRepository>
         </virtualRepositories>
     <federatedRepositories/>
-    <releaseBundlesRepositories/>
+    <releaseBundlesRepositories>
+        <releaseBundlesRepository>
+            <key>release-bundles</key>
+            <type>releasebundles</type>
+            <includesPattern>**/*</includesPattern>
+            <dockerApiVersion>V2</dockerApiVersion>
+            <forceNugetAuthentication>false</forceNugetAuthentication>
+            <forceConanAuthentication>false</forceConanAuthentication>
+            <ddebSupported>false</ddebSupported>
+            <signedUrlTtl>90</signedUrlTtl>
+            <blackedOut>false</blackedOut>
+            <handleReleases>true</handleReleases>
+            <handleSnapshots>true</handleSnapshots>
+            <maxUniqueSnapshots>0</maxUniqueSnapshots>
+            <maxUniqueTags>0</maxUniqueTags>
+            <blockPushingSchema1>true</blockPushingSchema1>
+            <suppressPomConsistencyChecks>true</suppressPomConsistencyChecks>
+            <propertySets/>
+            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
+            <priorityResolution>false</priorityResolution>
+            <snapshotVersionBehavior>unique</snapshotVersionBehavior>
+            <localRepoChecksumPolicyType>client-checksums</localRepoChecksumPolicyType>
+            <calculateYumMetadata>false</calculateYumMetadata>
+            <yumRootDepth>0</yumRootDepth>
+            <debianTrivialLayout>false</debianTrivialLayout>
+            <enableFileListsIndexing>false</enableFileListsIndexing>
+            <dockerTagRetention>1</dockerTagRetention>
+            <enableComposerV1Indexing>false</enableComposerV1Indexing>
+            <terraformType>MODULE</terraformType>
+        </releaseBundlesRepository>
+    </releaseBundlesRepositories>
     <proxies/>
     <reverseProxies>
         <reverseProxy>

--- a/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-release-bundle.xml
+++ b/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-release-bundle.xml
@@ -78,7 +78,37 @@
     <remoteRepositories></remoteRepositories>
     <virtualRepositories></virtualRepositories>
     <federatedRepositories/>
-    <releaseBundlesRepositories></releaseBundlesRepositories>
+    <releaseBundlesRepositories>
+        <releaseBundlesRepository>
+            <key>release-bundles</key>
+            <type>releasebundles</type>
+            <includesPattern>**/*</includesPattern>
+            <dockerApiVersion>V2</dockerApiVersion>
+            <forceNugetAuthentication>false</forceNugetAuthentication>
+            <forceConanAuthentication>false</forceConanAuthentication>
+            <ddebSupported>false</ddebSupported>
+            <signedUrlTtl>90</signedUrlTtl>
+            <blackedOut>false</blackedOut>
+            <handleReleases>true</handleReleases>
+            <handleSnapshots>true</handleSnapshots>
+            <maxUniqueSnapshots>0</maxUniqueSnapshots>
+            <maxUniqueTags>0</maxUniqueTags>
+            <blockPushingSchema1>true</blockPushingSchema1>
+            <suppressPomConsistencyChecks>true</suppressPomConsistencyChecks>
+            <propertySets/>
+            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
+            <priorityResolution>false</priorityResolution>
+            <snapshotVersionBehavior>unique</snapshotVersionBehavior>
+            <localRepoChecksumPolicyType>client-checksums</localRepoChecksumPolicyType>
+            <calculateYumMetadata>false</calculateYumMetadata>
+            <yumRootDepth>0</yumRootDepth>
+            <debianTrivialLayout>false</debianTrivialLayout>
+            <enableFileListsIndexing>false</enableFileListsIndexing>
+            <dockerTagRetention>1</dockerTagRetention>
+            <enableComposerV1Indexing>false</enableComposerV1Indexing>
+            <terraformType>MODULE</terraformType>
+        </releaseBundlesRepository>
+    </releaseBundlesRepositories>
     <proxies/>
     <reverseProxies>
         <reverseProxy>

--- a/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-remote.xml
+++ b/artifactory/commands/testdata/config_xmls_exclude_repos/cases/select-remote.xml
@@ -74,70 +74,7 @@
         <enabled>false</enabled>
         <cronExp>0 23 5 * * ?</cronExp>
     </indexer>
-    <localRepositories>
-        <localRepository>
-            <key>artifactory-build-info</key>
-            <type>buildinfo</type>
-            <description>Build Info repository</description>
-            <includesPattern>**/*</includesPattern>
-            <repoLayoutRef>simple-default</repoLayoutRef>
-            <dockerApiVersion>V2</dockerApiVersion>
-            <forceNugetAuthentication>false</forceNugetAuthentication>
-            <forceConanAuthentication>false</forceConanAuthentication>
-            <ddebSupported>false</ddebSupported>
-            <signedUrlTtl>30</signedUrlTtl>
-            <blackedOut>false</blackedOut>
-            <handleReleases>true</handleReleases>
-            <handleSnapshots>true</handleSnapshots>
-            <maxUniqueSnapshots>0</maxUniqueSnapshots>
-            <maxUniqueTags>0</maxUniqueTags>
-            <blockPushingSchema1>true</blockPushingSchema1>
-            <suppressPomConsistencyChecks>true</suppressPomConsistencyChecks>
-            <propertySets>
-                <propertySetRef>artifactory</propertySetRef>
-            </propertySets>
-            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
-            <priorityResolution>false</priorityResolution>
-            <snapshotVersionBehavior>unique</snapshotVersionBehavior>
-            <localRepoChecksumPolicyType>client-checksums</localRepoChecksumPolicyType>
-            <calculateYumMetadata>false</calculateYumMetadata>
-            <yumRootDepth>0</yumRootDepth>
-            <debianTrivialLayout>false</debianTrivialLayout>
-            <enableFileListsIndexing>false</enableFileListsIndexing>
-            <dockerTagRetention>1</dockerTagRetention>
-            <enableComposerV1Indexing>false</enableComposerV1Indexing>
-            <terraformType>MODULE</terraformType>
-        </localRepository>
-        <localRepository>
-            <key>ecosys-build-info</key>
-            <type>buildinfo</type>
-            <includesPattern>**/*</includesPattern>
-            <dockerApiVersion>V2</dockerApiVersion>
-            <forceNugetAuthentication>false</forceNugetAuthentication>
-            <forceConanAuthentication>false</forceConanAuthentication>
-            <ddebSupported>false</ddebSupported>
-            <signedUrlTtl>90</signedUrlTtl>
-            <blackedOut>false</blackedOut>
-            <handleReleases>true</handleReleases>
-            <handleSnapshots>true</handleSnapshots>
-            <maxUniqueSnapshots>0</maxUniqueSnapshots>
-            <maxUniqueTags>0</maxUniqueTags>
-            <blockPushingSchema1>true</blockPushingSchema1>
-            <suppressPomConsistencyChecks>true</suppressPomConsistencyChecks>
-            <propertySets/>
-            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
-            <priorityResolution>false</priorityResolution>
-            <snapshotVersionBehavior>unique</snapshotVersionBehavior>
-            <localRepoChecksumPolicyType>client-checksums</localRepoChecksumPolicyType>
-            <calculateYumMetadata>false</calculateYumMetadata>
-            <yumRootDepth>0</yumRootDepth>
-            <debianTrivialLayout>false</debianTrivialLayout>
-            <enableFileListsIndexing>false</enableFileListsIndexing>
-            <dockerTagRetention>1</dockerTagRetention>
-            <enableComposerV1Indexing>false</enableComposerV1Indexing>
-            <terraformType>MODULE</terraformType>
-        </localRepository>
-        </localRepositories>
+    <localRepositories></localRepositories>
     <remoteRepositories>
         <remoteRepository>
             <key>default-maven-remote</key>
@@ -201,7 +138,7 @@
         </remoteRepositories>
     <virtualRepositories></virtualRepositories>
     <federatedRepositories/>
-    <releaseBundlesRepositories/>
+    <releaseBundlesRepositories></releaseBundlesRepositories>
     <proxies/>
     <reverseProxies>
         <reverseProxy>

--- a/artifactory/commands/testdata/config_xmls_exclude_repos/input/artifactory.config.xml
+++ b/artifactory/commands/testdata/config_xmls_exclude_repos/input/artifactory.config.xml
@@ -524,7 +524,37 @@
         </virtualRepository>
     </virtualRepositories>
     <federatedRepositories/>
-    <releaseBundlesRepositories/>
+    <releaseBundlesRepositories>
+        <releaseBundlesRepository>
+            <key>release-bundles</key>
+            <type>releasebundles</type>
+            <includesPattern>**/*</includesPattern>
+            <dockerApiVersion>V2</dockerApiVersion>
+            <forceNugetAuthentication>false</forceNugetAuthentication>
+            <forceConanAuthentication>false</forceConanAuthentication>
+            <ddebSupported>false</ddebSupported>
+            <signedUrlTtl>90</signedUrlTtl>
+            <blackedOut>false</blackedOut>
+            <handleReleases>true</handleReleases>
+            <handleSnapshots>true</handleSnapshots>
+            <maxUniqueSnapshots>0</maxUniqueSnapshots>
+            <maxUniqueTags>0</maxUniqueTags>
+            <blockPushingSchema1>true</blockPushingSchema1>
+            <suppressPomConsistencyChecks>true</suppressPomConsistencyChecks>
+            <propertySets/>
+            <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
+            <priorityResolution>false</priorityResolution>
+            <snapshotVersionBehavior>unique</snapshotVersionBehavior>
+            <localRepoChecksumPolicyType>client-checksums</localRepoChecksumPolicyType>
+            <calculateYumMetadata>false</calculateYumMetadata>
+            <yumRootDepth>0</yumRootDepth>
+            <debianTrivialLayout>false</debianTrivialLayout>
+            <enableFileListsIndexing>false</enableFileListsIndexing>
+            <dockerTagRetention>1</dockerTagRetention>
+            <enableComposerV1Indexing>false</enableComposerV1Indexing>
+            <terraformType>MODULE</terraformType>
+        </releaseBundlesRepository>
+    </releaseBundlesRepositories>
     <proxies/>
     <reverseProxies>
         <reverseProxy>

--- a/artifactory/commands/transferconfig/configxmlutils/includerepos.go
+++ b/artifactory/commands/transferconfig/configxmlutils/includerepos.go
@@ -3,6 +3,7 @@ package configxmlutils
 import (
 	"encoding/xml"
 	"fmt"
+
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 )
@@ -11,7 +12,7 @@ import (
 // configXml            - artifactory.config.xml of the source Artifactory
 // includedRepositories - Selected repositories
 func RemoveNonIncludedRepositories(configXml string, includedRepositories []string) (string, error) {
-	for _, repoType := range []utils.RepoType{utils.LOCAL, utils.REMOTE, utils.VIRTUAL, utils.FEDERATED} {
+	for _, repoType := range []utils.RepoType{utils.Local, utils.Remote, utils.Virtual, utils.Federated} {
 		xmlTagIndices, exist, err := findAllXmlTagIndices(configXml, repoType.String()+`Repositories`, true)
 		if err != nil {
 			return "", err

--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -119,14 +119,14 @@ func (tcc *TransferConfigCommand) Run() (err error) {
 		return
 	}
 
-	// Filter repositories to transfer
-	transferRepositories, err := utils.GetFilteredRepositories(sourceServicesManager, tcc.includeReposPatterns, tcc.excludeReposPatterns)
-	if err != nil {
-		return
+	// Create the repository filter
+	repoFilter := &utils.RepositoryFilter{
+		IncludePatterns: tcc.includeReposPatterns,
+		ExcludePatterns: tcc.excludeReposPatterns,
 	}
 
 	// Prepare the config XML to be imported to SaaS
-	configXml, err = tcc.modifyConfigXml(configXml, tcc.sourceServerDetails.ArtifactoryUrl, tcc.targetServerDetails.AccessUrl, transferRepositories)
+	configXml, err = tcc.modifyConfigXml(configXml, tcc.sourceServerDetails.ArtifactoryUrl, tcc.targetServerDetails.AccessUrl, repoFilter)
 	if err != nil {
 		return
 	}
@@ -284,13 +284,11 @@ func (tcc *TransferConfigCommand) exportSourceArtifactory(sourceServicesManager 
 // Modify artifactory.config.xml:
 // 1. Remove non-included repositories, if provided
 // 2. Replace URL of federated repositories from sourceBaseUrl to targetBaseUrl
-func (tcc *TransferConfigCommand) modifyConfigXml(configXml, sourceBaseUrl, targetBaseUrl string, transferRepositories []string) (string, error) {
+func (tcc *TransferConfigCommand) modifyConfigXml(configXml, sourceBaseUrl, targetBaseUrl string, repoFilter *utils.RepositoryFilter) (string, error) {
 	var err error
-	if len(transferRepositories) > 0 {
-		configXml, err = configxmlutils.RemoveNonIncludedRepositories(configXml, transferRepositories)
-		if err != nil {
-			return "", err
-		}
+	configXml, err = configxmlutils.RemoveNonIncludedRepositories(configXml, repoFilter)
+	if err != nil {
+		return "", err
 	}
 	return configxmlutils.ReplaceUrlsInFederatedrepos(configXml, sourceBaseUrl, targetBaseUrl)
 }

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -237,6 +237,7 @@ func (tdc *TransferFilesCommand) getLocalRepositories(storageInfo *serviceUtils.
 	return append(buildInfoRepoKeys, repoKeys...), nil
 }
 
+// Return the storage info of the source and target Artifactory servers
 func (tdc *TransferFilesCommand) getSourceAndTargetStorageInfo() (*serviceUtils.StorageInfo, *serviceUtils.StorageInfo, error) {
 	// Get source storage info
 	sourceStorageInfo, err := tdc.getStorageInfo(tdc.sourceServerDetails)
@@ -246,10 +247,6 @@ func (tdc *TransferFilesCommand) getSourceAndTargetStorageInfo() (*serviceUtils.
 
 	// Get target storage info
 	targetStorageInfo, err := tdc.getStorageInfo(tdc.targetServerDetails)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	return sourceStorageInfo, targetStorageInfo, err
 }
 

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -27,7 +27,7 @@ const (
 	fileWritersChannelSize       = 500000
 	retries                      = 3
 	retriesWait                  = 0
-	dataTransferPluginMinVersion = "1.2.2"
+	dataTransferPluginMinVersion = "1.3.0"
 )
 
 type TransferFilesCommand struct {
@@ -66,8 +66,7 @@ func (tdc *TransferFilesCommand) Run() (err error) {
 	}
 
 	// Verify connection to the source Artifactory instance, and that the user plugin is installed, responsive, and stands in the minimal version requirement.
-	err = getAndValidateDataTransferPlugin(srcUpService)
-	if err != nil {
+	if err = getAndValidateDataTransferPlugin(srcUpService); err != nil {
 		return err
 	}
 
@@ -75,33 +74,26 @@ func (tdc *TransferFilesCommand) Run() (err error) {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(transferDir, 0777)
-	if err != nil {
+	if err = os.MkdirAll(transferDir, 0777); err != nil {
 		return errorutils.CheckError(err)
 	}
 
-	err = tdc.initCurThreads()
+	if err = tdc.initCurThreads(); err != nil {
+		return err
+	}
+
+	sourceStorageInfo, targetStorageInfo, err := tdc.getSourceAndTargetStorageInfo()
 	if err != nil {
 		return err
 	}
 
-	srcRepos, err := tdc.getSrcLocalRepositories()
-	if err != nil {
-		return err
-	}
-
-	targetRepos, err := tdc.getTargetLocalRepositories()
-	if err != nil {
-		return err
-	}
-
-	storageInfo, err := tdc.getSourceStorageInfo()
+	sourceRepos, targetRepos, err := tdc.getSourceAndTargetlocalRepositories(sourceStorageInfo, targetStorageInfo)
 	if err != nil {
 		return err
 	}
 
 	// Set progress bar
-	tdc.progressbar, err = progressbar.NewTransferProgressMng(int64(len(srcRepos)))
+	tdc.progressbar, err = progressbar.NewTransferProgressMng(int64(len(sourceRepos)))
 	if err != nil {
 		return err
 	}
@@ -112,7 +104,7 @@ func (tdc *TransferFilesCommand) Run() (err error) {
 	finishStopping := tdc.handleStop(&shouldStop, &newPhase, srcUpService)
 	defer finishStopping()
 
-	for _, repo := range srcRepos {
+	for _, repo := range sourceRepos {
 		if shouldStop {
 			break
 		}
@@ -123,7 +115,7 @@ func (tdc *TransferFilesCommand) Run() (err error) {
 			continue
 		}
 
-		repoSummary, err := getRepoSummaryFromList(storageInfo.RepositoriesSummaryList, repo)
+		repoSummary, err := getRepoSummaryFromList(sourceStorageInfo.RepositoriesSummaryList, repo)
 		if err != nil {
 			log.Error(err.Error() + ". Skipping...")
 			continue
@@ -218,24 +210,51 @@ func (tdc *TransferFilesCommand) initNewPhase(newPhase transferPhase, srcUpServi
 	newPhase.setProgressBar(tdc.progressbar)
 }
 
-func (tdc *TransferFilesCommand) getSrcLocalRepositories() ([]string, error) {
-	serviceManager, err := utils.CreateServiceManager(tdc.sourceServerDetails, retries, retriesWait, false)
+func (tdc *TransferFilesCommand) getSourceAndTargetlocalRepositories(sourceStorageInfo *serviceUtils.StorageInfo, targetStorageInfo *serviceUtils.StorageInfo) ([]string, []string, error) {
+	sourceRepos, err := tdc.getLocalRepositories(sourceStorageInfo, tdc.sourceServerDetails)
 	if err != nil {
-		return nil, err
+		return []string{}, []string{}, err
 	}
-	return utils.GetFilteredRepositories(serviceManager, tdc.includeReposPatterns, tdc.excludeReposPatterns, utils.LOCAL)
+	targetRepos, err := tdc.getLocalRepositories(targetStorageInfo, tdc.targetServerDetails)
+	return sourceRepos, targetRepos, err
 }
 
-func (tdc *TransferFilesCommand) getTargetLocalRepositories() ([]string, error) {
-	serviceManager, err := utils.CreateServiceManager(tdc.targetServerDetails, retries, retriesWait, false)
+func (tdc *TransferFilesCommand) getLocalRepositories(storageInfo *serviceUtils.StorageInfo, serverDetails *config.ServerDetails) ([]string, error) {
+	var repoKeys []string
+	serviceManager, err := utils.CreateServiceManager(serverDetails, retries, retriesWait, false)
 	if err != nil {
-		return nil, err
+		return repoKeys, err
 	}
-	return utils.GetFilteredRepositories(serviceManager, tdc.includeReposPatterns, tdc.excludeReposPatterns, utils.LOCAL)
+	repoKeys, err = utils.GetFilteredRepositories(serviceManager, tdc.includeReposPatterns, tdc.excludeReposPatterns, utils.Local)
+	if err != nil {
+		return repoKeys, err
+	}
+
+	buildInfoRepoKeys, err := utils.GetFilteredBuildInfoRepostories(storageInfo, tdc.includeReposPatterns, tdc.excludeReposPatterns)
+	if err != nil {
+		return repoKeys, err
+	}
+	return append(buildInfoRepoKeys, repoKeys...), nil
 }
 
-func (tdc *TransferFilesCommand) getSourceStorageInfo() (*serviceUtils.StorageInfo, error) {
-	serviceManager, err := utils.CreateServiceManager(tdc.sourceServerDetails, retries, retriesWait, false)
+func (tdc *TransferFilesCommand) getSourceAndTargetStorageInfo() (*serviceUtils.StorageInfo, *serviceUtils.StorageInfo, error) {
+	// Get source storage info
+	sourceStorageInfo, err := tdc.getStorageInfo(tdc.sourceServerDetails)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Get target storage info
+	targetStorageInfo, err := tdc.getStorageInfo(tdc.targetServerDetails)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return sourceStorageInfo, targetStorageInfo, err
+}
+
+func (tdc *TransferFilesCommand) getStorageInfo(serverDetails *config.ServerDetails) (*serviceUtils.StorageInfo, error) {
+	serviceManager, err := utils.CreateServiceManager(serverDetails, retries, retriesWait, false)
 	if err != nil {
 		return nil, err
 	}

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -87,7 +87,7 @@ func (tdc *TransferFilesCommand) Run() (err error) {
 		return err
 	}
 
-	sourceRepos, targetRepos, err := tdc.getSourceAndTargetlocalRepositories(sourceStorageInfo, targetStorageInfo)
+	sourceRepos, targetRepos, err := tdc.getSourceAndTargetLocalRepositories(sourceStorageInfo, targetStorageInfo)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func (tdc *TransferFilesCommand) initNewPhase(newPhase transferPhase, srcUpServi
 	newPhase.setProgressBar(tdc.progressbar)
 }
 
-func (tdc *TransferFilesCommand) getSourceAndTargetlocalRepositories(sourceStorageInfo *serviceUtils.StorageInfo, targetStorageInfo *serviceUtils.StorageInfo) ([]string, []string, error) {
+func (tdc *TransferFilesCommand) getSourceAndTargetLocalRepositories(sourceStorageInfo *serviceUtils.StorageInfo, targetStorageInfo *serviceUtils.StorageInfo) ([]string, []string, error) {
 	sourceRepos, err := tdc.getLocalRepositories(sourceStorageInfo, tdc.sourceServerDetails)
 	if err != nil {
 		return []string{}, []string{}, err
@@ -225,12 +225,12 @@ func (tdc *TransferFilesCommand) getLocalRepositories(storageInfo *serviceUtils.
 	if err != nil {
 		return repoKeys, err
 	}
-	repoKeys, err = utils.GetFilteredRepositories(serviceManager, tdc.includeReposPatterns, tdc.excludeReposPatterns, utils.Local)
+	repoKeys, err = utils.GetFilteredRepositoriesByNameAndType(serviceManager, tdc.includeReposPatterns, tdc.excludeReposPatterns, utils.Local)
 	if err != nil {
 		return repoKeys, err
 	}
 
-	buildInfoRepoKeys, err := utils.GetFilteredBuildInfoRepostories(storageInfo, tdc.includeReposPatterns, tdc.excludeReposPatterns)
+	buildInfoRepoKeys, err := utils.GetFilteredBuildInfoRepositories(storageInfo, tdc.includeReposPatterns, tdc.excludeReposPatterns)
 	if err != nil {
 		return repoKeys, err
 	}

--- a/artifactory/commands/utils/configfile.go
+++ b/artifactory/commands/utils/configfile.go
@@ -256,10 +256,10 @@ func (configFile *ConfigFile) configMaven() error {
 		return err
 	}
 	if configFile.Resolver.ServerId != "" {
-		if err := configFile.setRepo(&configFile.Resolver.ReleaseRepo, "Set resolution repository for release dependencies", configFile.Resolver.ServerId, utils.REMOTE); err != nil {
+		if err := configFile.setRepo(&configFile.Resolver.ReleaseRepo, "Set resolution repository for release dependencies", configFile.Resolver.ServerId, utils.Remote); err != nil {
 			return err
 		}
-		if err := configFile.setRepo(&configFile.Resolver.SnapshotRepo, "Set resolution repository for snapshot dependencies", configFile.Resolver.ServerId, utils.REMOTE); err != nil {
+		if err := configFile.setRepo(&configFile.Resolver.SnapshotRepo, "Set resolution repository for snapshot dependencies", configFile.Resolver.ServerId, utils.Remote); err != nil {
 			return err
 		}
 	}
@@ -268,10 +268,10 @@ func (configFile *ConfigFile) configMaven() error {
 		return err
 	}
 	if configFile.Deployer.ServerId != "" {
-		if err := configFile.setRepo(&configFile.Deployer.ReleaseRepo, "Set repository for release artifacts deployment", configFile.Deployer.ServerId, utils.LOCAL); err != nil {
+		if err := configFile.setRepo(&configFile.Deployer.ReleaseRepo, "Set repository for release artifacts deployment", configFile.Deployer.ServerId, utils.Local); err != nil {
 			return err
 		}
-		if err := configFile.setRepo(&configFile.Deployer.SnapshotRepo, "Set repository for snapshot artifacts deployment", configFile.Deployer.ServerId, utils.LOCAL); err != nil {
+		if err := configFile.setRepo(&configFile.Deployer.SnapshotRepo, "Set repository for snapshot artifacts deployment", configFile.Deployer.ServerId, utils.Local); err != nil {
 			return err
 		}
 		configFile.setIncludeExcludePatterns()
@@ -335,7 +335,7 @@ func (configFile *ConfigFile) setDeployer() error {
 
 	// Set deployment repository
 	if configFile.Deployer.ServerId != "" {
-		return configFile.setRepo(&configFile.Deployer.Repo, "Set repository for artifacts deployment", configFile.Deployer.ServerId, utils.LOCAL)
+		return configFile.setRepo(&configFile.Deployer.Repo, "Set repository for artifacts deployment", configFile.Deployer.ServerId, utils.Local)
 	}
 	return nil
 }
@@ -347,7 +347,7 @@ func (configFile *ConfigFile) setResolver() error {
 	}
 	// Set resolution repository
 	if configFile.Resolver.ServerId != "" {
-		return configFile.setRepo(&configFile.Resolver.Repo, "Set repository for dependencies resolution", configFile.Resolver.ServerId, utils.REMOTE)
+		return configFile.setRepo(&configFile.Resolver.Repo, "Set repository for dependencies resolution", configFile.Resolver.ServerId, utils.Remote)
 	}
 	return nil
 }
@@ -376,7 +376,7 @@ func (configFile *ConfigFile) setServerId(serverId *string, useArtifactoryQuesti
 func (configFile *ConfigFile) setRepo(repo *string, message string, serverId string, repoType utils.RepoType) error {
 	var err error
 	if *repo == "" {
-		*repo, err = readRepo(message+PressTabMsg, serverId, repoType, utils.VIRTUAL)
+		*repo, err = readRepo(message+PressTabMsg, serverId, repoType, utils.Virtual)
 	}
 	return err
 }

--- a/artifactory/utils/repositoryutils.go
+++ b/artifactory/utils/repositoryutils.go
@@ -1,21 +1,26 @@
 package utils
 
 import (
+	"path"
+	"strings"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
-	"path/filepath"
 
 	"github.com/jfrog/jfrog-client-go/artifactory"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
+	clientUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 )
+
+const buildInfoPackageType = "buildinfo"
 
 type RepoType int
 
 const (
-	LOCAL RepoType = iota
-	REMOTE
-	VIRTUAL
-	FEDERATED
+	Local RepoType = iota
+	Remote
+	Virtual
+	Federated
 )
 
 var RepoTypes = []string{
@@ -29,20 +34,24 @@ func (repoType RepoType) String() string {
 	return RepoTypes[repoType]
 }
 
-func GetRepositories(artDetails *config.ServerDetails, repoType ...RepoType) ([]string, error) {
+// GetRepositories returns the names of local, remote, virtual or federated repositories filtered by their type.
+// artDetails - Artifactory server details
+// repoTypes - Repository types to filter. If empty - return all repository types.
+func GetRepositories(artDetails *config.ServerDetails, repoTypes ...RepoType) ([]string, error) {
 	sm, err := CreateServiceManager(artDetails, 3, 0, false)
 	if err != nil {
 		return nil, err
 	}
+	if len(repoTypes) == 0 {
+		return GetFilteredRepositories(sm, nil, nil)
+	}
 	repos := []string{}
-	for i := range repoType {
-		r, err := GetFilteredRepositories(sm, nil, nil, repoType[i])
+	for _, repoType := range repoTypes {
+		repoKey, err := GetFilteredRepositories(sm, nil, nil, repoType)
 		if err != nil {
 			return repos, err
 		}
-		if len(r) > 0 {
-			repos = append(repos, r...)
-		}
+		repos = append(repos, repoKey...)
 	}
 
 	return repos, nil
@@ -70,7 +79,7 @@ func IsRemoteRepo(repoName string, serviceManager artifactory.ArtifactoryService
 	return repoDetails.GetRepoType() == "remote", nil
 }
 
-// GetFilteredRepositories returns the names of all repositories filtered by their names and types.
+// GetFilteredRepositories returns the names of local, remote, virtual and federated repositories filtered by their names.
 // includePatterns - patterns of repository names (can contain wildcards) to include in the results. A repository's name
 // must match at least one of these patterns in order to be included in the results. If includePatterns' length is zero,
 // all repositories are included.
@@ -79,18 +88,50 @@ func IsRemoteRepo(repoName string, serviceManager artifactory.ArtifactoryService
 // repoType - only repositories of this type will be returned. Only a maximum of ONE repository type can be filtered.
 // If more than one type are provided, the repositories will be filtered by the first one only.
 func GetFilteredRepositories(servicesManager artifactory.ArtifactoryServicesManager, includePatterns, excludePatterns []string, repoType ...RepoType) ([]string, error) {
-	filterParams := services.RepositoriesFilterParams{}
-	if len(repoType) > 0 {
-		filterParams.RepoType = repoType[0].String()
+	var repoDetailsList *[]services.RepositoryDetails
+	var err error
+
+	if len(repoType) == 0 {
+		repoDetailsList, err = servicesManager.GetAllRepositoriesFiltered(services.RepositoriesFilterParams{RepoType: repoType[0].String()})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		repoDetailsList, err = servicesManager.GetAllRepositories()
+		if err != nil {
+			return nil, err
+		}
 	}
-	repos, err := servicesManager.GetAllRepositoriesFiltered(filterParams)
-	if err != nil {
-		return nil, err
+	var repoKeys []string
+	for _, repoDetails := range *repoDetailsList {
+		repoKeys = append(repoKeys, repoDetails.Key)
 	}
-	return filterRepositoryNames(repos, includePatterns, excludePatterns)
+
+	return filterRepositoryNames(&repoKeys, includePatterns, excludePatterns)
 }
 
-func filterRepositoryNames(repos *[]services.RepositoryDetails, includePatterns, excludePatterns []string) ([]string, error) {
+// GetFilteredBuildInfoRepostories returns the names of all build-info repositories filtered by their names.
+// storageInfo - storage info response from Artifactory
+// includePatterns - patterns of repository names (can contain wildcards) to include in the results. A repository's name
+// must match at least one of these patterns in order to be included in the results. If includePatterns' length is zero,
+// all repositories are included.
+// excludePatterns - patterns of repository names (can contain wildcards) to exclude from the results. A repository's name
+// must NOT match any of these patterns in order to be included in the results.
+func GetFilteredBuildInfoRepostories(storageInfo *clientUtils.StorageInfo, includePatterns, excludePatterns []string) ([]string, error) {
+	var repoKeys []string
+	for _, repoSummary := range storageInfo.RepositoriesSummaryList {
+		if strings.ToLower(repoSummary.PackageType) == buildInfoPackageType {
+			repoKeys = append(repoKeys, repoSummary.RepoKey)
+		}
+	}
+	return filterRepositoryNames(&repoKeys, includePatterns, excludePatterns)
+}
+
+// Filter repositories by name and return a list of repository names
+// repos - The repository keys to filter
+// includePatterns - Repositories inclusion wildcard pattern
+// excludePatterns - Repositories exclusion wildcard pattern
+func filterRepositoryNames(repos *[]string, includePatterns, excludePatterns []string) ([]string, error) {
 	allIncluded := false
 	// If includePattens is empty, include all repositories.
 	if len(includePatterns) == 0 {
@@ -103,7 +144,7 @@ func filterRepositoryNames(repos *[]services.RepositoryDetails, includePatterns,
 
 		// Check if this repository name matches any include pattern.
 		for _, includePattern := range includePatterns {
-			matched, err := filepath.Match(includePattern, repo.Key)
+			matched, err := path.Match(includePattern, repo)
 			if err != nil {
 				return nil, err
 			}
@@ -115,7 +156,7 @@ func filterRepositoryNames(repos *[]services.RepositoryDetails, includePatterns,
 		if repoIncluded {
 			// Check if this repository name matches any exclude pattern.
 			for _, excludePattern := range excludePatterns {
-				matched, err := filepath.Match(excludePattern, repo.Key)
+				matched, err := path.Match(excludePattern, repo)
 				if err != nil {
 					return nil, err
 				}
@@ -125,7 +166,7 @@ func filterRepositoryNames(repos *[]services.RepositoryDetails, includePatterns,
 				}
 			}
 			if repoIncluded {
-				included = append(included, repo.Key)
+				included = append(included, repo)
 			}
 		}
 	}

--- a/artifactory/utils/repositoryutils_test.go
+++ b/artifactory/utils/repositoryutils_test.go
@@ -1,18 +1,18 @@
 package utils
 
 import (
-	"github.com/jfrog/jfrog-client-go/artifactory/services"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFilterRepositoryNames(t *testing.T) {
-	repos := []services.RepositoryDetails{
-		{Key: "jfrog-docker-local"},
-		{Key: "jfrog-npm-local"},
-		{Key: "docker-local"},
-		{Key: "jfrog-generic-remote"},
-		{Key: "jfrog-maven-local"},
+	repos := []string{
+		"jfrog-docker-local",
+		"jfrog-npm-local",
+		"docker-local",
+		"jfrog-generic-remote",
+		"jfrog-maven-local",
 	}
 	includePatterns := []string{
 		"jfrog-*-local",

--- a/artifactory/utils/repositoryutils_test.go
+++ b/artifactory/utils/repositoryutils_test.go
@@ -30,3 +30,32 @@ func TestFilterRepositoryNames(t *testing.T) {
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expectedRepoNames, actualRepoNames)
 }
+
+var shouldIncludeRepositoryTestCases = []struct {
+	name            string
+	repoKey         string
+	includePatterns []string
+	excludePatterns []string
+	shouldInclude   bool
+}{
+	{name: "Exact match", repoKey: "generic-local", includePatterns: []string{"generic-local"}, excludePatterns: []string{}, shouldInclude: true},
+	{name: "Wildcard pattern", repoKey: "generic-local", includePatterns: []string{"*-local"}, excludePatterns: []string{}, shouldInclude: true},
+	{name: "No match", repoKey: "generic-local", includePatterns: []string{"generic", "local"}, excludePatterns: []string{}, shouldInclude: false},
+	{name: "Third match", repoKey: "generic-local", includePatterns: []string{"generic", "local", "generic-local"}, excludePatterns: []string{}, shouldInclude: true},
+	{name: "Empty match", repoKey: "generic-local", includePatterns: []string{}, excludePatterns: []string{}, shouldInclude: true},
+	{name: "All match", repoKey: "generic-local", includePatterns: []string{"*"}, excludePatterns: []string{}, shouldInclude: true},
+	{name: "Exact exclude", repoKey: "generic-local", includePatterns: []string{}, excludePatterns: []string{"generic-local"}, shouldInclude: false},
+	{name: "All exclude", repoKey: "generic-local", includePatterns: []string{}, excludePatterns: []string{"*"}, shouldInclude: false},
+	{name: "All include and exclude", repoKey: "generic-local", includePatterns: []string{"*"}, excludePatterns: []string{"*"}, shouldInclude: false},
+}
+
+func TestShouldIncludeRepository(t *testing.T) {
+	for _, testCase := range shouldIncludeRepositoryTestCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			repositoryFilter := &RepositoryFilter{IncludePatterns: testCase.includePatterns, ExcludePatterns: testCase.excludePatterns}
+			actual, err := repositoryFilter.ShouldIncludeRepository(testCase.repoKey)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.shouldInclude, actual)
+		})
+	}
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Depends on: https://github.com/jfrog/data-transfer/pull/24 and releasing of data-transfer 1.3.0.
Integration test: https://github.com/jfrog/jfrog-cli/pull/1635

* Support transferring and filtering of build-info repositories in transfer-config and transfer-files.
* Support creating and filtering release bundle repositories in transfer-config. **Transferring release bundle repositories files is not supported.**
