### PR TITLE
Fix parsing error when parsing storage size

### DIFF
--- a/artifactory/utils/storageinfo.go
+++ b/artifactory/utils/storageinfo.go
@@ -147,7 +147,8 @@ func convertStorageSizeStringToBytes(sizeStr string) (int64, error) {
 	if len(usedSpaceParts) != 2 {
 		return 0, errorutils.CheckErrorf("could not parse size string '%s'", sizeStr)
 	}
-	sizeInUnit, err := strconv.ParseFloat(usedSpaceParts[0], 64)
+	// The ReplaceAll removes ',' from the number, for example: 1,004.64 -> 1004.64
+	sizeInUnit, err := strconv.ParseFloat(strings.ReplaceAll(usedSpaceParts[0], ",", ""), 64)
 	if err != nil {
 		return 0, errorutils.CheckError(err)
 	}

--- a/artifactory/utils/storageinfo_test.go
+++ b/artifactory/utils/storageinfo_test.go
@@ -70,6 +70,7 @@ func TestConvertStorageSizeStringToBytes(t *testing.T) {
 	}{
 		{"bytes", "2.22 bytes", false, 2.22},
 		{"KB", "3.333 KB", false, 3.333 * bytesInKB},
+		{"KB with comma", "1,004.64 KB", false, 1004.64 * bytesInKB},
 		{"MB", "4.4444 MB", false, 4.4444 * bytesInMB},
 		{"GB", "5.55555 GB", false, 5.55555 * bytesInGB},
 		{"TB", "6.666666 TB", false, 6.666666 * bytesInTB},


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Fix the following error received in transfer-files:
> strconv.ParseFloat: parsing "1,004.64": invalid syntax