### PR TITLE
Transfer config - empty check permissions response

### DIFF
--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -3,7 +3,6 @@ package transferconfig
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -279,7 +278,7 @@ func (tcc *TransferConfigCommand) verifyConfigImportPlugin(targetServicesManager
 	log.Info("config-import plugin version: " + configImportPluginVersion)
 
 	// Execute 'GET /api/plugins/execute/checkPermissions'
-	resp, _, _, err := targetServicesManager.Client().SendGet(artifactoryUrl+"api/plugins/execute/checkPermissions", false, rtDetails)
+	resp, body, _, err := targetServicesManager.Client().SendGet(artifactoryUrl+"api/plugins/execute/checkPermissions", false, rtDetails)
 	if err != nil {
 		return err
 	}
@@ -288,8 +287,7 @@ func (tcc *TransferConfigCommand) verifyConfigImportPlugin(targetServicesManager
 	}
 
 	// Unexpected status received: 403 if the user is not admin, 500+ if there is a server error
-	errorBody, _ := io.ReadAll(resp.Body)
-	messageFormat := fmt.Sprintf("Target server response: %s.\n%s", resp.Status, errorBody)
+	messageFormat := fmt.Sprintf("Target server response: %s.\n%s", resp.Status, body)
 	return errorutils.CheckErrorf(messageFormat)
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Check permissions API response from the config-import plugin is ignored.
Before:
![image](https://user-images.githubusercontent.com/11367982/201886810-e2b4c5f6-d6d4-479e-ba5e-e222b3ed6c5e.png)

After:
![image](https://user-images.githubusercontent.com/11367982/201887095-0a883801-8abc-4502-99bb-8af5f57cbb03.png)

