### PR TITLE
Audit - fail the whole scan if one of the modules sacn failed

### DIFF
--- a/xray/audit/commonutils.go
+++ b/xray/audit/commonutils.go
@@ -1,7 +1,6 @@
 package audit
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,8 +106,7 @@ func Scan(modulesDependencyTrees []*services.GraphNode, xrayGraphScanPrams servi
 
 		scanResults, err := xraycommands.RunScanGraphAndGetResults(serverDetails, xrayGraphScanPrams, xrayGraphScanPrams.IncludeVulnerabilities, xrayGraphScanPrams.IncludeLicenses, xrayVersion)
 		if err != nil {
-			log.Error(fmt.Sprintf("Scanning %s failed with error: %s", moduleName, err.Error()))
-			break
+			return results, errorutils.CheckErrorf("Scanning %s failed with error: %s", moduleName, err.Error())
 		}
 		for i := range scanResults.Vulnerabilities {
 			scanResults.Vulnerabilities[i].Technology = technology
@@ -117,10 +115,6 @@ func Scan(modulesDependencyTrees []*services.GraphNode, xrayGraphScanPrams servi
 			scanResults.Violations[i].Technology = technology
 		}
 		results = append(results, *scanResults)
-	}
-	if results == nil || len(results) < 1 {
-		// If all scans failed, fail the audit command
-		return results, errorutils.CheckErrorf("Audit command failed due to Xray internal error")
 	}
 	return results, nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    