### PR TITLE
Fix login suspension in transfer-config

### DIFF
--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -202,7 +202,7 @@ func (tcc *TransferConfigCommand) isDefaultCredentials(manager artifactory.Artif
 		return false, err
 	}
 	for _, lockedUser := range lockedUsers {
-		if *lockedUser == adminUsername {
+		if lockedUser == adminUsername {
 			return false, nil
 		}
 	}

--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -208,7 +208,7 @@ func (tcc *TransferConfigCommand) isDefaultCredentials(manager artifactory.Artif
 	}
 
 	// Ping Artifactory with the default admin:password credentials
-	artDetails := config.ServerDetails{ArtifactoryUrl: tcc.sourceServerDetails.ArtifactoryUrl, User: "admin", Password: "password"}
+	artDetails := config.ServerDetails{ArtifactoryUrl: tcc.sourceServerDetails.ArtifactoryUrl, User: adminUsername, Password: "password"}
 	pingCmd := generic.NewPingCommand().SetServerDetails(&artDetails)
 	// This cannot be executed with commands.Exec()! Doing so will cause usage report being sent with admin:password as well.
 	err = pingCmd.Run()

--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -78,12 +78,17 @@ func (tcc *TransferConfigCommand) SetExcludeReposPatterns(excludeReposPatterns [
 }
 
 func (tcc *TransferConfigCommand) Run() (err error) {
-	log.Info(coreutils.PrintTitle(coreutils.PrintBold("========== Phase 1/4 - Preparations ==========")))
-	// Create config managers
 	sourceServicesManager, err := utils.CreateServiceManager(tcc.sourceServerDetails, -1, 0, tcc.dryRun)
 	if err != nil {
-		return
+		return err
 	}
+
+	continueTransfer, err := tcc.promptWarnings(sourceServicesManager)
+	if err != nil || !continueTransfer {
+		return err
+	}
+
+	log.Info(coreutils.PrintTitle(coreutils.PrintBold("========== Phase 1/4 - Preparations ==========")))
 	targetServiceManager, err := utils.CreateServiceManager(tcc.targetServerDetails, -1, 0, false)
 	if err != nil {
 		return
@@ -146,7 +151,75 @@ func (tcc *TransferConfigCommand) Run() (err error) {
 	}
 
 	// Update the server details of the target Artifactory in the CLI configuration
-	return tcc.updateServerDetails()
+	err = tcc.updateServerDetails()
+	if err != nil {
+		return
+	}
+
+	// If config transfer passed successfully, add conclusion message
+	log.Info("Config transfer completed successfully!")
+	log.Info("☝️  Please make sure to disable configuration transfer in MyJFrog before running the 'jf transfer-files' command.")
+	return nil
+}
+
+func (tcc *TransferConfigCommand) promptWarnings(sourceServicesManager artifactory.ArtifactoryServicesManager) (continueTransfer bool, err error) {
+	// Prompt message
+	promptMsg := "This command will transfer Artifactory config data:\n" +
+		fmt.Sprintf("From %s - <%s>\n", coreutils.PrintBold("Source"), tcc.sourceServerDetails.ArtifactoryUrl) +
+		fmt.Sprintf("To %s - <%s>\n", coreutils.PrintBold("Target"), tcc.targetServerDetails.ArtifactoryUrl) +
+		"This action will wipe out all Artifactory content in the target.\n" +
+		"Make sure that you're using strong credentials in your source platform (for example - having the default admin:password credentials isn't recommended).\n" +
+		"Those credentials will be transferred to your SaaS target platform.\n" +
+		"Are you sure you want to continue?"
+
+	if !coreutils.AskYesNo(promptMsg, false) {
+		return false, nil
+	}
+
+	// Check if there is a configured user using default credentials in the source platform.
+	isDefaultCredentials, err := tcc.isDefaultCredentials(sourceServicesManager)
+	if err != nil {
+		return false, err
+	}
+	if isDefaultCredentials {
+		log.Output()
+		log.Warn("The default 'admin:password' credentials are used by a configured user in your source platform.\n" +
+			"Those credentials will be transferred to your SaaS target platform.")
+		if !coreutils.AskYesNo("Are you sure you want to continue?", false) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// Check if there is a configured user using default credentials 'admin:password' by pinging Artifactory.
+func (tcc *TransferConfigCommand) isDefaultCredentials(manager artifactory.ArtifactoryServicesManager) (bool, error) {
+	adminUsername := "admin"
+
+	// Check if admin is locked
+	lockedUsers, err := manager.GetLockedUsers()
+	if err != nil {
+		return false, err
+	}
+	for _, lockedUser := range lockedUsers {
+		if *lockedUser == adminUsername {
+			return false, nil
+		}
+	}
+
+	// Ping Artifactory with the default admin:password credentials
+	artDetails := config.ServerDetails{ArtifactoryUrl: tcc.sourceServerDetails.ArtifactoryUrl, User: "admin", Password: "password"}
+	pingCmd := generic.NewPingCommand().SetServerDetails(&artDetails)
+	// This cannot be executed with commands.Exec()! Doing so will cause usage report being sent with admin:password as well.
+	err = pingCmd.Run()
+	if err == nil {
+		return true, nil
+	}
+
+	// If the password of the admin user is not the default one, reset the failed login attempts counter in Artifactory
+	// by unlocking the user. We do that to avoid login suspension to the admin user.
+	err = manager.UnlockUser(adminUsername)
+	return false, err
 }
 
 // Make sure source and target Artifactory URLs are different.

--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -83,7 +83,7 @@ func (tcc *TransferConfigCommand) Run() (err error) {
 		return err
 	}
 
-	continueTransfer, err := tcc.promptWarnings(sourceServicesManager)
+	continueTransfer, err := tcc.printWarnings(sourceServicesManager)
 	if err != nil || !continueTransfer {
 		return err
 	}
@@ -162,7 +162,7 @@ func (tcc *TransferConfigCommand) Run() (err error) {
 	return nil
 }
 
-func (tcc *TransferConfigCommand) promptWarnings(sourceServicesManager artifactory.ArtifactoryServicesManager) (continueTransfer bool, err error) {
+func (tcc *TransferConfigCommand) printWarnings(sourceServicesManager artifactory.ArtifactoryServicesManager) (continueTransfer bool, err error) {
 	// Prompt message
 	promptMsg := "This command will transfer Artifactory config data:\n" +
 		fmt.Sprintf("From %s - <%s>\n", coreutils.PrintBold("Source"), tcc.sourceServerDetails.ArtifactoryUrl) +

--- a/artifactory/commands/transferconfig/transferconfig_test.go
+++ b/artifactory/commands/transferconfig/transferconfig_test.go
@@ -168,3 +168,87 @@ func TestVerifyConfigImportPluginForbidden(t *testing.T) {
 	err := transferConfigCmd.verifyConfigImportPlugin(serviceManager)
 	assert.ErrorContains(t, err, "Response from Artifactory: 403 Forbidden.")
 }
+
+func TestIsDefaultCredentialsDefault(t *testing.T) {
+	unlockCounter := 0
+	testServer, serverDetails, serviceManager := commonTests.CreateRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI == "/api/security/lockedUsers" {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("[]"))
+			assert.NoError(t, err)
+		} else if r.RequestURI == "/api/system/ping" {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("OK"))
+			assert.NoError(t, err)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("User admin was successfully unlocked"))
+			assert.NoError(t, err)
+			unlockCounter++
+		}
+	})
+	defer testServer.Close()
+
+	transferConfigCmd := NewTransferConfigCommand(serverDetails, &config.ServerDetails{Url: "dummy-url"})
+	isDefaultCreds, err := transferConfigCmd.isDefaultCredentials(serviceManager)
+	assert.NoError(t, err)
+	assert.True(t, isDefaultCreds)
+	assert.Equal(t, 0, unlockCounter)
+}
+
+func TestIsDefaultCredentialsNotDefault(t *testing.T) {
+	unlockCounter := 0
+	testServer, serverDetails, serviceManager := commonTests.CreateRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI == "/api/security/lockedUsers" {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("[]"))
+			assert.NoError(t, err)
+		} else if r.RequestURI == "/api/system/ping" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, err := w.Write([]byte("{\n  \"errors\" : [ {\n    \"status\" : 401,\n    \"message\" : \"Bad credentials\"\n  } ]\n}"))
+			assert.NoError(t, err)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("User admin was successfully unlocked"))
+			assert.NoError(t, err)
+			unlockCounter++
+		}
+	})
+	defer testServer.Close()
+
+	transferConfigCmd := NewTransferConfigCommand(serverDetails, &config.ServerDetails{Url: "dummy-url"})
+	isDefaultCreds, err := transferConfigCmd.isDefaultCredentials(serviceManager)
+	assert.NoError(t, err)
+	assert.False(t, isDefaultCreds)
+	assert.Equal(t, 1, unlockCounter)
+}
+
+func TestIsDefaultCredentialsLocked(t *testing.T) {
+	pingCounter := 0
+	unlockCounter := 0
+	testServer, serverDetails, serviceManager := commonTests.CreateRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI == "/api/security/lockedUsers" {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("[ \"admin\" ]"))
+			assert.NoError(t, err)
+		} else if r.RequestURI == "/api/system/ping" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, err := w.Write([]byte("{\n  \"errors\" : [ {\n    \"status\" : 401,\n    \"message\" : \"Bad credentials\"\n  } ]\n}"))
+			assert.NoError(t, err)
+			pingCounter++
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("User admin was successfully unlocked"))
+			assert.NoError(t, err)
+			unlockCounter++
+		}
+	})
+	defer testServer.Close()
+
+	transferConfigCmd := NewTransferConfigCommand(serverDetails, &config.ServerDetails{Url: "dummy-url"})
+	isDefaultCreds, err := transferConfigCmd.isDefaultCredentials(serviceManager)
+	assert.NoError(t, err)
+	assert.False(t, isDefaultCreds)
+	assert.Equal(t, 0, pingCounter)
+	assert.Equal(t, 0, unlockCounter)
+}

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ exclude (
 	github.com/pkg/sftp v1.10.1
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/asafgabai/jfrog-client-go v0.18.1-0.20220817150520-035875e87974
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.20.2-0.20220818095957-e8efb324798a
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.4.1-0.20220815064747-507baf9c3b23
 

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ exclude (
 	github.com/pkg/sftp v1.10.1
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/asafgabai/jfrog-client-go v0.18.1-0.20220816131744-574c7f9c032f
+replace github.com/jfrog/jfrog-client-go => github.com/asafgabai/jfrog-client-go v0.18.1-0.20220817150520-035875e87974
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.4.1-0.20220815064747-507baf9c3b23
 

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ exclude (
 	github.com/pkg/sftp v1.10.1
 )
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.19.1-0.20220815065240-ce6ff8d10c30
+replace github.com/jfrog/jfrog-client-go => github.com/asafgabai/jfrog-client-go v0.18.1-0.20220816131744-574c7f9c032f
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.4.1-0.20220815064747-507baf9c3b23
 

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,6 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/asafgabai/jfrog-client-go v0.18.1-0.20220817150520-035875e87974 h1:qr3lCw6qxNfgDevVguPaIUkPojE/Goo6O5ERSmvIJdg=
-github.com/asafgabai/jfrog-client-go v0.18.1-0.20220817150520-035875e87974/go.mod h1:cuNzLQVvGILul2F37/tTtLQLObWcz46wrK1H8OeyktQ=
 github.com/ashanbrown/forbidigo v1.3.0/go.mod h1:vVW7PEdqEFqapJe95xHkTfB1+XvZXBFg8t0sG2FIxmI=
 github.com/ashanbrown/makezero v1.1.0/go.mod h1:oG9Dnez7/ESBqc4EdrdNlryeo7d0KcW1ftXHm7nU/UU=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -471,6 +469,8 @@ github.com/jfrog/build-info-go v1.4.1 h1:JdkMVpN+Cr+wMKVRJ1/2JeXtL7MLjVnGv23b/tA
 github.com/jfrog/build-info-go v1.4.1/go.mod h1:LM0CXNLF2FkvcyXrPEp6Ox1ARmcOsx/eOrVG2Jer2Ss=
 github.com/jfrog/gofrog v1.2.0 h1:vlVwEL5ppuwOjBHUphxxuHUAv4QC3vwF3FDI9aDrbqM=
 github.com/jfrog/gofrog v1.2.0/go.mod h1:IXM6bw5sI6hMdhamlCYQpB1W17S0D1dwvBtzhaIarNU=
+github.com/jfrog/jfrog-client-go v1.20.2-0.20220818095957-e8efb324798a h1:2sEq5bz3LzEPnyKxYvDFVv/BW8uI+XB7wEZgEXQW73U=
+github.com/jfrog/jfrog-client-go v1.20.2-0.20220818095957-e8efb324798a/go.mod h1:cuNzLQVvGILul2F37/tTtLQLObWcz46wrK1H8OeyktQ=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+Dtp+nu2qOq+er9c=

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/asafgabai/jfrog-client-go v0.18.1-0.20220816131744-574c7f9c032f h1:hQ75zU145QY/zbWFjDg9esdtP6VJCgYS4l054SUGpN8=
-github.com/asafgabai/jfrog-client-go v0.18.1-0.20220816131744-574c7f9c032f/go.mod h1:cuNzLQVvGILul2F37/tTtLQLObWcz46wrK1H8OeyktQ=
+github.com/asafgabai/jfrog-client-go v0.18.1-0.20220817150520-035875e87974 h1:qr3lCw6qxNfgDevVguPaIUkPojE/Goo6O5ERSmvIJdg=
+github.com/asafgabai/jfrog-client-go v0.18.1-0.20220817150520-035875e87974/go.mod h1:cuNzLQVvGILul2F37/tTtLQLObWcz46wrK1H8OeyktQ=
 github.com/ashanbrown/forbidigo v1.3.0/go.mod h1:vVW7PEdqEFqapJe95xHkTfB1+XvZXBFg8t0sG2FIxmI=
 github.com/ashanbrown/makezero v1.1.0/go.mod h1:oG9Dnez7/ESBqc4EdrdNlryeo7d0KcW1ftXHm7nU/UU=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/asafgabai/jfrog-client-go v0.18.1-0.20220816131744-574c7f9c032f h1:hQ75zU145QY/zbWFjDg9esdtP6VJCgYS4l054SUGpN8=
+github.com/asafgabai/jfrog-client-go v0.18.1-0.20220816131744-574c7f9c032f/go.mod h1:cuNzLQVvGILul2F37/tTtLQLObWcz46wrK1H8OeyktQ=
 github.com/ashanbrown/forbidigo v1.3.0/go.mod h1:vVW7PEdqEFqapJe95xHkTfB1+XvZXBFg8t0sG2FIxmI=
 github.com/ashanbrown/makezero v1.1.0/go.mod h1:oG9Dnez7/ESBqc4EdrdNlryeo7d0KcW1ftXHm7nU/UU=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -469,8 +471,6 @@ github.com/jfrog/build-info-go v1.4.1 h1:JdkMVpN+Cr+wMKVRJ1/2JeXtL7MLjVnGv23b/tA
 github.com/jfrog/build-info-go v1.4.1/go.mod h1:LM0CXNLF2FkvcyXrPEp6Ox1ARmcOsx/eOrVG2Jer2Ss=
 github.com/jfrog/gofrog v1.2.0 h1:vlVwEL5ppuwOjBHUphxxuHUAv4QC3vwF3FDI9aDrbqM=
 github.com/jfrog/gofrog v1.2.0/go.mod h1:IXM6bw5sI6hMdhamlCYQpB1W17S0D1dwvBtzhaIarNU=
-github.com/jfrog/jfrog-client-go v1.20.1 h1:TFdPaK9+rp6j2M5M2RBbTAJ74ERLEXTXPk/58kTDnBo=
-github.com/jfrog/jfrog-client-go v1.20.1/go.mod h1:cuNzLQVvGILul2F37/tTtLQLObWcz46wrK1H8OeyktQ=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+Dtp+nu2qOq+er9c=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Moved the default credentials check from jfrog-cli to jfrog-cli-core.
The default credentials check won't run if admin is locked. After the check, and only if admin doesn't have the default credentials, it will unlock admin to reset its failed login attempts counter in Artifactory and avoid him being suspended or locked.