### PR TITLE
Transfer files ignoreState option

### DIFF
--- a/artifactory/commands/transferfiles/state.go
+++ b/artifactory/commands/transferfiles/state.go
@@ -92,7 +92,7 @@ func (ts *TransferState) getRepository(repoKey string, createIfMissing bool) (*R
 	if !createIfMissing {
 		return nil, errorutils.CheckErrorf("Could not find repository '" + repoKey + "' in state file. Aborting.")
 	}
-	repo := Repository{Name: repoKey}
+	repo := newRepositoryState(repoKey)
 	ts.Repositories = append(ts.Repositories, repo)
 	return &repo, nil
 }
@@ -246,6 +246,22 @@ func isRepoTransferred(repoKey string) (bool, error) {
 	}
 	err := doAndSaveState(action)
 	return isTransferred, err
+}
+
+func resetRepoState(repoKey string) error {
+	action := func(state *TransferState) error {
+		repo, err := state.getRepository(repoKey, true)
+		if err != nil || repo == nil {
+			return err
+		}
+		*repo = newRepositoryState(repoKey)
+		return nil
+	}
+	return doAndSaveState(action)
+}
+
+func newRepositoryState(repoKey string) Repository {
+	return Repository{Name: repoKey}
 }
 
 func convertTimeToRFC3339(timeToConvert time.Time) string {

--- a/artifactory/commands/transferfiles/state_test.go
+++ b/artifactory/commands/transferfiles/state_test.go
@@ -51,7 +51,7 @@ func getAndAssertNonExistingRepo(t *testing.T, state *TransferState, repoKey str
 }
 
 func TestFilesDiffRange(t *testing.T) {
-	cleanUp := setupStateTest(t)
+	cleanUp := initStateTest(t)
 	defer cleanUp()
 
 	repoKey := "repo"
@@ -123,12 +123,12 @@ func getRepoFromState(t *testing.T, repoKey string) *Repository {
 	return repo
 }
 
-func setupStateTest(t *testing.T) (cleanUp func()) {
+func initStateTest(t *testing.T) (cleanUp func()) {
 	cleanUpJfrogHome, err := tests.SetJfrogHome()
 	assert.NoError(t, err)
 	cleanUp = cleanUpJfrogHome
 
-	// Create transfer dir.
+	// Create transfer directory
 	transferDir, err := coreutils.GetJfrogTransferDir()
 	assert.NoError(t, err)
 	err = utils.CreateDirIfNotExist(transferDir)
@@ -137,7 +137,7 @@ func setupStateTest(t *testing.T) (cleanUp func()) {
 }
 
 func TestResetRepoState(t *testing.T) {
-	cleanUp := setupStateTest(t)
+	cleanUp := initStateTest(t)
 	defer cleanUp()
 	repo1Key, repo2Key := "repo1", "repo2"
 

--- a/artifactory/commands/transferfiles/state_test.go
+++ b/artifactory/commands/transferfiles/state_test.go
@@ -51,15 +51,8 @@ func getAndAssertNonExistingRepo(t *testing.T, state *TransferState, repoKey str
 }
 
 func TestFilesDiffRange(t *testing.T) {
-	cleanUpJfrogHome, err := tests.SetJfrogHome()
-	assert.NoError(t, err)
-	defer cleanUpJfrogHome()
-
-	// Create transfer dir.
-	transferDir, err := coreutils.GetJfrogTransferDir()
-	assert.NoError(t, err)
-	err = utils.CreateDirIfNotExist(transferDir)
-	assert.NoError(t, err)
+	cleanUp := setupStateTest(t)
+	defer cleanUp()
 
 	repoKey := "repo"
 	transferStartTime := time.Now()
@@ -128,4 +121,39 @@ func getRepoFromState(t *testing.T, repoKey string) *Repository {
 	repo, err := state.getRepository(repoKey, false)
 	assert.NoError(t, err)
 	return repo
+}
+
+func setupStateTest(t *testing.T) (cleanUp func()) {
+	cleanUpJfrogHome, err := tests.SetJfrogHome()
+	assert.NoError(t, err)
+	cleanUp = cleanUpJfrogHome
+
+	// Create transfer dir.
+	transferDir, err := coreutils.GetJfrogTransferDir()
+	assert.NoError(t, err)
+	err = utils.CreateDirIfNotExist(transferDir)
+	assert.NoError(t, err)
+	return
+}
+
+func TestResetRepoState(t *testing.T) {
+	cleanUp := setupStateTest(t)
+	defer cleanUp()
+	repo1Key, repo2Key := "repo1", "repo2"
+
+	// Reset a repository state on an empty state
+	err := resetRepoState(repo1Key)
+	assert.NoError(t, err)
+	// Set repository fully transferred. It will fail the test if the repository is not in the state.
+	setAndAssertRepoFullyTransfer(t, repo1Key, time.Now())
+
+	// Create another repository state
+	err = resetRepoState(repo2Key)
+	assert.NoError(t, err)
+	setAndAssertRepoFullyTransfer(t, repo2Key, time.Now())
+
+	// Reset repo1 only
+	err = resetRepoState(repo1Key)
+	assert.NoError(t, err)
+	assertRepoTransferred(t, repo1Key, false)
 }

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -160,7 +160,7 @@ func (tdc *TransferFilesCommand) transferRepos(sourceRepos []string, targetRepos
 		if tdc.ignoreState {
 			err = resetRepoState(repoKey)
 			if err != nil {
-				return tdc.cleanup(err, sourceRepos)
+				return err
 			}
 		}
 

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -37,6 +37,7 @@ type TransferFilesCommand struct {
 	progressbar               *progressbar.TransferProgressMng
 	includeReposPatterns      []string
 	excludeReposPatterns      []string
+	ignoreState               bool
 }
 
 func NewTransferFilesCommand(sourceServer, targetServer *config.ServerDetails) *TransferFilesCommand {
@@ -57,6 +58,10 @@ func (tdc *TransferFilesCommand) SetIncludeReposPatterns(includeReposPatterns []
 
 func (tdc *TransferFilesCommand) SetExcludeReposPatterns(excludeReposPatterns []string) {
 	tdc.excludeReposPatterns = excludeReposPatterns
+}
+
+func (tdc *TransferFilesCommand) SetIgnoreState(ignoreState bool) {
+	tdc.ignoreState = ignoreState
 }
 
 func (tdc *TransferFilesCommand) Run() (err error) {
@@ -132,6 +137,14 @@ func (tdc *TransferFilesCommand) Run() (err error) {
 		if tdc.progressbar != nil {
 			tdc.progressbar.NewRepository(repo)
 		}
+
+		if tdc.ignoreState {
+			err = resetRepoState(repo)
+			if err != nil {
+				return tdc.cleanup(err)
+			}
+		}
+
 		for currentPhaseId := 0; currentPhaseId < numberOfPhases; currentPhaseId++ {
 			if shouldStop {
 				break

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -132,7 +132,7 @@ func (tdc *TransferFilesCommand) Run() (err error) {
 		if tdc.ignoreState {
 			err = resetRepoState(repo)
 			if err != nil {
-				return tdc.cleanup(err)
+				return tdc.cleanup(err, sourceRepos)
 			}
 		}
 

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -158,7 +158,7 @@ func (tdc *TransferFilesCommand) transferRepos(sourceRepos []string, targetRepos
 		}
 
 		if tdc.ignoreState {
-			err = resetRepoState(repo)
+			err = resetRepoState(repoKey)
 			if err != nil {
 				return tdc.cleanup(err, sourceRepos)
 			}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Added ignoreState flag to TransferFilesCommand. If true, the CLI will ignore the saved state of previous runs of the transfer.