### PR TITLE
Transfer - skip handling errors if not needed

### DIFF
--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -228,6 +228,9 @@ func generateDiffAqlQuery(repoKey, fromTimestamp, toTimestamp string, pagination
 // Does so by creating and uploading by chunks, and polling on status.
 // Consumed errors files are deleted, new failures are written to new files.
 func (f *filesDiffPhase) handlePreviousUploadFailures() error {
+	if len(f.errorsFilesToHandle) == 0 {
+		return nil
+	}
 	log.Info("Starting to handle previous upload failures...")
 	manager := newTransferManager(f.phaseBase, getDelayUploadComparisonFunctions(f.repoSummary.PackageType))
 	action := func(pcWrapper *producerConsumerWrapper, uploadTokensChan chan string, delayHelper delayUploadHelper, errorsChannelMng *ErrorsChannelMng) error {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Currently, If there are no errors in phase 1, the code initializes a producer-consumer, attempting to upload an empty list. This process takes 20 seconds for each repository.
This PR avoids handling errors in phase 2 if not needed.