### PR TITLE
Fix Dotnet configfile usage

### DIFF
--- a/artifactory/commands/dotnet/dotnetcorecli.go
+++ b/artifactory/commands/dotnet/dotnetcorecli.go
@@ -2,12 +2,7 @@ package dotnet
 
 import (
 	"github.com/jfrog/build-info-go/build/utils/dotnet"
-	gofrogcmd "github.com/jfrog/gofrog/io"
-	"github.com/jfrog/gofrog/version"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 )
-
-const minDotnetSdkCoreVersionForAddSource = "3.1.200"
 
 type DotnetCoreCliCommand struct {
 	*DotnetCommand
@@ -20,27 +15,5 @@ func NewDotnetCoreCliCommand() *DotnetCoreCliCommand {
 }
 
 func (dccc *DotnetCoreCliCommand) Run() (err error) {
-	dccc.useNugetAddSource, err = isDotnetVersionAboveMin()
-	if err != nil {
-		return err
-	}
 	return dccc.Exec()
-}
-
-func isDotnetVersionAboveMin() (bool, error) {
-	// Run dotnet --version
-	versionCmd, err := dotnet.NewToolchainCmd(dotnet.DotnetCore)
-	if err != nil {
-		return false, err
-	}
-	versionCmd.CommandFlags = []string{"--version"}
-
-	output, err := gofrogcmd.RunCmdOutput(versionCmd)
-	if err != nil {
-		return false, err
-	}
-
-	dotNetSdkCoreVersion := version.NewVersion(output)
-	log.Debug("using .NET SDK Core", output)
-	return dotNetSdkCoreVersion.AtLeast(minDotnetSdkCoreVersionForAddSource), err
 }

--- a/artifactory/commands/dotnet/nuget.go
+++ b/artifactory/commands/dotnet/nuget.go
@@ -20,7 +20,6 @@ func NewNugetCommand() *NugetCommand {
 }
 
 func (nc *NugetCommand) Run() error {
-	nc.useNugetAddSource = true
 	return nc.Exec()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,6 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.22.1-0.20220905062038-e3221b3ab2be
 
-// replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.5.1-0.20220901152139-b617a66ca9b1
+replace github.com/jfrog/build-info-go => github.com/RobiNino/build-info-go v1.0.1-0.20220912064007-7aba1f05dfe1
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.1.3-0.20220630130242-df9cdb0c9e2d

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,6 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.22.1-0.20220905062038-e3221b3ab2be
 
-replace github.com/jfrog/build-info-go => github.com/RobiNino/build-info-go v1.0.1-0.20220912064007-7aba1f05dfe1
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.5.2-0.20220912090853-016d38955376
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.1.3-0.20220630130242-df9cdb0c9e2d

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VM
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/RobiNino/build-info-go v1.0.1-0.20220912064007-7aba1f05dfe1 h1:eHCd7S9VmaE6KV4WjO7zriLhFFaoIVVYRdR5Udj5grs=
-github.com/RobiNino/build-info-go v1.0.1-0.20220912064007-7aba1f05dfe1/go.mod h1:LkGqSQ9C14idhHq75b3tX1X3q51mxnFxrzKE+uxVaGk=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -198,6 +196,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jedib0t/go-pretty/v6 v6.3.7 h1:H3Ulkf7h6A+p0HgKBGzgDn0bZIupRbKKWF4pO4Bs7iA=
 github.com/jedib0t/go-pretty/v6 v6.3.7/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jfrog/build-info-go v1.5.2-0.20220912090853-016d38955376 h1:wzC1ImFfcF40ZCbAp9hq7em5cAJka5URcySkqbdh1go=
+github.com/jfrog/build-info-go v1.5.2-0.20220912090853-016d38955376/go.mod h1:LkGqSQ9C14idhHq75b3tX1X3q51mxnFxrzKE+uxVaGk=
 github.com/jfrog/gofrog v1.2.1 h1:3pIcyPfKcA9SIinE1UiC4+8OLg+UinHH/dfsOZH3qXg=
 github.com/jfrog/gofrog v1.2.1/go.mod h1:lbkGXX/DHKdomaSV34eiOC3pAr1HRNa9ffOYh7U7b1U=
 github.com/jfrog/jfrog-client-go v1.23.0 h1:9Q9TiLYduLKoghZaFhStu8mSLClfTpiEMYL0Gse/rfI=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VM
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
+github.com/RobiNino/build-info-go v1.0.1-0.20220912064007-7aba1f05dfe1 h1:eHCd7S9VmaE6KV4WjO7zriLhFFaoIVVYRdR5Udj5grs=
+github.com/RobiNino/build-info-go v1.0.1-0.20220912064007-7aba1f05dfe1/go.mod h1:LkGqSQ9C14idhHq75b3tX1X3q51mxnFxrzKE+uxVaGk=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -196,8 +198,6 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jedib0t/go-pretty/v6 v6.3.7 h1:H3Ulkf7h6A+p0HgKBGzgDn0bZIupRbKKWF4pO4Bs7iA=
 github.com/jedib0t/go-pretty/v6 v6.3.7/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/build-info-go v1.5.1 h1:V0OH12UnSTSdp7MxAr/5O9bXHMh2dwnN1cxKV6g5vLk=
-github.com/jfrog/build-info-go v1.5.1/go.mod h1:LkGqSQ9C14idhHq75b3tX1X3q51mxnFxrzKE+uxVaGk=
 github.com/jfrog/gofrog v1.2.1 h1:3pIcyPfKcA9SIinE1UiC4+8OLg+UinHH/dfsOZH3qXg=
 github.com/jfrog/gofrog v1.2.1/go.mod h1:lbkGXX/DHKdomaSV34eiOC3pAr1HRNa9ffOYh7U7b1U=
 github.com/jfrog/jfrog-client-go v1.23.0 h1:9Q9TiLYduLKoghZaFhStu8mSLClfTpiEMYL0Gse/rfI=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
 Following https://github.com/jfrog/jfrog-cli/issues/1623.
The configfile flag was not passed correctly to the Dotnet module when it was generated.
Breaking change: Removed unused setter `SetUseNugetAddSource`
Depends on https://github.com/jfrog/build-info-go/pull/103.