### PR TITLE
Transfer files - fix parsing error in progress bar

### DIFF
--- a/artifactory/commands/transferfiles/fulltransfer.go
+++ b/artifactory/commands/transferfiles/fulltransfer.go
@@ -2,13 +2,15 @@ package transferfiles
 
 import (
 	"fmt"
+	"path"
+	"time"
+
 	"github.com/jfrog/gofrog/parallel"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/api"
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	servicesUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	clientUtils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"path"
-	"time"
 )
 
 // Manages the phase of performing a full transfer of the repository.
@@ -24,7 +26,7 @@ func (m *fullTransferPhase) initProgressBar() error {
 	if m.progressBar == nil {
 		return nil
 	}
-	storage, err := m.repoSummary.UsedSpaceInBytes.Int64()
+	storage, err := utils.GetUsedSpaceInBytes(&m.repoSummary)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fix the following issue when running `jf rt transfer-files` on Artifactory 6:
```
[🚨Error] strconv.ParseInt: parsing "": invalid syntax
```