### PR TITLE
Fix GetProjectConfFilePath return value

### DIFF
--- a/artifactory/utils/projectconfig.go
+++ b/artifactory/utils/projectconfig.go
@@ -84,7 +84,7 @@ func GetProjectConfFilePath(projectType ProjectType) (confFilePath string, exist
 	}
 	if exists {
 		filePath := filepath.Join(projectDir, ".jfrog", confFileName)
-		exists, err = fileutils.IsFileExists(confFilePath, false)
+		exists, err = fileutils.IsFileExists(filePath, false)
 		if err != nil {
 			return
 		}
@@ -100,7 +100,7 @@ func GetProjectConfFilePath(projectType ProjectType) (confFilePath string, exist
 		return
 	}
 	filePath := filepath.Join(jfrogHomeDir, confFileName)
-	exists, err = fileutils.IsFileExists(confFilePath, false)
+	exists, err = fileutils.IsFileExists(filePath, false)
 	if exists {
 		confFilePath = filePath
 	}

--- a/artifactory/utils/projectconfig.go
+++ b/artifactory/utils/projectconfig.go
@@ -103,7 +103,6 @@ func GetProjectConfFilePath(projectType ProjectType) (confFilePath string, exist
 	exists, err = fileutils.IsFileExists(confFilePath, false)
 	if exists {
 		confFilePath = filePath
-		return
 	}
 	return
 }

--- a/artifactory/utils/projectconfig.go
+++ b/artifactory/utils/projectconfig.go
@@ -80,26 +80,31 @@ func GetProjectConfFilePath(projectType ProjectType) (confFilePath string, exist
 	confFileName := filepath.Join("projects", projectType.String()+".yaml")
 	projectDir, exists, err := fileutils.FindUpstream(".jfrog", fileutils.Dir)
 	if err != nil {
-		return "", false, err
+		return
 	}
 	if exists {
-		confFilePath = filepath.Join(projectDir, ".jfrog", confFileName)
+		filePath := filepath.Join(projectDir, ".jfrog", confFileName)
 		exists, err = fileutils.IsFileExists(confFilePath, false)
 		if err != nil {
-			return "", false, err
+			return
 		}
 
 		if exists {
+			confFilePath = filePath
 			return
 		}
 	}
 	// If missing in the root project, check in the home dir
 	jfrogHomeDir, err := coreutils.GetJfrogHomeDir()
 	if err != nil {
-		return "", exists, err
+		return
 	}
-	confFilePath = filepath.Join(jfrogHomeDir, confFileName)
+	filePath := filepath.Join(jfrogHomeDir, confFileName)
 	exists, err = fileutils.IsFileExists(confFilePath, false)
+	if exists {
+		confFilePath = filePath
+		return
+	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
GetProjectConfFilePath() should return empty path if config not exist or error thrown