### PR TITLE
Transfer - producer consumers fixes

### DIFF
--- a/artifactory/commands/transferfiles/delayedartifactshandler.go
+++ b/artifactory/commands/transferfiles/delayedartifactshandler.go
@@ -91,7 +91,7 @@ func handleDelayedArtifactsFiles(filesToConsume []string, base phaseBase, delayU
 		}
 		return consumeDelayedArtifactsFiles(pcWrapper, filesToConsume, uploadTokensChan, base, delayHelper, errorsChannelMng)
 	}
-	err := manager.doTransferWithSingleProducer(action)
+	err := manager.doTransferWithProducerConsumer(action)
 	if err == nil {
 		log.Info("Done handling delayed artifacts uploads.")
 	}

--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -207,7 +207,7 @@ func (f *filesDiffPhase) handlePreviousUploadFailures() error {
 	action := func(pcWrapper *producerConsumerWrapper, uploadTokensChan chan string, delayHelper delayUploadHelper, errorsChannelMng *ErrorsChannelMng) error {
 		return f.handleErrorsFiles(pcWrapper, uploadTokensChan, delayHelper, errorsChannelMng)
 	}
-	err := manager.doTransferWithSingleProducer(action)
+	err := manager.doTransferWithProducerConsumer(action)
 	if err == nil {
 		log.Info("Done handling previous upload failures.")
 	}

--- a/artifactory/commands/transferfiles/fulltransfer.go
+++ b/artifactory/commands/transferfiles/fulltransfer.go
@@ -97,7 +97,7 @@ func (m *fullTransferPhase) run() error {
 func (m *fullTransferPhase) StopGracefully() {
 	m.phaseBase.StopGracefully()
 	if m.transferManager != nil {
-		m.transferManager.stopProcuderConsumer()
+		m.transferManager.stopProducerConsumer()
 	}
 }
 

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -24,7 +24,7 @@ import (
 const (
 	waitTimeBetweenChunkStatusSeconds            = 3
 	waitTimeBetweenThreadsUpdateSeconds          = 20
-	assumeProducerConsumerDoneWhenIdleForSeconds = 7
+	assumeProducerConsumerDoneWhenIdleForSeconds = 15
 	DefaultAqlPaginationLimit                    = 10000
 )
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Bug fix - changing threads did not update both producer consumers.
Bug fix - panic could occur if writers are closed before producer consumers.
