### PR TITLE
Transfer - Overcome empty usedSpaceInBytes

### DIFF
--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -320,9 +320,13 @@ func (tdc *TransferFilesCommand) updateRepoState(repoSummary *serviceUtils.Repos
 	if err != nil {
 		return errorutils.CheckError(err)
 	}
-	usedSpaceInBytes, err := repoSummary.UsedSpaceInBytes.Int64()
-	if err != nil {
-		return errorutils.CheckError(err)
+
+	var usedSpaceInBytes int64
+	if repoSummary.UsedSpaceInBytes.String() != "" {
+		usedSpaceInBytes, err = repoSummary.UsedSpaceInBytes.Int64()
+		if err != nil {
+			return errorutils.CheckError(err)
+		}
 	}
 
 	return tdc.stateManager.SetRepoState(repoSummary.RepoKey, usedSpaceInBytes, int(filesCount), tdc.ignoreState)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Avoid the following error, when the value of `UsedSpaceInBytes` cannot be retrieved from Artifactory.
```
strconv.ParseInt: parsing "": invalid syntax
```

    