### PR TITLE
Transfer - Illegal AQL query may be sent in Phase 2

### DIFF
--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -211,15 +211,17 @@ func (f *filesDiffPhase) getDockerTimeFrameFilesDiff(repoKey, fromTimestamp, toT
 				return
 			}
 		}
-		// Get all content of Artifactory folders containing a "manifest.json" file.
-		query = generateGetDirContentAqlQuery(repoKey, manifestPaths)
-		var pathsResult *servicesUtils.AqlSearchResult
-		pathsResult, err = runAql(f.context, f.srcRtDetails, query)
-		if err != nil {
-			return
+		if manifestPaths != nil {
+			// Get all content of Artifactory folders containing a "manifest.json" file.
+			query = generateGetDirContentAqlQuery(repoKey, manifestPaths)
+			var pathsResult *servicesUtils.AqlSearchResult
+			pathsResult, err = runAql(f.context, f.srcRtDetails, query)
+			if err != nil {
+				return
+			}
+			// Merge "list.manifest.json" files with all other files.
+			result = append(result, pathsResult.Results...)
 		}
-		// Merge "list.manifest.json" files with all other files.
-		result = append(result, pathsResult.Results...)
 	}
 	aqlResult = &servicesUtils.AqlSearchResult{}
 	aqlResult.Results = result

--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -198,26 +198,29 @@ func (f *filesDiffPhase) getDockerTimeFrameFilesDiff(repoKey, fromTimestamp, toT
 		return
 	}
 	var result []servicesUtils.ResultItem
-	var manifestPaths []string
-	// Add the "list.manifest.json" files to the result, skip "manifest.json" files and save their paths separately.
-	for _, file := range manifestFilesResult.Results {
-		if file.Name == "manifest.json" {
-			manifestPaths = append(manifestPaths, file.Path)
-		} else if file.Name == "list.manifest.json" {
-			result = append(result, file)
-		} else {
-			err = errorutils.CheckErrorf("unexpected file name returned from AQL query. Expecting either 'manifest.json' or 'list.manifest.json'. Received '%s'.", file.Name)
+	if len(manifestFilesResult.Results) > 0 {
+		var manifestPaths []string
+		// Add the "list.manifest.json" files to the result, skip "manifest.json" files and save their paths separately.
+		for _, file := range manifestFilesResult.Results {
+			if file.Name == "manifest.json" {
+				manifestPaths = append(manifestPaths, file.Path)
+			} else if file.Name == "list.manifest.json" {
+				result = append(result, file)
+			} else {
+				err = errorutils.CheckErrorf("unexpected file name returned from AQL query. Expecting either 'manifest.json' or 'list.manifest.json'. Received '%s'.", file.Name)
+				return
+			}
+		}
+		// Get all content of Artifactory folders containing a "manifest.json" file.
+		query = generateGetDirContentAqlQuery(repoKey, manifestPaths)
+		var pathsResult *servicesUtils.AqlSearchResult
+		pathsResult, err = runAql(f.context, f.srcRtDetails, query)
+		if err != nil {
 			return
 		}
+		// Merge "list.manifest.json" files with all other files.
+		result = append(result, pathsResult.Results...)
 	}
-	// Get all content of Artifactory folders containing a "manifest.json" file.
-	query = generateGetDirContentAqlQuery(repoKey, manifestPaths)
-	pathsResult, err := runAql(f.context, f.srcRtDetails, query)
-	if err != nil {
-		return
-	}
-	// Merge "list.manifest.json" files with all other files.
-	result = append(result, pathsResult.Results...)
 	aqlResult = &servicesUtils.AqlSearchResult{}
 	aqlResult.Results = result
 	return


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
The following illegal AQL query may be created as part of Phase 2, if no results are founds.
```
16:37:24 [Error] server response: 400 Bad Request
Failed to parse query: items.find({"$or":[]}).include("name","repo","path","actual_md5","actual_sha1","sha256","size","type","modified","created","property"), it looks like there is syntax error near the following sub-query: ]}).include("name","repo","path","actual_md5","actual_sha1","sha256","size","type","modified","created","property")
```    