### PR TITLE
Fix Python Dependencies Tree

### DIFF
--- a/xray/audit/python/python.go
+++ b/xray/audit/python/python.go
@@ -23,22 +23,27 @@ const (
 )
 
 func BuildDependencyTree(pythonTool pythonutils.PythonTool, requirementsFile string) (dependencyTree []*services.GraphNode, err error) {
-	dependenciesGraph, rootDependenciesList, err := getDependencies(pythonTool, requirementsFile)
+	dependenciesGraph, rootNode, directDependenciesList, err := getDependencies(pythonTool, requirementsFile)
 	if err != nil {
 		return
 	}
-	for _, rootDep := range rootDependenciesList {
-		parentNode := &services.GraphNode{
+	directDependencies := []*services.GraphNode{}
+	for _, rootDep := range directDependenciesList {
+		directDependency := &services.GraphNode{
 			Id:    pythonPackageTypeIdentifier + rootDep,
 			Nodes: []*services.GraphNode{},
 		}
-		populatePythonDependencyTree(parentNode, dependenciesGraph)
-		dependencyTree = append(dependencyTree, parentNode)
+		populatePythonDependencyTree(directDependency, dependenciesGraph)
+		directDependencies = append(directDependencies, directDependency)
 	}
-	return
+	root := &services.GraphNode{
+		Id:    pythonPackageTypeIdentifier + rootNode,
+		Nodes: directDependencies,
+	}
+	return []*services.GraphNode{root}, nil
 }
 
-func getDependencies(pythonTool pythonutils.PythonTool, requirementsFile string) (dependenciesGraph map[string][]string, rootDependencies []string, err error) {
+func getDependencies(pythonTool pythonutils.PythonTool, requirementsFile string) (dependenciesGraph map[string][]string, rootNode string, directDependencies []string, err error) {
 	wd, err := os.Getwd()
 	if errorutils.CheckError(err) != nil {
 		return
@@ -87,7 +92,11 @@ func getDependencies(pythonTool pythonutils.PythonTool, requirementsFile string)
 	if err != nil {
 		return
 	}
-	dependenciesGraph, rootDependencies, err = pythonutils.GetPythonDependencies(pythonTool, tempDirPath, localDependenciesPath)
+	dependenciesGraph, directDependencies, err = pythonutils.GetPythonDependencies(pythonTool, tempDirPath, localDependenciesPath)
+	if err != nil {
+		return
+	}
+	rootNode, err = pythonutils.GetPackageName(pythonTool, tempDirPath)
 	return
 }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
 The Python dependencies tree was missing the root project level.