### PR TITLE
Show JWT token subject in 'jf c show'

### DIFF
--- a/common/commands/config.go
+++ b/common/commands/config.go
@@ -538,7 +538,7 @@ func printConfigs(configuration []*config.ServerDetails) {
 		logIfNotEmpty(details.PipelinesUrl, "Pipelines URL:\t\t\t", false, isDefault)
 		logIfNotEmpty(details.User, "User:\t\t\t\t", false, isDefault)
 		logIfNotEmpty(details.Password, "Password:\t\t\t", true, isDefault)
-		logIfNotEmpty(details.AccessToken, "Access token:\t\t\t", true, isDefault)
+		logAccessTokenIfNotEmpty(details.AccessToken, isDefault)
 		logIfNotEmpty(details.RefreshToken, "Refresh token:\t\t\t", true, isDefault)
 		logIfNotEmpty(details.SshKeyPath, "SSH key file path:\t\t", false, isDefault)
 		logIfNotEmpty(details.SshPassphrase, "SSH passphrase:\t\t\t", true, isDefault)
@@ -560,6 +560,24 @@ func logIfNotEmpty(value, prefix string, mask, isDefault bool) {
 		}
 		log.Output(fullString)
 	}
+}
+
+func logAccessTokenIfNotEmpty(token string, isDefault bool) {
+	if token == "" {
+		return
+	}
+	tokenString := "***"
+	// Extract the token's subject only if it is JWT
+	if strings.Count(token, ".") == 2 {
+		subject, err := auth.ExtractSubjectFromAccessToken(token)
+		if err != nil {
+			log.Error(err)
+		} else {
+			tokenString += fmt.Sprintf(" (Subject: '%s')", subject)
+		}
+	}
+
+	logIfNotEmpty(tokenString, "Access token:\t\t\t", false, isDefault)
 }
 
 func (cc *ConfigCommand) delete() error {

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.25.1-0.20230119133624-ec89f6372ca2
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.25.1-0.20230122122354-e1a7bdab40e0
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.5-0.20230103131235-4993ad739dc6
 

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/jfrog/build-info-go v1.8.5 h1:NXk0LrgGZzaK1QwHS8wMjvyLob9iLwi8//80vja
 github.com/jfrog/build-info-go v1.8.5/go.mod h1:iSTj26qEX3eUtyAGMH0qKsW4WJT+MceYxLWP9FfiAq4=
 github.com/jfrog/gofrog v1.2.5 h1:jCgJC0iGQ8bU7jCC+YEFJTNINyngApIrhd8BjZAVRIE=
 github.com/jfrog/gofrog v1.2.5/go.mod h1:o00tSRff6IapTgaCMuX1Cs9MH08Y1JqnsKgRtx91Gc4=
-github.com/jfrog/jfrog-client-go v1.25.1-0.20230119133624-ec89f6372ca2 h1:TnG/8lNdrlM8jcaSivHmego4ZAlVU4LGzDdrphmVWHs=
-github.com/jfrog/jfrog-client-go v1.25.1-0.20230119133624-ec89f6372ca2/go.mod h1:3UIKpuDbH+CeWXHrIqnYPqZmG0+0lXnFh5WJ7qN3jAM=
+github.com/jfrog/jfrog-client-go v1.25.1-0.20230122122354-e1a7bdab40e0 h1:6WxdXuAUxXSD3J8ar2Zy2NPy00uGKojt0CC7byMv8CE=
+github.com/jfrog/jfrog-client-go v1.25.1-0.20230122122354-e1a7bdab40e0/go.mod h1:3UIKpuDbH+CeWXHrIqnYPqZmG0+0lXnFh5WJ7qN3jAM=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add subject to access tokens in `jf c show` command. The subject can be extracted only in JWT access tokens. In reference tokens, for example, the subject is impossible to extract.

![image](https://user-images.githubusercontent.com/11367982/213915727-4dcd9356-2b43-42fc-adfa-a265ee42a06c.png)
