### PR TITLE
Searching JFrog config shouldn't return a permission denied error

### DIFF
--- a/artifactory/utils/buildutils.go
+++ b/artifactory/utils/buildutils.go
@@ -357,7 +357,7 @@ func (bc *BuildConfiguration) GetBuildName() (string, error) {
 func (bc *BuildConfiguration) getBuildNameFromConfigFile() (string, error) {
 	confFilePath, exist, err := GetProjectConfFilePath(Build)
 	if os.IsPermission(err) {
-		log.Info("The 'build-name' cannot be read from JFrog config due to permission denied...")
+		log.Info("The 'build-name' cannot be read from JFrog config due to permission denied.")
 		return "", nil
 	}
 	if err != nil || !exist {

--- a/artifactory/utils/buildutils.go
+++ b/artifactory/utils/buildutils.go
@@ -7,6 +7,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/jfrog/build-info-go/build"
 	buildInfo "github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -14,11 +20,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
 )
 
 const (
@@ -342,12 +343,23 @@ func (bc *BuildConfiguration) GetBuildName() (string, error) {
 		return bc.buildName, nil
 	}
 	// Resolve from env var.
-	if envValue := os.Getenv(coreutils.BuildName); envValue != "" {
-		bc.buildName = envValue
+	if bc.buildName = os.Getenv(coreutils.BuildName); bc.buildName != "" {
 		return bc.buildName, nil
 	}
 	// Resolve from config file in '.jfrog' folder.
+	var err error
+	if bc.buildName, err = bc.getBuildNameFromConfigFile(); bc.buildName != "" {
+		bc.loadedFromConfigFile = true
+	}
+	return bc.buildName, err
+}
+
+func (bc *BuildConfiguration) getBuildNameFromConfigFile() (string, error) {
 	confFilePath, exist, err := GetProjectConfFilePath(Build)
+	if os.IsPermission(err) {
+		log.Info("The 'build-name' cannot be read from JFrog config due to permission denied...")
+		return "", nil
+	}
 	if err != nil || !exist {
 		return "", err
 	}
@@ -355,10 +367,7 @@ func (bc *BuildConfiguration) GetBuildName() (string, error) {
 	if err != nil || vConfig == nil {
 		return "", err
 	}
-	if bc.buildName = vConfig.GetString(ProjectConfigBuildNameKey); bc.buildName != "" {
-		bc.loadedFromConfigFile = true
-	}
-	return bc.buildName, nil
+	return vConfig.GetString(ProjectConfigBuildNameKey), nil
 }
 
 func (bc *BuildConfiguration) GetBuildNumber() (string, error) {

--- a/artifactory/utils/buildutils_test.go
+++ b/artifactory/utils/buildutils_test.go
@@ -1,13 +1,14 @@
 package utils
 
 import (
-	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
-	testsutils "github.com/jfrog/jfrog-client-go/utils/tests"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
+	testsutils "github.com/jfrog/jfrog-client-go/utils/tests"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	artclientutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
@@ -68,7 +69,36 @@ func TestGetBuildName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, buildNameFile, actualBuildName)
 }
+func TestGetEmptyBuildNameOnAccessDenied(t *testing.T) {
+	// Create build config in temp folder.
+	tmpDir, createTempDirCallback := tests.CreateTempDirWithCallbackAndAssert(t)
+	defer createTempDirCallback()
 
+	// Create build config in temp folder
+	destConfFile := filepath.Join(tmpDir, ".jfrog", "projects")
+	srcConfFile := filepath.Join("testdata", "build.yaml")
+	assert.NoError(t, fileutils.CopyFile(destConfFile, srcConfFile))
+
+	// Remove permissions from config file
+	err := os.Chmod(destConfFile, 0000)
+	assert.NoError(t, err)
+
+	// Validate build name form config file doesn't throw an error if access is denied.
+	wd, err := os.Getwd()
+	assert.NoError(t, err, "Failed to get current dir")
+	chdirCallBack := testsutils.ChangeDirWithCallback(t, wd, tmpDir)
+	defer chdirCallBack()
+	buildConfig := NewBuildConfiguration("", "", "", "")
+	actualBuildName, err := buildConfig.GetBuildName()
+	assert.NoError(t, err)
+	assert.False(t, buildConfig.loadedFromConfigFile)
+	assert.Empty(t, actualBuildName)
+
+	// Restore permissions for deleting the config file.
+	err = os.Chmod(destConfFile, 0770)
+	assert.NoError(t, err)
+
+}
 func TestGetBuildNumber(t *testing.T) {
 	const buildNumber = "buildNumber1"
 	const buildNumberEnv = "envBuildNumber"

--- a/artifactory/utils/buildutils_test.go
+++ b/artifactory/utils/buildutils_test.go
@@ -69,7 +69,10 @@ func TestGetBuildName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, buildNameFile, actualBuildName)
 }
-func TestGetEmptyBuildNameOnAccessDenied(t *testing.T) {
+func TestGetEmptyBuildNameOnUnixAccessDenied(t *testing.T) {
+	if coreutils.IsWindows() {
+		t.Skip("Skipping TestGetEmptyBuildNameOnUnixAccessDenied test on windows...")
+	}
 	// Create build config in temp folder.
 	tmpDir, createTempDirCallback := tests.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
A JFrog CLI command searches for the config file at the PWD file path. The PR adds logic to handle permission denials gracefully.