### PR TITLE
Transfer - fix storage info time between retries

### DIFF
--- a/artifactory/utils/storageinfo.go
+++ b/artifactory/utils/storageinfo.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	serviceManagerRetriesPerRequest         = 3
-	serviceManagerRetriesWaitPerRequest int = int(1 * time.Second)
+	serviceManagerRetriesPerRequest                  = 3
+	serviceManagerRetriesWaitPerRequestMilliSecs int = 1000
 )
 
 var getRepoSummaryPollingTimeout = 10 * time.Minute
@@ -23,7 +23,7 @@ type StorageInfoManager struct {
 }
 
 func NewStorageInfoManager(serverDetails *config.ServerDetails) (*StorageInfoManager, error) {
-	serviceManager, err := CreateServiceManager(serverDetails, serviceManagerRetriesPerRequest, serviceManagerRetriesWaitPerRequest, false)
+	serviceManager, err := CreateServiceManager(serverDetails, serviceManagerRetriesPerRequest, serviceManagerRetriesWaitPerRequestMilliSecs, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Get storage info should be running with 3 retries and a wait-interval of 1 second between each attempt.
    