### PR TITLE
Transfer config - remove all federated members

### DIFF
--- a/artifactory/commands/testdata/config_xmls_federated_repos/expected/artifactory.config-0.xml
+++ b/artifactory/commands/testdata/config_xmls_federated_repos/expected/artifactory.config-0.xml
@@ -172,12 +172,7 @@
             <dockerTagRetention>1</dockerTagRetention>
             <enableComposerV1Indexing>false</enableComposerV1Indexing>
             <terraformType>MODULE</terraformType>
-            <federatedMembers>
-                <federatedMember>
-                    <url>https://acme.jfrog.io/artifactory/federated-generic-local</url>
-                    <enabled>true</enabled>
-                </federatedMember>
-            </federatedMembers>
+            <federatedMembers></federatedMembers>
             <modificationDate>1652778886914</modificationDate>
         </federatedRepository>
     </federatedRepositories>

--- a/artifactory/commands/testdata/config_xmls_federated_repos/expected/artifactory.config-1.xml
+++ b/artifactory/commands/testdata/config_xmls_federated_repos/expected/artifactory.config-1.xml
@@ -172,16 +172,7 @@
             <dockerTagRetention>1</dockerTagRetention>
             <enableComposerV1Indexing>false</enableComposerV1Indexing>
             <terraformType>MODULE</terraformType>
-            <federatedMembers>
-                <federatedMember>
-                    <url>https://acme.jfrog.io/artifactory/federated-generic-local</url>
-                    <enabled>true</enabled>
-                </federatedMember>
-                <federatedMember>
-                    <url>http://localhost:8082/artifactory/federated-generic-local</url>
-                    <enabled>true</enabled>
-                </federatedMember>
-            </federatedMembers>
+            <federatedMembers></federatedMembers>
             <modificationDate>1652778886914</modificationDate>
         </federatedRepository>
     </federatedRepositories>

--- a/artifactory/commands/testdata/config_xmls_federated_repos/expected/artifactory.config-2.xml
+++ b/artifactory/commands/testdata/config_xmls_federated_repos/expected/artifactory.config-2.xml
@@ -172,8 +172,7 @@
             <dockerTagRetention>1</dockerTagRetention>
             <enableComposerV1Indexing>false</enableComposerV1Indexing>
             <terraformType>MODULE</terraformType>
-            <federatedMembers>
-            </federatedMembers>
+            <federatedMembers></federatedMembers>
             <modificationDate>1652778886914</modificationDate>
         </federatedRepository>
     </federatedRepositories>

--- a/artifactory/commands/testdata/config_xmls_federated_repos/expected/artifactory.config-3.xml
+++ b/artifactory/commands/testdata/config_xmls_federated_repos/expected/artifactory.config-3.xml
@@ -173,12 +173,7 @@
             <dockerTagRetention>1</dockerTagRetention>
             <enableComposerV1Indexing>false</enableComposerV1Indexing>
             <terraformType>MODULE</terraformType>
-            <federatedMembers>
-                <federatedMember>
-                    <url>https://acme.jfrog.io/artifactory/federated-generic-local</url>
-                    <enabled>true</enabled>
-                </federatedMember>
-            </federatedMembers>
+            <federatedMembers></federatedMembers>
             <modificationDate>1652778886914</modificationDate>
         </federatedRepository>
         <federatedRepository>
@@ -215,12 +210,7 @@
             <dockerTagRetention>1</dockerTagRetention>
             <enableComposerV1Indexing>false</enableComposerV1Indexing>
             <terraformType>MODULE</terraformType>
-            <federatedMembers>
-                <federatedMember>
-                    <url>https://acme.jfrog.io/artifactory/federated-generic-local</url>
-                    <enabled>true</enabled>
-                </federatedMember>
-            </federatedMembers>
+            <federatedMembers></federatedMembers>
             <modificationDate>1652778886914</modificationDate>
         </federatedRepository>
     </federatedRepositories>

--- a/artifactory/commands/transferconfig/configxmlutils/federatedrepos.go
+++ b/artifactory/commands/transferconfig/configxmlutils/federatedrepos.go
@@ -1,53 +1,56 @@
 package configxmlutils
 
-import "github.com/jfrog/jfrog-client-go/utils/log"
-
 // Remove federated members of federated repositories in artifactory.config.xml
-// configXml     - artifactory.config.xml of the source Artifactory
-// targetBaseUrl - Base URL of the target Artifactory
-func RemoveFederatedMembers(configXml string) (string, error) {
+// configXml - artifactory.config.xml of the source Artifactory
+// Return the modified config.xml, a boolean indicating whether federated repositories were actually removed and an error, if any.
+func RemoveFederatedMembers(configXml string) (string, bool, error) {
 	xmlTagIndices, exist, err := findAllXmlTagIndices(configXml, `federatedRepositories`, true)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	if !exist {
-		return configXml, nil
+		return configXml, false, nil
 	}
 	results := ""
 	prefix, content, suffix := splitXmlTag(configXml, xmlTagIndices, 0)
-	federatedRepositories, err := fixFederatedRepositories(content)
+	federatedRepositories, federatedMembersRemoved, err := fixFederatedRepositories(content)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	results += prefix + federatedRepositories + suffix
-	return results, nil
+	return results, federatedMembersRemoved, nil
 }
 
-func fixFederatedRepositories(content string) (string, error) {
+// Remove federated members of federated repositories in all federated repositories.
+// content - The federated repositories content in artifactory.config.xml
+// Return the modified federated repositories in the config.xml, a boolean indicating whether federated repositories were actually removed and an error, if any.
+func fixFederatedRepositories(content string) (string, bool, error) {
 	xmlTagIndices, exist, err := findAllXmlTagIndices(content, `federatedRepository`, false)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	if !exist {
-		return content, nil
+		return content, false, nil
 	}
+	// federatedMembersRemoved indicates whether at least one federated member is removed
 	federatedMembersRemoved := false
 	results := ""
 	for i := range xmlTagIndices {
 		prefix, content, suffix := splitXmlTag(content, xmlTagIndices, i)
 		federatedRepository, removed, err := removeFederatedMembers(content)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
 		results += prefix + federatedRepository + suffix
+		// federatedMembersRemoved will be true only if at least one of the "removed" values will be true
 		federatedMembersRemoved = federatedMembersRemoved || removed
 	}
-	if federatedMembersRemoved {
-		log.Info("☝️  All federated members have been excluded from your federated repositories. Please configure your federation in the target server repositories.")
-	}
-	return results, nil
+	return results, federatedMembersRemoved, nil
 }
 
+// Remove federated members of federated repositories in a federated repository.
+// content - The federated repository content in artifactory.config.xml
+// Return the modified federated repository in the config.xml, a boolean indicating whether federated repositories were actually removed and an error, if any.
 func removeFederatedMembers(content string) (string, bool, error) {
 	xmlTagIndices, exist, err := findAllXmlTagIndices(content, `federatedMembers`, false)
 	if err != nil {
@@ -56,6 +59,7 @@ func removeFederatedMembers(content string) (string, bool, error) {
 	if !exist {
 		return content, false, nil
 	}
+	// The actual removing of the federated members content - We ignore the inner content of the XML tag.
 	prefix, _, suffix := splitXmlTag(content, xmlTagIndices, 0)
 	return prefix + suffix, true, nil
 }

--- a/artifactory/commands/transferconfig/configxmlutils/fereratedrepos_test.go
+++ b/artifactory/commands/transferconfig/configxmlutils/fereratedrepos_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,8 +26,9 @@ func TestRemoveFederatedMembers(t *testing.T) {
 			expectedConfigXml, err := os.ReadFile(expectedConfigXmlPath)
 			assert.NoError(t, err)
 
-			result, err := RemoveFederatedMembers(string(inputConfigXml))
+			result, federatedMembersRemoved, err := RemoveFederatedMembers(string(inputConfigXml))
 			assert.NoError(t, err)
+			assert.Equal(t, federatedMembersRemoved, strings.Contains(string(inputConfigXml), "federatedMembers"))
 			assert.Equal(t, string(expectedConfigXml), result)
 		})
 	}

--- a/artifactory/commands/transferconfig/configxmlutils/fereratedrepos_test.go
+++ b/artifactory/commands/transferconfig/configxmlutils/fereratedrepos_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReplaceUrlInFederatedrepos(t *testing.T) {
+func TestRemoveFederatedMembers(t *testing.T) {
 	testCasesDir := filepath.Join("..", "..", "testdata", "config_xmls_federated_repos")
 	files, err := os.ReadDir(filepath.Join(testCasesDir, "input"))
 	assert.NoError(t, err)
@@ -25,7 +25,7 @@ func TestReplaceUrlInFederatedrepos(t *testing.T) {
 			expectedConfigXml, err := os.ReadFile(expectedConfigXmlPath)
 			assert.NoError(t, err)
 
-			result, err := ReplaceUrlsInFederatedrepos(string(inputConfigXml), "http://localhost:8081/artifactory", "https://acme.jfrog.io/artifactory")
+			result, err := RemoveFederatedMembers(string(inputConfigXml))
 			assert.NoError(t, err)
 			assert.Equal(t, string(expectedConfigXml), result)
 		})

--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -132,7 +132,7 @@ func (tcc *TransferConfigCommand) Run() (err error) {
 	}
 
 	// Prepare the config XML to be imported to SaaS
-	configXml, err = tcc.modifyConfigXml(configXml, tcc.sourceServerDetails.ArtifactoryUrl, tcc.targetServerDetails.AccessUrl, repoFilter)
+	configXml, err = tcc.modifyConfigXml(configXml, tcc.targetServerDetails.ArtifactoryUrl, repoFilter)
 	if err != nil {
 		return
 	}
@@ -353,14 +353,14 @@ func (tcc *TransferConfigCommand) exportSourceArtifactory(sourceServicesManager 
 
 // Modify artifactory.config.xml:
 // 1. Remove non-included repositories, if provided
-// 2. Replace URL of federated repositories from sourceBaseUrl to targetBaseUrl
-func (tcc *TransferConfigCommand) modifyConfigXml(configXml, sourceBaseUrl, targetBaseUrl string, repoFilter *utils.RepositoryFilter) (string, error) {
+// 2. Remove federated members of federated repositories
+func (tcc *TransferConfigCommand) modifyConfigXml(configXml, targetBaseUrl string, repoFilter *utils.RepositoryFilter) (string, error) {
 	var err error
 	configXml, err = configxmlutils.RemoveNonIncludedRepositories(configXml, repoFilter)
 	if err != nil {
 		return "", err
 	}
-	return configxmlutils.ReplaceUrlsInFederatedrepos(configXml, sourceBaseUrl, targetBaseUrl)
+	return configxmlutils.RemoveFederatedMembers(configXml)
 }
 
 // Import from the input buffer to the target Artifactory


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Remove all federated members from all federated repositories. The reason for that change is to allow importing configuration from non-accessible members' URLs.

Add "Your Federated repositories have been transferred to your target instance, but their members have been removed on the target" message in the end:
![image](https://user-images.githubusercontent.com/11367982/189535173-3bd0d47d-509a-48bc-88d8-da2cbaf7af64.png)
