### PR TITLE
Transfer - Notify pc finished after graceful stop

### DIFF
--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -78,7 +78,7 @@ func (f *filesDiffPhase) handleDiffTimeFrames() error {
 		return err
 	}
 
-	manager := newTransferManager(f.phaseBase, getDelayUploadComparisonFunctions(f.repoSummary.PackageType))
+	f.transferManager = newTransferManager(f.phaseBase, getDelayUploadComparisonFunctions(f.repoSummary.PackageType))
 	action := func(pcWrapper *producerConsumerWrapper, uploadChunkChan chan UploadedChunkData, delayHelper delayUploadHelper, errorsChannelMng *ErrorsChannelMng) error {
 		// Create tasks to handle files diffs in time frames of searchTimeFramesMinutes.
 		// In case an error occurred while handling errors/delayed artifacts files - stop transferring.
@@ -93,7 +93,7 @@ func (f *filesDiffPhase) handleDiffTimeFrames() error {
 		}
 		return nil
 	}
-	err = manager.doTransferWithProducerConsumer(action)
+	err = f.transferManager.doTransferWithProducerConsumer(action)
 	if err == nil {
 		log.Info("Done handling files diffs.")
 	}

--- a/artifactory/commands/transferfiles/fileserror.go
+++ b/artifactory/commands/transferfiles/fileserror.go
@@ -35,13 +35,13 @@ func (e *errorsRetryPhase) handlePreviousUploadFailures() error {
 		return nil
 	}
 	log.Info("Starting to handle previous upload failures...")
-	manager := newTransferManager(e.phaseBase, getDelayUploadComparisonFunctions(e.repoSummary.PackageType))
+	e.transferManager = newTransferManager(e.phaseBase, getDelayUploadComparisonFunctions(e.repoSummary.PackageType))
 	action := func(pcWrapper *producerConsumerWrapper, uploadChunkChan chan UploadedChunkData, delayHelper delayUploadHelper, errorsChannelMng *ErrorsChannelMng) error {
 		errFileHandler := e.createErrorFilesHandleFunc(pcWrapper, uploadChunkChan, delayHelper, errorsChannelMng)
 		_, err := pcWrapper.chunkBuilderProducerConsumer.AddTaskWithError(errFileHandler(), pcWrapper.errorsQueue.AddError)
 		return err
 	}
-	err := manager.doTransferWithProducerConsumer(action)
+	err := e.transferManager.doTransferWithProducerConsumer(action)
 	if err == nil {
 		log.Info("Done handling previous upload failures.")
 	}

--- a/artifactory/commands/transferfiles/fulltransfer.go
+++ b/artifactory/commands/transferfiles/fulltransfer.go
@@ -86,13 +86,6 @@ func (m *fullTransferPhase) run() error {
 	return m.transferManager.doTransferWithProducerConsumer(action)
 }
 
-func (m *fullTransferPhase) StopGracefully() {
-	m.phaseBase.StopGracefully()
-	if m.transferManager != nil {
-		m.transferManager.stopProducerConsumer()
-	}
-}
-
 type folderFullTransferHandlerFunc func(params folderParams) parallel.TaskFunc
 
 type folderParams struct {

--- a/artifactory/commands/transferfiles/manager.go
+++ b/artifactory/commands/transferfiles/manager.go
@@ -124,13 +124,6 @@ func (ftm *transferManager) doTransfer(pcWrapper *producerConsumerWrapper, trans
 	return returnedError
 }
 
-func (ftm *transferManager) stopProducerConsumer() {
-	if ftm.pcDetails != nil {
-		ftm.pcDetails.chunkBuilderProducerConsumer.Cancel()
-		ftm.pcDetails.chunkUploaderProducerConsumer.Cancel()
-	}
-}
-
 type PollingTasksManager struct {
 	// Done channel notifies the polling go routines that no more tasks are expected.
 	doneChannel chan bool

--- a/artifactory/commands/transferfiles/phase.go
+++ b/artifactory/commands/transferfiles/phase.go
@@ -50,6 +50,7 @@ type phaseBase struct {
 	timeEstMng                *timeEstimationManager
 	proxyKey                  string
 	pcDetails                 *producerConsumerWrapper
+	transferManager           *transferManager
 }
 
 func (pb *phaseBase) ShouldStop() bool {
@@ -64,10 +65,16 @@ func (pb *phaseBase) getInterruptionErr() error {
 	return nil
 }
 
-// Indicate graceful stopping in the progress bar
+// Stop and indicate graceful stopping in the progress bar
 func (pb *phaseBase) StopGracefully() {
 	if pb.progressBar != nil {
 		pb.progressBar.StopGracefully()
+	}
+	if pb.pcDetails != nil {
+		pb.pcDetails.chunkBuilderProducerConsumer.Cancel()
+		pb.pcDetails.chunkUploaderProducerConsumer.Cancel()
+		pb.pcDetails.notifyIfBuilderFinished(true)
+		pb.pcDetails.notifyIfUploaderFinished(true)
 	}
 }
 

--- a/artifactory/commands/transferfiles/phase_test.go
+++ b/artifactory/commands/transferfiles/phase_test.go
@@ -34,7 +34,7 @@ func TestStopGracefully(t *testing.T) {
 	err := runProducerConsumers(phaseBase.pcDetails)
 	assert.NoError(t, err)
 
-	// Since we stopped the tasks after half second, expect the tasks to run exactly once
+	// Since we stopped the tasks after half second, and the tasks sleep for one second during their execution, expect the tasks to run exactly once.
 	assert.Equal(t, 1, uploaderCounter)
 	assert.Equal(t, 1, builderCounter)
 

--- a/artifactory/commands/transferfiles/phase_test.go
+++ b/artifactory/commands/transferfiles/phase_test.go
@@ -1,0 +1,53 @@
+package transferfiles
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jfrog/gofrog/parallel"
+	"github.com/stretchr/testify/assert"
+)
+
+const zeroUint32 uint32 = 0
+
+func TestStopGracefully(t *testing.T) {
+	phaseBase := &phaseBase{pcDetails: newProducerConsumerWrapper()}
+	go func() {
+		// Stop gracefully after half second
+		time.Sleep(time.Second / 2)
+
+		// Assert active threads before stopping the producer consumers
+		phaseBase.pcDetails.chunkUploaderProducerConsumer.IsStarted()
+		assert.Greater(t, phaseBase.pcDetails.chunkUploaderProducerConsumer.ActiveThreads(), zeroUint32)
+		assert.Greater(t, phaseBase.pcDetails.chunkBuilderProducerConsumer.ActiveThreads(), zeroUint32)
+
+		// Stop the running threads
+		phaseBase.StopGracefully()
+	}()
+
+	// Run 5 counter tasks in the uploader and builder producer-consumers
+	uploaderCounter, builderCounter := 0, 0
+	for i := 0; i < 5; i++ {
+		phaseBase.pcDetails.chunkUploaderProducerConsumer.AddTask(createCounterTask(&uploaderCounter))
+		phaseBase.pcDetails.chunkBuilderProducerConsumer.AddTask(createCounterTask(&builderCounter))
+	}
+	err := runProducerConsumers(phaseBase.pcDetails)
+	assert.NoError(t, err)
+
+	// Since we stopped the tasks after half second, expect the tasks to run exactly once
+	assert.Equal(t, 1, uploaderCounter)
+	assert.Equal(t, 1, builderCounter)
+
+	// Assert no active threads
+	assert.Equal(t, zeroUint32, phaseBase.pcDetails.chunkUploaderProducerConsumer.ActiveThreads())
+	assert.Equal(t, zeroUint32, phaseBase.pcDetails.chunkBuilderProducerConsumer.ActiveThreads())
+}
+
+// Create a task that increases the counter by 1 after a second
+func createCounterTask(counter *int) parallel.TaskFunc {
+	return func(int) error {
+		(*counter)++
+		time.Sleep(time.Second)
+		return nil
+	}
+}

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -531,8 +531,6 @@ func addErrorToChannel(errorsChannelMng *ErrorsChannelMng, file FileUploadStatus
 func ShouldStop(phase *phaseBase, delayHelper *delayUploadHelper, errorsChannelMng *ErrorsChannelMng) bool {
 	if phase != nil && phase.ShouldStop() {
 		log.Debug("Stop transferring data - Interrupted.")
-		phase.pcDetails.notifyIfBuilderFinished(true)
-		phase.pcDetails.notifyIfUploaderFinished(true)
 		return true
 	}
 	if delayHelper != nil && delayHelper.delayedArtifactsChannelMng.shouldStop() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Followup https://github.com/jfrog/jfrog-cli-core/pull/570

Notify and cancel producer-consumers after every step - full transfer, diff, or file errors transfer. This expected to happen before calling to ShouldStop, right after clicking ctrl+c.
