### PR TITLE
Transfer - wrong storage and files count in status

### DIFF
--- a/artifactory/commands/transferfiles/state/statemanager.go
+++ b/artifactory/commands/transferfiles/state/statemanager.go
@@ -79,6 +79,8 @@ func (ts *TransferStateManager) SetRepoState(repoKey string, totalSizeBytes, tot
 		}
 		repo.TotalSizeBytes = totalSizeBytes
 		repo.TotalUnits = totalFiles
+		repo.TransferredSizeBytes = 0
+		repo.TransferredUnits = 0
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
**Fix the following issue**:
1. User runs transfer-files
2. User interrupts the transfer by clicking on ctrl+c
3. User run transfer-files again

**Results**:
The `Storage` and `Files` count is the sum of all previous transfer-files runnings and we see this after running transfer-files with the --status flag.
