### PR TITLE
The Maven/Gradle build fails if there is no deployer in the config file

### DIFF
--- a/artifactory/utils/buildinfoproperties.go
+++ b/artifactory/utils/buildinfoproperties.go
@@ -155,6 +155,39 @@ func ReadConfigFile(configPath string, configType ConfigType) (config *viper.Vip
 	return config, errorutils.CheckError(err)
 }
 
+func ReadGradleConfig(path string, useWrapperIfMissingConfig bool) (config *viper.Viper, err error) {
+	if path == "" {
+		config = createDefaultGradleConfig(useWrapperIfMissingConfig)
+	} else {
+		config, err = ReadConfigFile(path, YAML)
+	}
+	return
+}
+
+func ReadMavenConfig(path string) (config *viper.Viper, err error) {
+	if path == "" {
+		config = createDefaultMavenConfig()
+	} else {
+		config, err = ReadConfigFile(path, YAML)
+	}
+	return
+}
+
+func createDefaultMavenConfig() *viper.Viper {
+	vConfig := viper.New()
+	vConfig.SetConfigType(string(YAML))
+	vConfig.Set("type", Maven.String())
+	return vConfig
+}
+
+func createDefaultGradleConfig(useWrapperIfMissingConfig bool) *viper.Viper {
+	vConfig := viper.New()
+	vConfig.SetConfigType(string(YAML))
+	vConfig.Set("type", Gradle.String())
+	vConfig.Set("usewrapper", useWrapperIfMissingConfig)
+	return vConfig
+}
+
 // Returns the Artifactory details
 // Checks first for the deployer information if exists and if not, checks for the resolver information.
 func GetServerDetails(vConfig *viper.Viper) (*config.ServerDetails, error) {
@@ -170,7 +203,7 @@ func GetServerDetails(vConfig *viper.Viper) (*config.ServerDetails, error) {
 	return nil, nil
 }
 
-func CreateBuildInfoProps(deployableArtifactsFile string, config *viper.Viper, projectType ProjectType) (map[string]string, error) {
+func CreateBuildInfoProps(buildArtifactsDetailsFile string, config *viper.Viper, projectType ProjectType) (map[string]string, error) {
 	if config.GetString("type") != projectType.String() {
 		return nil, errorutils.CheckErrorf("Incompatible build config, expected: " + projectType.String() + " got: " + config.GetString("type"))
 	}
@@ -183,8 +216,8 @@ func CreateBuildInfoProps(deployableArtifactsFile string, config *viper.Viper, p
 	if err := setProxyIfDefined(config); err != nil {
 		return nil, err
 	}
-	if deployableArtifactsFile != "" {
-		config.Set(DeployableArtifacts, deployableArtifactsFile)
+	if buildArtifactsDetailsFile != "" {
+		config.Set(DeployableArtifacts, buildArtifactsDetailsFile)
 	}
 	return createProps(config, projectType), nil
 }

--- a/utils/gradle/utils.go
+++ b/utils/gradle/utils.go
@@ -49,7 +49,6 @@ func RunGradle(vConfig *viper.Viper, tasks, deployableArtifactsFile string, conf
 }
 
 func createGradleRunConfig(vConfig *viper.Viper, deployableArtifactsFile string, buildConf *utils.BuildConfiguration, threads int, useWrapperIfMissingConfig, disableDeploy bool) (props map[string]string, wrapper, plugin bool, err error) {
-
 	wrapper = vConfig.GetBool(useWrapper)
 	if threads > 0 {
 		vConfig.Set(utils.ForkCount, threads)

--- a/utils/gradle/utils.go
+++ b/utils/gradle/utils.go
@@ -17,7 +17,7 @@ const (
 	useWrapper = "usewrapper"
 )
 
-func RunGradle(tasks, configPath, deployableArtifactsFile string, configuration *utils.BuildConfiguration, threads int, useWrapperIfMissingConfig, disableDeploy bool) error {
+func RunGradle(vConfig *viper.Viper, tasks, deployableArtifactsFile string, configuration *utils.BuildConfiguration, threads int, useWrapperIfMissingConfig, disableDeploy bool) error {
 	buildInfoService := utils.CreateBuildInfoService()
 	buildName, err := configuration.GetBuildName()
 	if err != nil {
@@ -35,7 +35,7 @@ func RunGradle(tasks, configPath, deployableArtifactsFile string, configuration 
 	if err != nil {
 		return errorutils.CheckError(err)
 	}
-	props, wrapper, plugin, err := createGradleRunConfig(configPath, deployableArtifactsFile, configuration, threads, useWrapperIfMissingConfig, disableDeploy)
+	props, wrapper, plugin, err := createGradleRunConfig(vConfig, deployableArtifactsFile, configuration, threads, useWrapperIfMissingConfig, disableDeploy)
 	if err != nil {
 		return err
 	}
@@ -48,19 +48,8 @@ func RunGradle(tasks, configPath, deployableArtifactsFile string, configuration 
 	return coreutils.ConvertExitCodeError(gradleModule.CalcDependencies())
 }
 
-func createGradleRunConfig(configPath, deployableArtifactsFile string, buildConf *utils.BuildConfiguration, threads int, useWrapperIfMissingConfig, disableDeploy bool) (props map[string]string, wrapper, plugin bool, err error) {
-	var vConfig *viper.Viper
-	if configPath == "" {
-		vConfig = viper.New()
-		vConfig.SetConfigType(string(utils.YAML))
-		vConfig.Set("type", utils.Gradle.String())
-		vConfig.Set(useWrapper, useWrapperIfMissingConfig)
-	} else {
-		vConfig, err = utils.ReadConfigFile(configPath, utils.YAML)
-		if err != nil {
-			return
-		}
-	}
+func createGradleRunConfig(vConfig *viper.Viper, deployableArtifactsFile string, buildConf *utils.BuildConfiguration, threads int, useWrapperIfMissingConfig, disableDeploy bool) (props map[string]string, wrapper, plugin bool, err error) {
+
 	wrapper = vConfig.GetBool(useWrapper)
 	if threads > 0 {
 		vConfig.Set(utils.ForkCount, threads)

--- a/xray/audit/java/gradle.go
+++ b/xray/audit/java/gradle.go
@@ -2,6 +2,7 @@ package java
 
 import (
 	"fmt"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	ioUtils "github.com/jfrog/jfrog-client-go/utils/io"
 
@@ -52,5 +53,10 @@ func runGradle(buildConfiguration *utils.BuildConfiguration, excludeTestDeps, us
 	} else {
 		configFilePath = ""
 	}
-	return gradleutils.RunGradle(tasks, configFilePath, "", buildConfiguration, 0, useWrapper, true)
+	// Read config
+	vConfig, err := utils.ReadGradleConfig(configFilePath, useWrapper)
+	if err != nil {
+		return err
+	}
+	return gradleutils.RunGradle(vConfig, tasks, "", buildConfiguration, 0, useWrapper, true)
 }

--- a/xray/audit/java/mvn.go
+++ b/xray/audit/java/mvn.go
@@ -2,6 +2,7 @@ package java
 
 import (
 	"fmt"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	ioUtils "github.com/jfrog/jfrog-client-go/utils/io"
 
@@ -47,5 +48,10 @@ func runMvn(buildConfiguration *utils.BuildConfiguration, insecureTls bool) erro
 	} else {
 		configFilePath = ""
 	}
-	return mvnutils.RunMvn(configFilePath, "", buildConfiguration, goals, 0, insecureTls, true)
+	// Read config
+	vConfig, err := utils.ReadMavenConfig(configFilePath)
+	if err != nil {
+		return err
+	}
+	return mvnutils.RunMvn(vConfig, "", buildConfiguration, goals, 0, insecureTls, true)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Whenever Maven/Gradle builds are run without a deployer, an error is returned:
![image](https://user-images.githubusercontent.com/9606235/184875654-f474ffcc-a664-4f4c-af2f-b550d30cc54a.png)
As there are no deployed artifacts, the deployment view fails to calculate the deployed artifacts.
We fix this bug by first checking if there is a deployer before calculating the deployment view