### PR TITLE
Transfer - Support HTTP proxy and check connectivity

### DIFF
--- a/artifactory/commands/transferfiles/api.go
+++ b/artifactory/commands/transferfiles/api.go
@@ -29,6 +29,7 @@ type TargetAuth struct {
 	TargetUsername       string `json:"target_username,omitempty"`
 	TargetPassword       string `json:"target_password,omitempty"`
 	TargetToken          string `json:"target_token,omitempty"`
+	TargetProxyKey       string `json:"target_proxy_key,omitempty"`
 }
 
 type HandlePropertiesDiff struct {

--- a/artifactory/commands/transferfiles/fulltransfer.go
+++ b/artifactory/commands/transferfiles/fulltransfer.go
@@ -123,7 +123,7 @@ func (m *fullTransferPhase) transferFolder(params folderParams, logMsgPrefix str
 	log.Debug(logMsgPrefix+"Visited folder:", path.Join(params.repoKey, params.relativePath))
 
 	curUploadChunk := UploadChunk{
-		TargetAuth:                createTargetAuth(m.targetRtDetails),
+		TargetAuth:                createTargetAuth(m.targetRtDetails, m.proxyKey),
 		CheckExistenceInFilestore: m.checkExistenceInFilestore,
 	}
 

--- a/artifactory/commands/transferfiles/phase.go
+++ b/artifactory/commands/transferfiles/phase.go
@@ -48,6 +48,7 @@ type phaseBase struct {
 	progressBar               *TransferProgressMng
 	repoSummary               serviceUtils.RepositorySummary
 	timeEstMng                *timeEstimationManager
+	proxyKey                  string
 }
 
 func (pb *phaseBase) ShouldStop() bool {
@@ -101,14 +102,14 @@ func (pb *phaseBase) setProgressBar(progressbar *TransferProgressMng) {
 	pb.progressBar = progressbar
 }
 
-func getPhaseByNum(context context.Context, i int, repoKey string, buildInfoRepo bool) transferPhase {
+func getPhaseByNum(context context.Context, i int, repoKey, proxyKey string, buildInfoRepo bool) transferPhase {
 	switch i {
 	case 0:
-		return &fullTransferPhase{phaseBase: phaseBase{context: context, repoKey: repoKey, phaseId: FullTransferPhase, buildInfoRepo: buildInfoRepo}}
+		return &fullTransferPhase{phaseBase: phaseBase{context: context, repoKey: repoKey, proxyKey: proxyKey, phaseId: FullTransferPhase, buildInfoRepo: buildInfoRepo}}
 	case 1:
-		return &filesDiffPhase{phaseBase: phaseBase{context: context, repoKey: repoKey, phaseId: FilesDiffPhase, buildInfoRepo: buildInfoRepo}}
+		return &filesDiffPhase{phaseBase: phaseBase{context: context, repoKey: repoKey, proxyKey: proxyKey, phaseId: FilesDiffPhase, buildInfoRepo: buildInfoRepo}}
 	case 2:
-		return &propertiesDiffPhase{phaseBase: phaseBase{context: context, repoKey: repoKey, phaseId: PropertiesDiffPhase}}
+		return &propertiesDiffPhase{phaseBase: phaseBase{context: context, repoKey: repoKey, proxyKey: proxyKey, phaseId: PropertiesDiffPhase}}
 	}
 	return nil
 }

--- a/artifactory/commands/transferfiles/propertiesdiff.go
+++ b/artifactory/commands/transferfiles/propertiesdiff.go
@@ -44,7 +44,7 @@ func (p *propertiesDiffPhase) run() error {
 	}
 
 	requestBody := HandlePropertiesDiff{
-		TargetAuth:        createTargetAuth(p.targetRtDetails),
+		TargetAuth:        createTargetAuth(p.targetRtDetails, p.proxyKey),
 		RepoKey:           p.repoKey,
 		StartMilliseconds: convertTimeToEpochMilliseconds(diffStart),
 		EndMilliseconds:   convertTimeToEpochMilliseconds(diffEnd),

--- a/artifactory/commands/transferfiles/srcpluginservice.go
+++ b/artifactory/commands/transferfiles/srcpluginservice.go
@@ -167,6 +167,20 @@ func (sup *srcUserPluginService) verifyCompatibilityRequest() (*VerifyCompatibil
 	return &result, nil
 }
 
+func (sup *srcUserPluginService) verifyConnectivityRequest(targetAuth TargetAuth) error {
+	httpDetails := sup.GetArtifactoryDetails().CreateHttpClientDetails()
+	content, err := json.Marshal(targetAuth)
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	resp, body, err := sup.client.SendPost(sup.GetArtifactoryDetails().GetUrl()+pluginsExecuteRestApi+"verifySourceTargetConnectivity", content, &httpDetails)
+	if err != nil {
+		return err
+	}
+
+	return errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK)
+}
+
 func (sup *srcUserPluginService) stop() (nodeId string, err error) {
 	httpDetails := sup.GetArtifactoryDetails().CreateHttpClientDetails()
 	resp, body, err := sup.client.SendPost(sup.GetArtifactoryDetails().GetUrl()+pluginsExecuteRestApi+"stop", []byte{}, &httpDetails)

--- a/artifactory/commands/transferfiles/srcpluginservice.go
+++ b/artifactory/commands/transferfiles/srcpluginservice.go
@@ -148,6 +148,7 @@ func (sup *srcUserPluginService) version() (string, error) {
 
 func (sup *srcUserPluginService) verifyCompatibilityRequest() (*VerifyCompatibilityResponse, error) {
 	httpDetails := sup.GetArtifactoryDetails().CreateHttpClientDetails()
+	utils.SetContentType("application/json", &httpDetails.Headers)
 	resp, body, err := sup.client.SendPost(sup.GetArtifactoryDetails().GetUrl()+pluginsExecuteRestApi+"verifyCompatibility", []byte("{}"), &httpDetails)
 	if err != nil {
 		return nil, err
@@ -169,6 +170,7 @@ func (sup *srcUserPluginService) verifyCompatibilityRequest() (*VerifyCompatibil
 
 func (sup *srcUserPluginService) verifyConnectivityRequest(targetAuth TargetAuth) error {
 	httpDetails := sup.GetArtifactoryDetails().CreateHttpClientDetails()
+	utils.SetContentType("application/json", &httpDetails.Headers)
 	content, err := json.Marshal(targetAuth)
 	if err != nil {
 		return errorutils.CheckError(err)

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -28,7 +28,7 @@ const (
 	fileWritersChannelSize       = 500000
 	retries                      = 1000
 	retriesWaitMilliSecs         = 1000
-	dataTransferPluginMinVersion = "1.4.1"
+	dataTransferPluginMinVersion = "1.5.0"
 )
 
 type TransferFilesCommand struct {
@@ -45,6 +45,7 @@ type TransferFilesCommand struct {
 	timeStarted               time.Time
 	ignoreState               bool
 	timeEstMng                *timeEstimationManager
+	proxyKey                  string
 }
 
 func NewTransferFilesCommand(sourceServer, targetServer *config.ServerDetails) *TransferFilesCommand {
@@ -78,14 +79,21 @@ func (tdc *TransferFilesCommand) SetIgnoreState(ignoreState bool) {
 	tdc.ignoreState = ignoreState
 }
 
+func (tdc *TransferFilesCommand) SetProxyKey(proxyKey string) {
+	tdc.proxyKey = proxyKey
+}
+
 func (tdc *TransferFilesCommand) Run() (err error) {
 	srcUpService, err := createSrcRtUserPluginServiceManager(tdc.context, tdc.sourceServerDetails)
 	if err != nil {
 		return err
 	}
 
-	// Verify connection to the source Artifactory instance, and that the user plugin is installed, responsive, and stands in the minimal version requirement.
 	if err = getAndValidateDataTransferPlugin(srcUpService); err != nil {
+		return err
+	}
+
+	if err = tdc.verifySourceTargetConnectivity(srcUpService); err != nil {
 		return err
 	}
 
@@ -230,7 +238,7 @@ func (tdc *TransferFilesCommand) transferSingleRepo(sourceRepoKey string, target
 		if err != nil {
 			log.Error(err)
 		}
-		*newPhase = getPhaseByNum(tdc.context, currentPhaseId, sourceRepoKey, buildInfoRepo)
+		*newPhase = getPhaseByNum(tdc.context, currentPhaseId, sourceRepoKey, tdc.proxyKey, buildInfoRepo)
 		if err = tdc.startPhase(newPhase, sourceRepoKey, *repoSummary, srcUpService); err != nil {
 			return
 		}
@@ -440,6 +448,16 @@ func (tdc *TransferFilesCommand) shouldStop() bool {
 	return tdc.context.Err() != nil
 }
 
+func (tdc *TransferFilesCommand) verifySourceTargetConnectivity(srcUpService *srcUserPluginService) error {
+	log.Info("Verifying source to target Artifactory servers connectivity...")
+	targetAuth := createTargetAuth(tdc.targetServerDetails, tdc.proxyKey)
+	err := srcUpService.verifyConnectivityRequest(targetAuth)
+	if err == nil {
+		log.Info("Connectivity check passed!")
+	}
+	return err
+}
+
 func validateDataTransferPluginMinimumVersion(currentVersion string) error {
 	if strings.Contains(currentVersion, "SNAPSHOT") {
 		return nil
@@ -456,6 +474,7 @@ func getMinimalVersionErrorMsg(currentVersion string) string {
 		currentVersion + "' on your source instance, while the minimum required version is '" + dataTransferPluginMinVersion + "' or higher."
 }
 
+// Verify connection to the source Artifactory instance, and that the user plugin is installed, responsive, and stands in the minimal version requirement.
 func getAndValidateDataTransferPlugin(srcUpService *srcUserPluginService) error {
 	verifyResponse, err := srcUpService.verifyCompatibilityRequest()
 	if err != nil {

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -78,9 +78,12 @@ func runAql(ctx context.Context, sourceRtDetails *config.ServerDetails, query st
 	return result, errorutils.CheckError(err)
 }
 
-func createTargetAuth(targetRtDetails *config.ServerDetails) TargetAuth {
-	targetAuth := TargetAuth{TargetArtifactoryUrl: targetRtDetails.ArtifactoryUrl,
-		TargetToken: targetRtDetails.AccessToken}
+func createTargetAuth(targetRtDetails *config.ServerDetails, proxyKey string) TargetAuth {
+	targetAuth := TargetAuth{
+		TargetArtifactoryUrl: targetRtDetails.ArtifactoryUrl,
+		TargetToken:          targetRtDetails.AccessToken,
+		TargetProxyKey:       proxyKey,
+	}
 	if targetAuth.TargetToken == "" {
 		targetAuth.TargetUsername = targetRtDetails.User
 		targetAuth.TargetPassword = targetRtDetails.Password
@@ -378,7 +381,7 @@ func uploadChunkWhenPossibleHandler(phaseBase *phaseBase, chunk UploadChunk, upl
 // An uuid token is returned after the chunk is sent and is being polled on for status.
 func uploadByChunks(files []FileRepresentation, uploadTokensChan chan string, base phaseBase, delayHelper delayUploadHelper, errorsChannelMng *ErrorsChannelMng, pcWrapper *producerConsumerWrapper) (shouldStop bool, err error) {
 	curUploadChunk := UploadChunk{
-		TargetAuth:                createTargetAuth(base.targetRtDetails),
+		TargetAuth:                createTargetAuth(base.targetRtDetails, base.proxyKey),
 		CheckExistenceInFilestore: base.checkExistenceInFilestore,
 	}
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Depends on https://github.com/jfrog/data-transfer/pull/37

* Add support for an HTTP proxy, configured in the platform UI.
* Check connectivity between the source and the target Artifactory servers before starting the transfer.
