### PR TITLE
Transfer - limit build info transferring threads

### DIFF
--- a/artifactory/commands/transfer/settings.go
+++ b/artifactory/commands/transfer/settings.go
@@ -2,12 +2,14 @@ package transfer
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
+
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/ioutils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"strconv"
 )
 
 const MaxThreadsLimit = 1024
@@ -42,6 +44,7 @@ func (tst *TransferSettingsCommand) Run() error {
 		return err
 	}
 	log.Output("The settings were saved successfully. It might take a few moments for the new settings to take effect.")
+	log.Output(fmt.Sprintf("Notice - For Build Info repositories, the number of threads is limited by %d.", utils.MaxBuildInfoThreads))
 	return nil
 }
 

--- a/artifactory/commands/transferfiles/manager.go
+++ b/artifactory/commands/transferfiles/manager.go
@@ -157,7 +157,7 @@ func (ptm *PollingTasksManager) start(phaseBase *phaseBase, runWaitGroup *sync.W
 	}
 	go func() {
 		defer runWaitGroup.Done()
-		periodicallyUpdateThreads(producerConsumer, ptm.doneChannel)
+		periodicallyUpdateThreads(producerConsumer, ptm.doneChannel, phaseBase.buildInfoRepo)
 	}()
 
 	// Check status of uploaded chunks.

--- a/artifactory/commands/transferfiles/phase.go
+++ b/artifactory/commands/transferfiles/phase.go
@@ -29,6 +29,7 @@ type transferPhase interface {
 
 type phaseBase struct {
 	repoKey                   string
+	buildInfoRepo             bool
 	phaseId                   int
 	checkExistenceInFilestore bool
 	startTime                 time.Time
@@ -60,13 +61,13 @@ func (pb *phaseBase) stopGracefully() {
 	}
 }
 
-func getPhaseByNum(i int, repoKey string) transferPhase {
+func getPhaseByNum(i int, repoKey string, buildInfoRepo bool) transferPhase {
 	stopValue := false
 	switch i {
 	case 0:
-		return &fullTransferPhase{phaseBase: phaseBase{repoKey: repoKey, phaseId: 0, stop: &stopValue}}
+		return &fullTransferPhase{phaseBase: phaseBase{repoKey: repoKey, phaseId: 0, buildInfoRepo: buildInfoRepo, stop: &stopValue}}
 	case 1:
-		return &filesDiffPhase{phaseBase: phaseBase{repoKey: repoKey, phaseId: 1, stop: &stopValue}}
+		return &filesDiffPhase{phaseBase: phaseBase{repoKey: repoKey, phaseId: 1, buildInfoRepo: buildInfoRepo, stop: &stopValue}}
 	case 2:
 		return &propertiesDiffPhase{phaseBase: phaseBase{repoKey: repoKey, phaseId: 2, stop: &stopValue}}
 	}

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -270,10 +270,11 @@ func (tdc *TransferFilesCommand) initCurThreads(buildInfoRepo bool) error {
 	}
 	if settings != nil {
 		curThreads = settings.CalcNumberOfThreads(buildInfoRepo)
+		if buildInfoRepo && curThreads < settings.ThreadsNumber {
+			log.Info("Build info transferring - using reduced number of threads")
+		}
 	}
-	if buildInfoRepo && curThreads < settings.ThreadsNumber {
-		log.Info("Build info transferring - using reduced number of threads")
-	}
+
 	log.Info("Running with " + strconv.Itoa(curThreads) + " threads...")
 	return nil
 }

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -238,15 +238,6 @@ func uploadChunkAndAddToken(sup *srcUserPluginService, chunk UploadChunk, upload
 	return nil
 }
 
-func verifyRepoExistsInTarget(targetRepos []string, srcRepoKey string) bool {
-	for _, targetRepo := range targetRepos {
-		if targetRepo == srcRepoKey {
-			return true
-		}
-	}
-	return false
-}
-
 func GetThreads() int {
 	return curThreads
 }

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -261,7 +261,7 @@ func periodicallyUpdateThreads(producerConsumer parallel.Runner, doneChan chan b
 
 func updateThreads(producerConsumer parallel.Runner, buildInfoRepo bool) error {
 	settings, err := utils.LoadTransferSettings()
-	if err != nil {
+	if err != nil || settings == nil {
 		return err
 	}
 	calculatedNumberOfThreads := settings.CalcNumberOfThreads(buildInfoRepo)

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -21,6 +21,7 @@ const (
 	waitTimeBetweenThreadsUpdateSeconds          = 20
 	assumeProducerConsumerDoneWhenIdleForSeconds = 15
 	DefaultAqlPaginationLimit                    = 10000
+	maxBuildInfoRepoThreads                      = 8
 )
 
 var AqlPaginationLimit = DefaultAqlPaginationLimit
@@ -254,28 +255,29 @@ func GetThreads() int {
 // Number of threads in the settings files is expected to change by running a separate command.
 // The new number of threads should be almost immediately (checked every waitTimeBetweenThreadsUpdateSeconds) reflected on
 // the CLI side (by updating the producer consumer if used and the local variable) and as a result reflected on the Artifactory User Plugin side.
-func periodicallyUpdateThreads(producerConsumer parallel.Runner, doneChan chan bool) {
+func periodicallyUpdateThreads(producerConsumer parallel.Runner, doneChan chan bool, buildInfoRepo bool) {
 	for {
 		time.Sleep(waitTimeBetweenThreadsUpdateSeconds * time.Second)
 		if shouldStopPolling(doneChan) {
 			return
 		}
-		err := updateThreads(producerConsumer)
+		err := updateThreads(producerConsumer, buildInfoRepo)
 		if err != nil {
 			log.Error(err)
 		}
 	}
 }
 
-func updateThreads(producerConsumer parallel.Runner) error {
+func updateThreads(producerConsumer parallel.Runner, buildInfoRepo bool) error {
 	settings, err := utils.LoadTransferSettings()
 	if err != nil {
 		return err
 	}
-	if settings != nil && curThreads != settings.ThreadsNumber {
-		curThreads = settings.ThreadsNumber
+	calculatedNumberOfThreads := settings.CalcNumberOfThreads(buildInfoRepo)
+	if settings != nil && curThreads != calculatedNumberOfThreads {
+		curThreads = calculatedNumberOfThreads
 		if producerConsumer != nil {
-			producerConsumer.SetMaxParallel(settings.ThreadsNumber)
+			producerConsumer.SetMaxParallel(calculatedNumberOfThreads)
 		}
 		log.Info("Number of threads have been updated to " + strconv.Itoa(curThreads))
 	}

--- a/artifactory/utils/transfersettings.go
+++ b/artifactory/utils/transfersettings.go
@@ -3,13 +3,14 @@ package utils
 import (
 	"bytes"
 	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/lock"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 )
 
 const (

--- a/artifactory/utils/transfersettings.go
+++ b/artifactory/utils/transfersettings.go
@@ -14,7 +14,8 @@ import (
 
 const (
 	// DefaultThreads is the default number of threads working while transferring Artifactory's data
-	DefaultThreads = 8
+	DefaultThreads      = 8
+	MaxBuildInfoThreads = 8
 
 	transferSettingsFile     = "transfer.conf"
 	transferSettingsLockFile = "transfer-settings"
@@ -22,6 +23,13 @@ const (
 
 type TransferSettings struct {
 	ThreadsNumber int `json:"threadsNumber,omitempty"`
+}
+
+func (ts *TransferSettings) CalcNumberOfThreads(buildInfoRepo bool) int {
+	if buildInfoRepo && MaxBuildInfoThreads < ts.ThreadsNumber {
+		return MaxBuildInfoThreads
+	}
+	return ts.ThreadsNumber
 }
 
 func LoadTransferSettings() (settings *TransferSettings, err error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
* Limit the number of transferring threads to 8 in build-info repositories.
* Add the limitation notice in the transfer-settings:
<img width="824" alt="image" src="https://user-images.githubusercontent.com/11367982/183470357-b4ed1203-ca12-4256-88e5-fc51f2d63446.png">
