### PR TITLE
[Unreleased bug] Transfer - Fix "status" view layout

### DIFF
--- a/artifactory/commands/transferfiles/status.go
+++ b/artifactory/commands/transferfiles/status.go
@@ -39,18 +39,18 @@ func ShowStatus() error {
 
 func addOverallStatus(stateManager *state.TransferStateManager, output *strings.Builder, runningTime string) {
 	addTitle(output, "Overall Transfer Status")
-	addString(output, "🟢", "Status", "Running", 2)
-	addString(output, "⏱️ ", "Running for", runningTime, 1)
-	addString(output, "🗄 ", "Storage", sizeToString(stateManager.TotalRepositories.TransferredSizeBytes)+" / "+sizeToString(stateManager.TotalRepositories.TotalSizeBytes)+calcPercentageInt64(stateManager.TotalRepositories.TransferredSizeBytes, stateManager.TotalRepositories.TotalSizeBytes), 2)
-	addString(output, "📦", "Repositories", fmt.Sprintf("%d / %d", stateManager.TotalRepositories.TransferredUnits, stateManager.TotalRepositories.TotalUnits)+calcPercentageInt64(stateManager.TotalRepositories.TransferredUnits, stateManager.TotalRepositories.TotalUnits), 1)
-	addString(output, "🧵", "Working threads", strconv.Itoa(stateManager.WorkingThreads), 1)
-	addString(output, "⚡", "Transfer speed", stateManager.GetSpeedString(), 1)
+	addString(output, "🟢", "Status", "Running", 3)
+	addString(output, "⏱️ ", "Running for", runningTime, 2)
+	addString(output, "🗄 ", "Storage", sizeToString(stateManager.TotalRepositories.TransferredSizeBytes)+" / "+sizeToString(stateManager.TotalRepositories.TotalSizeBytes)+calcPercentageInt64(stateManager.TotalRepositories.TransferredSizeBytes, stateManager.TotalRepositories.TotalSizeBytes), 3)
+	addString(output, "📦", "Repositories", fmt.Sprintf("%d / %d", stateManager.TotalRepositories.TransferredUnits, stateManager.TotalRepositories.TotalUnits)+calcPercentageInt64(stateManager.TotalRepositories.TransferredUnits, stateManager.TotalRepositories.TotalUnits), 2)
+	addString(output, "🧵", "Working threads", strconv.Itoa(stateManager.WorkingThreads), 2)
+	addString(output, "⚡", "Transfer speed", stateManager.GetSpeedString(), 2)
 	addString(output, "⌛", "Estimated time remaining", stateManager.GetEstimatedRemainingTimeString(), 1)
 	failureTxt := strconv.FormatUint(uint64(stateManager.TransferFailures), 10)
 	if stateManager.TransferFailures > 0 {
 		failureTxt += " (" + RetryFailureContentNote + ")"
 	}
-	addString(output, "❌", "Transfer failures", failureTxt, 1)
+	addString(output, "❌", "Transfer failures", failureTxt, 2)
 }
 
 func calcPercentageInt64(transferred, total int64) string {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fixes the "Estimated time remaining:" layout of the `jf rt transfer-files --status` view, which is currently - 


<img width="784" alt="image" src="https://user-images.githubusercontent.com/7830056/199841636-260a8112-66db-4e20-a599-0000c7a0dee0.png">



to be - 


<img width="669" alt="image" src="https://user-images.githubusercontent.com/7830056/199841693-9f11c06a-f37b-4940-9f37-f0e4f898b626.png">


    