### PR TITLE
Transfer - Better parsing of repository used space

### DIFF
--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -321,12 +321,9 @@ func (tdc *TransferFilesCommand) updateRepoState(repoSummary *serviceUtils.Repos
 		return errorutils.CheckError(err)
 	}
 
-	var usedSpaceInBytes int64
-	if repoSummary.UsedSpaceInBytes.String() != "" {
-		usedSpaceInBytes, err = repoSummary.UsedSpaceInBytes.Int64()
-		if err != nil {
-			return errorutils.CheckError(err)
-		}
+	usedSpaceInBytes, err := utils.GetUsedSpaceInBytes(repoSummary)
+	if err != nil {
+		return err
 	}
 
 	return tdc.stateManager.SetRepoState(repoSummary.RepoKey, usedSpaceInBytes, int(filesCount), tdc.ignoreState)

--- a/artifactory/utils/storageinfo.go
+++ b/artifactory/utils/storageinfo.go
@@ -114,10 +114,10 @@ func (sim *StorageInfoManager) GetReposTotalSize(repoKeys ...string) (int64, err
 			if err != nil {
 				return true, nil, err
 			}
-			for _, repoSummary := range storageInfo.RepositoriesSummaryList {
+			for i, repoSummary := range storageInfo.RepositoriesSummaryList {
 				if reposSet.Exists(repoSummary.RepoKey) {
 					reposCounted++
-					sizeToAdd, err := GetUsedSpaceInBytes(&repoSummary)
+					sizeToAdd, err := GetUsedSpaceInBytes(&storageInfo.RepositoriesSummaryList[i])
 					if err != nil {
 						return true, nil, err
 					}

--- a/artifactory/utils/storageinfo_test.go
+++ b/artifactory/utils/storageinfo_test.go
@@ -128,7 +128,7 @@ func TestGetReposTotalSize(t *testing.T) {
 
 	// Assert error is returned due to the missing repository.
 	_, err = storageInfoManager.GetReposTotalSize("repo-1", "repo-2", "repo-3")
-	assert.EqualError(t, err, getStorageInfoRepoMissingError())
+	assert.EqualError(t, err, storageInfoRepoMissingError)
 }
 
 func mockGetStorageInfoAndInitManager(t *testing.T, repositoriesSummaryList []clientUtils.RepositorySummary) (*httptest.Server, *StorageInfoManager) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Followup: https://github.com/jfrog/jfrog-cli-core/pull/590

UsedSpaceInBytes does not exist in the repository summary in Artifactory 6. In storageinfo.go we fallback to using the UsedSpace field. 
This PR makes the code in transfer.go to use the fallback too.