### PR TITLE
Bug fix - GetReposTotalSize was missing reset between polling

### DIFF
--- a/artifactory/utils/storageinfo.go
+++ b/artifactory/utils/storageinfo.go
@@ -95,7 +95,7 @@ func (sim *StorageInfoManager) GetReposTotalSize(repoKeys ...string) (int64, err
 		PollingInterval: getRepoSummaryPollingInterval,
 		MsgPrefix:       "Waiting for storage info calculation completion",
 		PollingAction: func() (shouldStop bool, responseBody []byte, err error) {
-			// Reset counters between polling.
+			// Reset counters between polling attempts.
 			totalSize = 0
 			reposCounted = 0
 

--- a/artifactory/utils/storageinfo_test.go
+++ b/artifactory/utils/storageinfo_test.go
@@ -127,7 +127,7 @@ func TestGetReposTotalSize(t *testing.T) {
 	assert.Equal(t, int64(13023), total)
 
 	// Assert error is returned due to the missing repository.
-	total, err = storageInfoManager.GetReposTotalSize("repo-1", "repo-2", "repo-3")
+	_, err = storageInfoManager.GetReposTotalSize("repo-1", "repo-2", "repo-3")
 	assert.EqualError(t, err, getStorageInfoRepoMissingError())
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    