### PR TITLE
Transfer - CTRL+C doesn't shut down the process

### DIFF
--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -110,7 +110,7 @@ type timeFrameParams struct {
 func (f *filesDiffPhase) createDiffTimeFrameHandlerFunc(pcWrapper *producerConsumerWrapper, uploadChunkChan chan UploadedChunkData, delayHelper delayUploadHelper, errorsChannelMng *ErrorsChannelMng) diffTimeFrameHandlerFunc {
 	return func(params timeFrameParams) parallel.TaskFunc {
 		return func(threadId int) error {
-			defer pcWrapper.notifyIfBuilderFinished()
+			defer pcWrapper.notifyIfBuilderFinished(false)
 			logMsgPrefix := clientUtils.GetLogMsgPrefix(threadId, false)
 			return f.handleTimeFrameFilesDiff(pcWrapper, params, logMsgPrefix, uploadChunkChan, delayHelper, errorsChannelMng)
 		}

--- a/artifactory/commands/transferfiles/fileserror.go
+++ b/artifactory/commands/transferfiles/fileserror.go
@@ -94,7 +94,7 @@ func (e *errorsRetryPhase) createErrorFilesHandleFunc(pcWrapper *producerConsume
 		return func(threadId int) error {
 			var errList []string
 			var err error
-			defer pcWrapper.notifyIfBuilderFinished()
+			defer pcWrapper.notifyIfBuilderFinished(false)
 			for _, errFile := range e.errorsFilesToHandle {
 				err = e.handleErrorsFile(errFile, pcWrapper, uploadChunkChan, delayHelper, errorsChannelMng)
 				if err != nil {

--- a/artifactory/commands/transferfiles/fulltransfer.go
+++ b/artifactory/commands/transferfiles/fulltransfer.go
@@ -104,7 +104,7 @@ func (m *fullTransferPhase) createFolderFullTransferHandlerFunc(pcWrapper produc
 	delayHelper delayUploadHelper, errorsChannelMng *ErrorsChannelMng) folderFullTransferHandlerFunc {
 	return func(params folderParams) parallel.TaskFunc {
 		return func(threadId int) error {
-			defer pcWrapper.notifyIfBuilderFinished()
+			defer pcWrapper.notifyIfBuilderFinished(false)
 			logMsgPrefix := clientUtils.GetLogMsgPrefix(threadId, false)
 			return m.transferFolder(params, logMsgPrefix, pcWrapper, uploadChunkChan, delayHelper, errorsChannelMng)
 		}

--- a/artifactory/commands/transferfiles/phase.go
+++ b/artifactory/commands/transferfiles/phase.go
@@ -49,6 +49,7 @@ type phaseBase struct {
 	repoSummary               serviceUtils.RepositorySummary
 	timeEstMng                *timeEstimationManager
 	proxyKey                  string
+	pcDetails                 *producerConsumerWrapper
 }
 
 func (pb *phaseBase) ShouldStop() bool {

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -464,7 +464,7 @@ func shouldStopPolling(doneChan chan bool) bool {
 func uploadChunkWhenPossibleHandler(pcWrapper *producerConsumerWrapper, phaseBase *phaseBase, chunk UploadChunk,
 	uploadTokensChan chan UploadedChunkData, errorsChannelMng *ErrorsChannelMng) parallel.TaskFunc {
 	return func(threadId int) error {
-		defer pcWrapper.notifyIfUploaderFinished()
+		defer pcWrapper.notifyIfUploaderFinished(false)
 		logMsgPrefix := clientUtils.GetLogMsgPrefix(threadId, false)
 		log.Debug(logMsgPrefix + "Handling chunk upload")
 		shouldStop := uploadChunkWhenPossible(phaseBase, chunk, uploadTokensChan, errorsChannelMng)
@@ -531,6 +531,8 @@ func addErrorToChannel(errorsChannelMng *ErrorsChannelMng, file FileUploadStatus
 func ShouldStop(phase *phaseBase, delayHelper *delayUploadHelper, errorsChannelMng *ErrorsChannelMng) bool {
 	if phase != nil && phase.ShouldStop() {
 		log.Debug("Stop transferring data - Interrupted.")
+		phase.pcDetails.notifyIfBuilderFinished(true)
+		phase.pcDetails.notifyIfUploaderFinished(true)
 		return true
 	}
 	if delayHelper != nil && delayHelper.delayedArtifactsChannelMng.shouldStop() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
When attempting to stop the transfer-files command with CTRL+C the command doesn't stop. This is caused as a result of the new `notifyIfBuilderFinished ` and `notifyIfUploaderFinished ` mechanisms, which may cause the application to wait for the two producer-consumers to finish, even if the system is in "shut down more". 
To fix the issue, these two mechanism are now released as part of the `ShouldStop` function.
See the these lines which trigger the release. They receive a new "force" boolean set to true.
```
phase.pcDetails.notifyIfBuilderFinished(true)
phase.pcDetails.notifyIfUploaderFinished(true)
```