### PR TITLE
Warn when configuring unsafe HTTP connections

### DIFF
--- a/common/commands/config.go
+++ b/common/commands/config.go
@@ -640,11 +640,11 @@ func (cc *ConfigCommand) assertUrlsSafe() error {
 			continue
 		}
 		if cc.interactive {
-			if cc.disablePrompts || !coreutils.AskYesNo("We noticed that your JFrog URL uses an insecure HTTP connection. Are you sure you want to continue?", false) {
+			if cc.disablePrompts || !coreutils.AskYesNo("Your JFrog URL uses an insecure HTTP connection, instead of HTTPS. Are you sure you want to continue?", false) {
 				return errorutils.CheckErrorf("config was aborted due to an insecure HTTP connection")
 			}
 		} else {
-			log.Warn("Your configured JFrog URL uses an insecure HTTP connection. Please consider replacing it with HTTPS.")
+			log.Warn("Your configured JFrog URL uses an insecure HTTP connection. Please consider using SSL (HTTPS instead of HTTP).")
 		}
 		return nil
 	}

--- a/common/commands/config_test.go
+++ b/common/commands/config_test.go
@@ -143,16 +143,45 @@ func TestBasicAuthOnlyOption(t *testing.T) {
 	assert.NoError(t, NewConfigCommand(Delete, "test").Run())
 }
 
-func TestUnsafeUrl(t *testing.T) {
-	// Test non-interactive - should pass with a warning message
-	inputDetails := tests.CreateTestServerDetails()
-	inputDetails.Url = "http://acme.jfrog.io"
-	configAndTest(t, inputDetails, false)
+type unsafeUrlTest struct {
+	url    string
+	isSafe bool
+}
 
-	// Test interactive - should fail with an error
-	configCmd := NewConfigCommand(AddOrEdit, "test").SetDetails(inputDetails).SetInteractive(true)
-	configCmd.disablePrompts = true
-	assert.ErrorContains(t, configCmd.Run(), "config was aborted due to an insecure HTTP connection")
+var unsafeUrlTestCases = []unsafeUrlTest{
+	// Safe URLs
+	{"https://acme.jfrog.io", true},
+	{"http://127.0.0.1", true},
+	{"http://localhost", true},
+	{"http://127.0.0.1:8081", true},
+	{"http://localhost:8081", true},
+	{"ssh://localhost:1339/", true},
+
+	// Unsafe URLs:
+	{"http://acme.jfrog.io", false},
+	{"http://acme.jfrog.io:8081", false},
+	{"http://localhost-123", false},
+}
+
+func TestAssertUrlsSafe(t *testing.T) {
+	for _, testCase := range unsafeUrlTestCases {
+		t.Run(testCase.url, func(t *testing.T) {
+			// Test non-interactive - should pass with a warning message
+			inputDetails := &config.ServerDetails{Url: testCase.url, ServerId: "test"}
+			configAndTest(t, inputDetails, false)
+
+			// Test interactive - should fail with an error
+			configCmd := NewConfigCommand(AddOrEdit, "test").SetDetails(inputDetails).SetInteractive(true)
+			configCmd.disablePrompts = true
+			err := configCmd.Run()
+			if testCase.isSafe {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, "config was aborted due to an insecure HTTP connection")
+			}
+		})
+	}
+
 }
 
 func TestExportEmptyConfig(t *testing.T) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Warn when a user configures an HTTP connection to the platform:
Interactive:
![image](https://user-images.githubusercontent.com/11367982/187082583-289bbaeb-7173-4b97-aec2-dbb80897cab0.png)

Non-interactive:
![image](https://user-images.githubusercontent.com/11367982/187082600-f6bacc3f-b210-4a8b-ae21-bc7d8768554d.png)
