### PR TITLE
Fix minor issue in state and add tests

### DIFF
--- a/artifactory/commands/transferfiles/state/state.go
+++ b/artifactory/commands/transferfiles/state/state.go
@@ -60,7 +60,7 @@ func (ts *TransferState) getRepository(repoKey string, createIfMissing bool) (*R
 	}
 	repo := newRepositoryState(repoKey)
 	ts.Repositories = append(ts.Repositories, repo)
-	return &repo, nil
+	return &ts.Repositories[len(ts.Repositories)-1], nil
 }
 
 func newRepositoryState(repoKey string) Repository {

--- a/artifactory/commands/transferfiles/status_test.go
+++ b/artifactory/commands/transferfiles/status_test.go
@@ -1,10 +1,120 @@
 package transferfiles
 
 import (
+	"bytes"
 	"testing"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/jfrog/build-info-go/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/state"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/stretchr/testify/assert"
 )
+
+func initStatusTest(t *testing.T) (*bytes.Buffer, func()) {
+	cleanUpJfrogHome, err := tests.SetJfrogHome()
+	assert.NoError(t, err)
+
+	// Create transfer directory
+	transferDir, err := coreutils.GetJfrogTransferDir()
+	assert.NoError(t, err)
+	err = utils.CreateDirIfNotExist(transferDir)
+	assert.NoError(t, err)
+
+	// Redirect log to buffer
+	buffer, _, previousLog := tests.RedirectLogOutputToBuffer()
+	return buffer, func() {
+		log.SetLogger(previousLog)
+		cleanUpJfrogHome()
+	}
+}
+
+func TestShowStatusNotRunning(t *testing.T) {
+	buffer, cleanUp := initStatusTest(t)
+	defer cleanUp()
+
+	// Run show status and check output
+	assert.NoError(t, ShowStatus())
+	assert.Contains(t, buffer.String(), "Status:Not running")
+}
+
+func TestShowStatus(t *testing.T) {
+	buffer, cleanUp := initStatusTest(t)
+	defer cleanUp()
+
+	// Create state manager and persist to file system
+	createStateManager(t, FullTransferPhase)
+
+	// Run show status and check output
+	assert.NoError(t, ShowStatus())
+	results := buffer.String()
+
+	// Check overall status
+	assert.Contains(t, results, "Overall Transfer Status")
+	assert.Contains(t, results, "Status:		Running")
+	assert.Contains(t, results, "Start time:		")
+	assert.Contains(t, results, "Storage:		4.9 KiB / 10.9 KiB (45.0%)")
+	assert.Contains(t, results, "Repositories:	15 / 1111 (1.4%)")
+	assert.Contains(t, results, "Working threads:	16")
+
+	// Check repository status
+	assert.Contains(t, results, "Current Repository Status")
+	assert.Contains(t, results, "Name:		repo1")
+	assert.Contains(t, results, "Phase:		Transferring all files in the repository (1/3)")
+	assert.Contains(t, results, "Storage:		4.9 KiB / 9.8 KiB (50.0%)")
+	assert.Contains(t, results, "Files:		500 / 10000 (5.0%)")
+}
+
+func TestShowStatusDiffPhase(t *testing.T) {
+	buffer, cleanUp := initStatusTest(t)
+	defer cleanUp()
+
+	// Create state manager and persist to file system
+	createStateManager(t, FilesDiffPhase)
+
+	// Run show status and check output
+	assert.NoError(t, ShowStatus())
+	results := buffer.String()
+
+	// Check overall status
+	assert.Contains(t, results, "Overall Transfer Status")
+	assert.Contains(t, results, "Status:		Running")
+	assert.Contains(t, results, "Start time:		")
+	assert.Contains(t, results, "Storage:		4.9 KiB / 10.9 KiB (45.0%)")
+	assert.Contains(t, results, "Repositories:	15 / 1111 (1.4%)")
+	assert.Contains(t, results, "Working threads:	16")
+
+	// Check repository status
+	assert.Contains(t, results, "Current Repository Status")
+	assert.Contains(t, results, "Name:		repo1")
+	assert.Contains(t, results, "Phase:		Transferring newly created and modified files (2/3)")
+	assert.NotContains(t, results, "Storage:		4.9 KiB / 9.8 KiB (50.0%)")
+	assert.NotContains(t, results, "Files:		500 / 10000 (5.0%)")
+}
+
+// Create state manager and persist in the file system.
+// t     - The testing object
+// phase - Phase ID
+func createStateManager(t *testing.T, phase int) {
+	stateManager, err := state.NewTransferStateManager(false)
+	assert.NoError(t, err)
+	assert.NoError(t, stateManager.TryLockTransferStateManager())
+	assert.NoError(t, stateManager.SetRepoState(repo1Key, 10000, 10000, false))
+
+	stateManager.CurrentRepo = repo1Key
+	stateManager.CurrentRepoPhase = phase
+	stateManager.TotalSizeBytes = 11111
+	stateManager.TotalUnits = 1111
+	stateManager.TransferredUnits = 15
+	stateManager.WorkingThreads = 16
+
+	// Increment transferred suze and files. This action also persists the run status.
+	assert.NoError(t, stateManager.IncTransferredSizeAndFiles(repo1Key, 500, 5000))
+
+	// Save transfer state.
+	assert.NoError(t, stateManager.SaveState())
+}
 
 func TestSizeToString(t *testing.T) {
 	testCases := []struct {

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	corelog "github.com/jfrog/jfrog-cli-core/v2/utils/log"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
@@ -142,4 +144,16 @@ func CompareTree(a, b *services.GraphNode) bool {
 		}
 	}
 	return true
+}
+
+// Set new logger with output redirection to a buffer.
+// Caller is responsible to set the old log back.
+func RedirectLogOutputToBuffer() (outputBuffer, stderrBuffer *bytes.Buffer, previousLog log.Log) {
+	stderrBuffer, outputBuffer = &bytes.Buffer{}, &bytes.Buffer{}
+	previousLog = log.Logger
+	newLog := log.NewLogger(corelog.GetCliLogLevel(), nil)
+	newLog.SetOutputWriter(outputBuffer)
+	newLog.SetLogsWriter(stderrBuffer, 0)
+	log.SetLogger(newLog)
+	return outputBuffer, stderrBuffer, previousLog
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Followup https://github.com/jfrog/jfrog-cli-core/pull/581

* Fix the following unreleased issue: When the repository does not exist in the state, SetRepoState does not initialize appropriately the repository's total size and total files.
* Add unit tests to the `transfer-files --status` option.
* Move RedirectLogOutputToBuffer from https://github.com/jfrog/jfrog-cli/blob/v2.27.1/utils/tests/utils.go#L672 to the core.