### PR TITLE
Transfer - fix 'invalid phase id' message

### DIFF
--- a/artifactory/commands/transferfiles/transferfileprogress.go
+++ b/artifactory/commands/transferfiles/transferfileprogress.go
@@ -106,6 +106,10 @@ func (t *TransferProgressMng) ShouldDisplay() bool {
 
 // IncrementPhase increments completed tasks count for a specific phase by 1.
 func (t *TransferProgressMng) IncrementPhase(id int) error {
+	if len(t.phases) == 0 {
+		// Progress bar was terminated
+		return nil
+	}
 	if id < 0 || id > len(t.phases)-1 {
 		return errorutils.CheckErrorf("IncrementPhase: invalid phase id %d", id)
 	}
@@ -120,6 +124,10 @@ func (t *TransferProgressMng) IncrementPhase(id int) error {
 
 // IncrementPhaseBy increments completed tasks count for a specific phase by n.
 func (t *TransferProgressMng) IncrementPhaseBy(id, n int) error {
+	if len(t.phases) == 0 {
+		// Progress bar was terminated
+		return nil
+	}
 	if id < 0 || id > len(t.phases)-1 {
 		return errorutils.CheckErrorf("IncrementPhaseBy: invalid phase id %d", id)
 	}
@@ -136,6 +144,10 @@ func (t *TransferProgressMng) IncrementPhaseBy(id, n int) error {
 }
 
 func (t *TransferProgressMng) DonePhase(id int) error {
+	if len(t.phases) == 0 {
+		// Progress bar was terminated
+		return nil
+	}
 	if id < 0 || id > len(t.phases)-1 {
 		return errorutils.CheckErrorf("DonePhase: invalid phase id %d", id)
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
If the progress bar was terminated after clicking ctrl+c, the phases slice will be empty.
This PR return nil if the phases slice is empty.