### PR TITLE
Transfer - Avoid uploading empty build-info dirs

### DIFF
--- a/artifactory/commands/transferfiles/api.go
+++ b/artifactory/commands/transferfiles/api.go
@@ -2,7 +2,10 @@ package transferfiles
 
 import (
 	"encoding/json"
+	"fmt"
+
 	"github.com/jfrog/gofrog/datastructures"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 type ProcessStatusType string
@@ -115,6 +118,13 @@ func fillTokensBatch(awaitingStatusChunksSet *datastructures.Set[string], upload
 	}
 }
 
-func (uc *UploadChunk) appendUploadCandidate(file FileRepresentation) {
+// Append upload candidate to the list of upload candidates. Skip empty directories in build-info repositories.
+// file          - The upload candidate
+// buildInfoRepo - True if this is a build-info repository
+func (uc *UploadChunk) appendUploadCandidateIfNeeded(file FileRepresentation, buildInfoRepo bool) {
+	if buildInfoRepo && file.Name == "" {
+		log.Debug(fmt.Sprintf("Skipping unneeded empty dir '%s' in the build-info repository '%s'", file.Path, file.Repo))
+		return
+	}
 	uc.UploadCandidates = append(uc.UploadCandidates, file)
 }

--- a/artifactory/commands/transferfiles/fulltransfer.go
+++ b/artifactory/commands/transferfiles/fulltransfer.go
@@ -169,7 +169,7 @@ func (m *fullTransferPhase) transferFolder(params folderParams, logMsgPrefix str
 
 		// Empty folder. Add it as candidate.
 		if paginationI == 0 && len(result.Results) == 0 {
-			curUploadChunk.appendUploadCandidate(FileRepresentation{Repo: params.repoKey, Path: params.relativePath})
+			curUploadChunk.appendUploadCandidateIfNeeded(FileRepresentation{Repo: params.repoKey, Path: params.relativePath}, m.buildInfoRepo)
 			break
 		}
 
@@ -200,7 +200,7 @@ func (m *fullTransferPhase) transferFolder(params folderParams, logMsgPrefix str
 				if delayed {
 					continue
 				}
-				curUploadChunk.appendUploadCandidate(file)
+				curUploadChunk.appendUploadCandidateIfNeeded(file, m.buildInfoRepo)
 				if len(curUploadChunk.UploadCandidates) == uploadChunkSize {
 					_, err = pcWrapper.chunkUploaderProducerConsumer.AddTaskWithError(uploadChunkWhenPossibleHandler(&m.phaseBase, curUploadChunk, uploadTokensChan, errorsChannelMng), pcWrapper.errorsQueue.AddError)
 					if err != nil {

--- a/artifactory/commands/transferfiles/transfer_test.go
+++ b/artifactory/commands/transferfiles/transfer_test.go
@@ -119,7 +119,7 @@ func uploadChunkAndPollTwice(t *testing.T, srcPluginManager *srcUserPluginServic
 	var runWaitGroup sync.WaitGroup
 
 	chunk := UploadChunk{}
-	chunk.appendUploadCandidate(fileSample)
+	chunk.appendUploadCandidateIfNeeded(fileSample, false)
 	stopped := uploadChunkWhenPossible(&phaseBase{context: context.Background(), srcUpService: srcPluginManager}, chunk, uploadTokensChan, nil)
 	assert.False(t, stopped)
 	stopped = uploadChunkWhenPossible(&phaseBase{context: context.Background(), srcUpService: srcPluginManager}, chunk, uploadTokensChan, nil)

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -364,7 +364,7 @@ func uploadByChunks(files []FileRepresentation, uploadTokensChan chan string, ba
 		if delayed {
 			continue
 		}
-		curUploadChunk.appendUploadCandidate(file)
+		curUploadChunk.appendUploadCandidateIfNeeded(file, base.buildInfoRepo)
 		if len(curUploadChunk.UploadCandidates) == uploadChunkSize {
 			_, err = pcWrapper.chunkUploaderProducerConsumer.AddTaskWithError(uploadChunkWhenPossibleHandler(&base, curUploadChunk, uploadTokensChan, errorsChannelMng), pcWrapper.errorsQueue.AddError)
 			if err != nil {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Uploading empty build-info directories (without the .json files) is meaningless and may cause unexpected behavior. One example of such unexpected behavior is the following error: (notice that the "name" is empty")
```CSV
Repo,Path,Name,Status,StatusCode,Reason,Time
artifactory-build-info,build-name,,FAIL,500,"FileExpectedException: Expected a file but found a folder, at: artifactory-build-info:build-name",2022-09-01T18:56:45Z
```