### PR TITLE
Transfer - fix NPD in CI mode

### DIFF
--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -2,9 +2,10 @@ package transferfiles
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/api"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
-	"time"
 
 	"github.com/jfrog/gofrog/parallel"
 	servicesUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
@@ -129,7 +130,9 @@ func (f *filesDiffPhase) handleTimeFrameFilesDiff(pcWrapper *producerConsumerWra
 		totalSize := 0
 		for _, r := range files {
 			totalSize += int(r.Size)
-			f.phaseBase.progressBar.phases[f.phaseId].GetTasksProgressBar().IncGeneralProgressTotalBy(r.Size)
+			if f.progressBar != nil {
+				f.progressBar.phases[f.phaseId].GetTasksProgressBar().IncGeneralProgressTotalBy(r.Size)
+			}
 		}
 		err = f.transferManager.stateManager.IncTotalSizeAndFilesDiff(params.repoKey, int64(len(files)), int64(totalSize))
 		if err != nil {

--- a/artifactory/commands/transferfiles/manager.go
+++ b/artifactory/commands/transferfiles/manager.go
@@ -402,10 +402,9 @@ func updateProgress(phase *phaseBase, progressbar *TransferProgressMng, timeEstM
 		if err != nil {
 			return err
 		}
-		progressbar.increaseTotalSize(int(chunnkSizeInBytes))
 		if progressbar != nil {
-			err := progressbar.IncrementPhaseBy(phase.phaseId, int(chunnkSizeInBytes))
-			if err != nil {
+			progressbar.increaseTotalSize(int(chunnkSizeInBytes))
+			if err := progressbar.IncrementPhaseBy(phase.phaseId, int(chunnkSizeInBytes)); err != nil {
 				return err
 			}
 		}

--- a/artifactory/commands/transferfiles/transferfileprogress.go
+++ b/artifactory/commands/transferfiles/transferfileprogress.go
@@ -273,7 +273,9 @@ func (t *TransferProgressMng) SetRunningThreads(n int) {
 }
 
 func (t *TransferProgressMng) increaseTotalSize(n int) {
-	t.totalSize.GetBar().IncrBy(n)
+	if t.ShouldDisplay() {
+		t.totalSize.GetBar().IncrBy(n)
+	}
 }
 
 func (t *TransferProgressMng) StopGracefully() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
    
Fix unreleased bug caused Nil Pointer Dereference in CI mode and in the integration tests in the JFrog CLI.
In CI mode, the transfer progress bar is nil and therefore we should check for nil before updating the progress bar.

Steps to reproduce:
Run the following command:
```
CI=true ./jf rt transfer-files source-server target-server
```

Results:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x18c9aeb]

goroutine 125 [running]:
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.(*TransferProgressMng).increaseTotalSize(...)
	/Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/transferfileprogress.go:269
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.updateProgress(0xc0000c4160, 0x0, 0xc0003fa5c0, {{{0xc0003f7c50, 0x24}}, {0xc00b7bd150, 0x4}, {0xc00b7c22c0, 0x5, 0x6}}, ...)
	/Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/manager.go:411 +0xcb
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.handleChunksStatuses(0x25d38e0?, 0xc00b175cf8, 0xc00b4a0000?, 0xc00b175c20, 0x40?, 0x0?)
	/Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/manager.go:376 +0x266
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.pollUploads(0xc0000c4160, 0x0?, 0x0?, 0x0?, 0x0?)
	/Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/manager.go:298 +0x45f
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.(*PollingTasksManager).start.func2()
	/Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/manager.go:176 +0x6f
created by github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.(*PollingTasksManager).start
	/Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/manager.go:174 +0x24d
```
