### PR TITLE
Transfer Files - Improve polling when there is a network interrupt

### DIFF
--- a/artifactory/commands/transferfiles/srcpluginservice.go
+++ b/artifactory/commands/transferfiles/srcpluginservice.go
@@ -14,7 +14,7 @@ import (
 const pluginsExecuteRestApi = "api/plugins/execute/"
 const syncChunks = "syncChunks"
 
-type VerifyCompatabilityResponse struct {
+type VerifyCompatibilityResponse struct {
 	Version string `json:"version,omitempty"`
 	Message string `json:"message,omitempty"`
 }
@@ -146,19 +146,24 @@ func (sup *srcUserPluginService) version() (string, error) {
 	return commandsUtils.GetTransferPluginVersion(sup.client, dataTransferVersionUrl, "data-transfer", commandsUtils.Source, &httpDetails)
 }
 
-func (sup *srcUserPluginService) verifyCompatabilityRequest() (*VerifyCompatabilityResponse, *http.Response, error) {
+func (sup *srcUserPluginService) verifyCompatibilityRequest() (*VerifyCompatibilityResponse, error) {
 	httpDetails := sup.GetArtifactoryDetails().CreateHttpClientDetails()
-	resp, body, err := sup.client.SendPost(sup.GetArtifactoryDetails().GetUrl()+pluginsExecuteRestApi+"verifyCompatability", []byte{}, &httpDetails)
+	resp, body, err := sup.client.SendPost(sup.GetArtifactoryDetails().GetUrl()+pluginsExecuteRestApi+"verifyCompatibility", []byte("{}"), &httpDetails)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	var result VerifyCompatabilityResponse
+	var result VerifyCompatibilityResponse
 	err = json.Unmarshal(body, &result)
 	if err != nil {
-		return nil, nil, errorutils.CheckError(err)
+		return nil, errorutils.CheckError(err)
 	}
 
-	return &result, resp, nil
+	err = errorutils.CheckResponseStatus(resp, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
 }
 
 func (sup *srcUserPluginService) stop() (nodeId string, err error) {

--- a/artifactory/commands/transferfiles/srcpluginservice.go
+++ b/artifactory/commands/transferfiles/srcpluginservice.go
@@ -152,15 +152,16 @@ func (sup *srcUserPluginService) verifyCompatibilityRequest() (*VerifyCompatibil
 	if err != nil {
 		return nil, err
 	}
+
+	err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
 	var result VerifyCompatibilityResponse
 	err = json.Unmarshal(body, &result)
 	if err != nil {
 		return nil, errorutils.CheckError(err)
-	}
-
-	err = errorutils.CheckResponseStatus(resp, http.StatusOK)
-	if err != nil {
-		return nil, err
 	}
 
 	return &result, nil

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -1,9 +1,8 @@
 package transferfiles
 
 import (
-	"errors"
 	"fmt"
-	"net/http"
+	"github.com/jfrog/gofrog/version"
 	"os"
 	"os/signal"
 	"strings"
@@ -13,7 +12,6 @@ import (
 	"strconv"
 
 	buildInfoUtils "github.com/jfrog/build-info-go/utils"
-	"github.com/jfrog/gofrog/version"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -439,13 +437,9 @@ func getMinimalVersionErrorMsg(currentVersion string) string {
 }
 
 func getAndValidateDataTransferPlugin(srcUpService *srcUserPluginService) error {
-	verifyResponse, httpResponse, err := srcUpService.verifyCompatabilityRequest()
+	verifyResponse, err := srcUpService.verifyCompatibilityRequest()
 	if err != nil {
 		return err
-	}
-	err = errorutils.CheckResponseStatus(httpResponse, http.StatusOK)
-	if err != nil {
-		return errors.New(verifyResponse.Message)
 	}
 
 	err = validateDataTransferPluginMinimumVersion(verifyResponse.Version)

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -422,6 +423,9 @@ func (tdc *TransferFilesCommand) handleMaxUniqueSnapshots(repoSummary *serviceUt
 }
 
 func validateDataTransferPluginMinimumVersion(currentVersion string) error {
+	if strings.Contains(dataTransferPluginMinVersion, "SNAPSHOT") {
+		return nil
+	}
 	curVer := version.NewVersion(currentVersion)
 	if !curVer.AtLeast(dataTransferPluginMinVersion) {
 		return errorutils.CheckErrorf(getMinimalVersionErrorMsg(currentVersion))

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -421,7 +421,7 @@ func (tdc *TransferFilesCommand) handleMaxUniqueSnapshots(repoSummary *serviceUt
 }
 
 func validateDataTransferPluginMinimumVersion(currentVersion string) error {
-	if strings.Contains(dataTransferPluginMinVersion, "SNAPSHOT") {
+	if strings.Contains(currentVersion, "SNAPSHOT") {
 		return nil
 	}
 	curVer := version.NewVersion(currentVersion)

--- a/artifactory/commands/transferfiles/transfer_test.go
+++ b/artifactory/commands/transferfiles/transfer_test.go
@@ -28,7 +28,8 @@ func TestHandleStopInitAndClose(t *testing.T) {
 	assert.False(t, transferFilesCommand.ShouldStop())
 }
 
-const uuidTokenForTest = "af14706e-e0c1-4b7d-8791-6a18bd1fd339"
+const firstUuidTokenForTest = "347cd3e9-86b6-4bec-9be9-e053a485f327"
+const secondUuidTokenForTest = "af14706e-e0c1-4b7d-8791-6a18bd1fd339"
 
 func TestValidateDataTransferPluginMinimumVersion(t *testing.T) {
 	t.Run("valid version", func(t *testing.T) { testValidateDataTransferPluginMinimumVersion(t, "9.9.9", false) })
@@ -36,7 +37,7 @@ func TestValidateDataTransferPluginMinimumVersion(t *testing.T) {
 		testValidateDataTransferPluginMinimumVersion(t, dataTransferPluginMinVersion, false)
 	})
 	t.Run("invalid version", func(t *testing.T) { testValidateDataTransferPluginMinimumVersion(t, "1.0.0", true) })
-	t.Run("snapshot version", func(t *testing.T) { testValidateDataTransferPluginMinimumVersion(t, "1.0.x-SNAPSHOT", true) })
+	t.Run("snapshot version", func(t *testing.T) { testValidateDataTransferPluginMinimumVersion(t, "1.0.x-SNAPSHOT", false) })
 }
 
 func testValidateDataTransferPluginMinimumVersion(t *testing.T, curVersion string, errorExpected bool) {
@@ -84,24 +85,27 @@ func TestVerifyConfigImportPluginNotInstalled(t *testing.T) {
 
 func TestUploadChunkAndPollUploads(t *testing.T) {
 	totalChunkStatusVisits := 0
+	totalUploadChunkVisits := 0
 	fileSample := FileRepresentation{
 		Repo: "my-repo-local",
 		Path: "rel-path",
 		Name: "name-demo",
 	}
 
-	testServer, serverDetails, _ := initPollUploadsTestMockServer(t, &totalChunkStatusVisits, fileSample)
+	testServer, serverDetails, _ := initPollUploadsTestMockServer(t, &totalChunkStatusVisits, &totalUploadChunkVisits, fileSample)
 	defer testServer.Close()
 	srcPluginManager := initSrcUserPluginServiceManager(t, serverDetails)
 
-	uploadChunkAndPollThreeTimes(t, srcPluginManager, fileSample)
+	uploadChunkAndPollTwice(t, srcPluginManager, fileSample)
 
-	// Assert that exactly 3 requests to chunk status were made - once when it is still in progress, once after done received and once to notify back to the source.
-	assert.Equal(t, 3, totalChunkStatusVisits)
+	// Assert that exactly 2 requests to chunk status were made
+	// First request - get one DONE chunk and one IN PROGRESS
+	// Second Request - get DONE for the other chunk
+	assert.Equal(t, 2, totalChunkStatusVisits)
 }
 
 // Sends chunk to upload, polls on chunk three times - once when it is still in progress, once after done received and once to notify back to the source.
-func uploadChunkAndPollThreeTimes(t *testing.T, srcPluginManager *srcUserPluginService, fileSample FileRepresentation) {
+func uploadChunkAndPollTwice(t *testing.T, srcPluginManager *srcUserPluginService, fileSample FileRepresentation) {
 	curThreads = 8
 	uploadTokensChan := make(chan string, 3)
 	doneChan := make(chan bool, 1)
@@ -111,7 +115,9 @@ func uploadChunkAndPollThreeTimes(t *testing.T, srcPluginManager *srcUserPluginS
 	chunk.appendUploadCandidate(fileSample)
 	stopped := uploadChunkWhenPossible(&phaseBase{srcUpService: srcPluginManager, Stoppable: &Stoppable{}}, chunk, uploadTokensChan, nil)
 	assert.False(t, stopped)
-	assert.Equal(t, 1, curProcessedUploadChunks)
+	stopped = uploadChunkWhenPossible(&phaseBase{srcUpService: srcPluginManager, Stoppable: &Stoppable{}}, chunk, uploadTokensChan, nil)
+	assert.False(t, stopped)
+	assert.Equal(t, 2, curProcessedUploadChunks)
 
 	runWaitGroup.Add(1)
 	go func() {
@@ -125,9 +131,14 @@ func uploadChunkAndPollThreeTimes(t *testing.T, srcPluginManager *srcUserPluginS
 	runWaitGroup.Wait()
 }
 
-func getUploadChunkMockResponse(t *testing.T, w http.ResponseWriter) {
+func getUploadChunkMockResponse(t *testing.T, w http.ResponseWriter, totalUploadChunkVisits *int) {
 	w.WriteHeader(http.StatusAccepted)
-	resp := UploadChunkResponse{UuidTokenResponse: UuidTokenResponse{UuidToken: uuidTokenForTest}}
+	var resp UploadChunkResponse
+	if *totalUploadChunkVisits == 1 {
+		resp = UploadChunkResponse{UuidTokenResponse: UuidTokenResponse{UuidToken: firstUuidTokenForTest}}
+	} else {
+		resp = UploadChunkResponse{UuidTokenResponse: UuidTokenResponse{UuidToken: secondUuidTokenForTest}}
+	}
 	writeMockResponse(t, w, resp)
 }
 
@@ -140,38 +151,45 @@ func validateChunkStatusBody(t *testing.T, r *http.Request) {
 
 	// Make sure all parameters as expected
 	if len(actual.ChunksToDelete) == 0 {
-		assert.Len(t, actual.AwaitingStatusChunks, 1)
-		assert.Equal(t, uuidTokenForTest, actual.AwaitingStatusChunks[0])
+		assert.Len(t, actual.AwaitingStatusChunks, 2)
+		assert.Equal(t, firstUuidTokenForTest, actual.AwaitingStatusChunks[0])
+		assert.Equal(t, secondUuidTokenForTest, actual.AwaitingStatusChunks[1])
 	} else {
 		assert.Len(t, actual.ChunksToDelete, 1)
-		assert.Equal(t, uuidTokenForTest, actual.ChunksToDelete[0])
+		assert.Len(t, actual.AwaitingStatusChunks, 1)
+		assert.Equal(t, firstUuidTokenForTest, actual.ChunksToDelete[0])
+		assert.Equal(t, secondUuidTokenForTest, actual.AwaitingStatusChunks[0])
 	}
 
 }
 
-func getChunkStatusMockInProgressResponse(t *testing.T, w http.ResponseWriter) {
+func getChunkStatusMockFirstResponse(t *testing.T, w http.ResponseWriter) {
 	resp := UploadChunksStatusResponse{ChunksStatus: []ChunkStatus{
 		{
-			UuidTokenResponse: UuidTokenResponse{UuidToken: uuidTokenForTest},
+			UuidTokenResponse: UuidTokenResponse{UuidToken: firstUuidTokenForTest},
+			Status:            Done,
+		},
+		{
+			UuidTokenResponse: UuidTokenResponse{UuidToken: secondUuidTokenForTest},
 			Status:            InProgress,
 		},
 	}}
 	writeMockResponse(t, w, resp)
 }
 
-func getChunkStatusMockDoneResponse(t *testing.T, w http.ResponseWriter, file FileRepresentation) {
-	resp := UploadChunksStatusResponse{ChunksStatus: []ChunkStatus{
-		{
-			UuidTokenResponse: UuidTokenResponse{UuidToken: uuidTokenForTest},
-			Status:            Done,
-			Files:             []FileUploadStatusResponse{{FileRepresentation: file, Status: Success, StatusCode: http.StatusOK}},
+func getChunkStatusMockSecondResponse(t *testing.T, w http.ResponseWriter, file FileRepresentation) {
+	resp := UploadChunksStatusResponse{
+		ChunksStatus: []ChunkStatus{
+			{
+				UuidTokenResponse: UuidTokenResponse{UuidToken: secondUuidTokenForTest},
+				Status:            Done,
+				Files:             []FileUploadStatusResponse{{FileRepresentation: file, Status: Success, StatusCode: http.StatusOK}},
+			},
 		},
-	}}
-	writeMockResponse(t, w, resp)
-}
-
-func getChunkStatusMockChunksDeletedResponse(t *testing.T, w http.ResponseWriter) {
-	resp := UploadChunksStatusResponse{DeletedChunks: []string{uuidTokenForTest}}
+		DeletedChunks: []string{
+			firstUuidTokenForTest,
+		},
+	}
 	writeMockResponse(t, w, resp)
 }
 
@@ -182,20 +200,19 @@ func writeMockResponse(t *testing.T, w http.ResponseWriter, resp interface{}) {
 	assert.NoError(t, err)
 }
 
-func initPollUploadsTestMockServer(t *testing.T, totalChunkStatusVisits *int, file FileRepresentation) (*httptest.Server, *coreConfig.ServerDetails, artifactory.ArtifactoryServicesManager) {
+func initPollUploadsTestMockServer(t *testing.T, totalChunkStatusVisits *int, totalUploadChunkVisits *int, file FileRepresentation) (*httptest.Server, *coreConfig.ServerDetails, artifactory.ArtifactoryServicesManager) {
 	return commonTests.CreateRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.RequestURI == "/"+pluginsExecuteRestApi+"uploadChunk" {
-			getUploadChunkMockResponse(t, w)
+			*totalUploadChunkVisits++
+			getUploadChunkMockResponse(t, w, totalUploadChunkVisits)
 		} else if r.RequestURI == "/"+pluginsExecuteRestApi+syncChunks {
 			*totalChunkStatusVisits++
 			validateChunkStatusBody(t, r)
 			// If already visited chunk status, return status done this time.
 			if *totalChunkStatusVisits == 1 {
-				getChunkStatusMockInProgressResponse(t, w)
-			} else if *totalChunkStatusVisits == 2 {
-				getChunkStatusMockDoneResponse(t, w, file)
+				getChunkStatusMockFirstResponse(t, w)
 			} else {
-				getChunkStatusMockChunksDeletedResponse(t, w)
+				getChunkStatusMockSecondResponse(t, w, file)
 			}
 		}
 	})

--- a/artifactory/commands/transferfiles/transfer_test.go
+++ b/artifactory/commands/transferfiles/transfer_test.go
@@ -36,6 +36,7 @@ func TestValidateDataTransferPluginMinimumVersion(t *testing.T) {
 		testValidateDataTransferPluginMinimumVersion(t, dataTransferPluginMinVersion, false)
 	})
 	t.Run("invalid version", func(t *testing.T) { testValidateDataTransferPluginMinimumVersion(t, "1.0.0", true) })
+	t.Run("snapshot version", func(t *testing.T) { testValidateDataTransferPluginMinimumVersion(t, "1.0.x-SNAPSHOT", true) })
 }
 
 func testValidateDataTransferPluginMinimumVersion(t *testing.T, curVersion string, errorExpected bool) {

--- a/artifactory/commands/transferfiles/transfer_test.go
+++ b/artifactory/commands/transferfiles/transfer_test.go
@@ -42,7 +42,7 @@ func TestValidateDataTransferPluginMinimumVersion(t *testing.T) {
 func testValidateDataTransferPluginMinimumVersion(t *testing.T, curVersion string, errorExpected bool) {
 	var pluginVersion string
 	testServer, serverDetails, _ := commonTests.CreateRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/"+pluginsExecuteRestApi+"verifyCompatability" {
+		if r.RequestURI == "/"+pluginsExecuteRestApi+"verifyCompatibility" {
 			content, err := json.Marshal(utils.VersionResponse{Version: pluginVersion})
 			assert.NoError(t, err)
 			_, err = w.Write(content)

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -136,12 +136,8 @@ func pollUploads(phaseBase *phaseBase, srcUpService *srcUserPluginService, uploa
 			continue
 		}
 
-		// Send and handle.
-		curTokensBatch.AwaitingStatusChunks = awaitingStatusChunksSet.ToSlice()
-		curTokensBatch.ChunksToDelete = deletedChunksSet.ToSlice()
-		chunksStatus, err := srcUpService.syncChunks(curTokensBatch)
+		chunksStatus, err := sendSyncChunksRequest(curTokensBatch, awaitingStatusChunksSet, deletedChunksSet, srcUpService)
 		if err != nil {
-			log.Error("error returned when getting upload chunks statuses: " + err.Error())
 			continue
 		}
 		// Clear body for the next request
@@ -152,6 +148,17 @@ func pollUploads(phaseBase *phaseBase, srcUpService *srcUserPluginService, uploa
 			return
 		}
 	}
+}
+
+// Send and handle.
+func sendSyncChunksRequest(curTokensBatch UploadChunksStatusBody, awaitingStatusChunksSet *datastructures.Set[string], deletedChunksSet *datastructures.Set[string], srcUpService *srcUserPluginService) (UploadChunksStatusResponse, error) {
+	curTokensBatch.AwaitingStatusChunks = awaitingStatusChunksSet.ToSlice()
+	curTokensBatch.ChunksToDelete = deletedChunksSet.ToSlice()
+	chunksStatus, err := srcUpService.syncChunks(curTokensBatch)
+	if err != nil {
+		log.Error("error returned when getting upload chunks statuses: " + err.Error())
+	}
+	return chunksStatus, err
 }
 
 func removeDeletedChunksFromSet(deletedChunks []string, deletedChunksSet *datastructures.Set[string]) {

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -110,7 +110,9 @@ var processedUploadChunksMutex sync.Mutex
 // and a new token to be polled on.
 func pollUploads(phaseBase *phaseBase, srcUpService *srcUserPluginService, uploadTokensChan chan string, doneChan chan bool, errorsChannelMng *ErrorsChannelMng, progressbar *TransferProgressMng) {
 	curTokensBatch := UploadChunksStatusBody{}
+	// awaitingStatusChunksSet is used to keep all the uploaded chunks tokens in order to request their upload status from the source.
 	awaitingStatusChunksSet := datastructures.MakeSet[string]()
+	// deletedChunksSet is used to notify the source that these chunks can be deleted from the source's status map.
 	deletedChunksSet := datastructures.MakeSet[string]()
 	curProcessedUploadChunks = 0
 	for {
@@ -122,15 +124,12 @@ func pollUploads(phaseBase *phaseBase, srcUpService *srcUserPluginService, uploa
 		if progressbar != nil {
 			progressbar.SetRunningThreads(curProcessedUploadChunks)
 		}
-		// Each uploading thread receive a token from the source via the uploadTokensChan, so this go routine can poll on its status.
 
+		// Each uploading thread receive a token from the source via the uploadTokensChan, so this go routine can poll on its status.
 		fillTokensBatch(awaitingStatusChunksSet, uploadTokensChan)
-		// awaitingStatusChunksSet is used to keep all the uploaded chunks tokens in order to request their upload status from the source.
-		// deletedChunksSet is used to notify the source that these chunks can be deleted from the source's status map.
-		// After we receive 'DONE', we inform the source that the 'DONE' message has been received, and it no longer has to keep those chunks UUIDs.
-		// When both deletedChunksSet and awaitingStatusChunksSet length is zero, it means that all the tokens are uploaded,
+		// When awaitingStatusChunksSet size is zero, it means that all the tokens are uploaded,
 		// we received 'DONE' for all of them, and we notified the source that they can be deleted from the memory.
-		if awaitingStatusChunksSet.Size() == 0 && deletedChunksSet.Size() == 0 {
+		if awaitingStatusChunksSet.Size() == 0 {
 			if shouldStopPolling(doneChan) {
 				return
 			}
@@ -156,6 +155,8 @@ func pollUploads(phaseBase *phaseBase, srcUpService *srcUserPluginService, uploa
 }
 
 func removeDeletedChunksFromSet(deletedChunks []string, deletedChunksSet *datastructures.Set[string]) {
+	// deletedChunks is an array received from the source, confirming which chunks were deleted from the source side.
+	// In deletedChunksSet, we keep only chunks for which we have yet to receive confirmation
 	for _, deletedChunk := range deletedChunks {
 		err := deletedChunksSet.Remove(deletedChunk)
 		if err != nil {
@@ -188,6 +189,7 @@ func handleChunksStatuses(phase *phaseBase, chunksStatus []ChunkStatus, progress
 			if err != nil {
 				log.Error(err.Error())
 			}
+			// Using the deletedChunksSet, we inform the source that the 'DONE' message has been received, and it no longer has to keep those chunks UUIDs.
 			deletedChunksSet.Add(chunk.UuidToken)
 			stopped := handleFilesOfCompletedChunk(chunk.Files, errorsChannelMng)
 			// In case an error occurred while writing errors status's to the errors file - stop transferring.


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
- Refactor and reduce number of lines in pollUploads function.
- Stop polling although there are still chunks in the deletedChunksSet, the nodes stop between phases will handle this case
- Fix bug in validateDataTransferPluginMinimumVersion