### PR TITLE
Change the log level while searching for the build name

### DIFF
--- a/artifactory/utils/buildutils.go
+++ b/artifactory/utils/buildutils.go
@@ -357,7 +357,7 @@ func (bc *BuildConfiguration) GetBuildName() (string, error) {
 func (bc *BuildConfiguration) getBuildNameFromConfigFile() (string, error) {
 	confFilePath, exist, err := GetProjectConfFilePath(Build)
 	if os.IsPermission(err) {
-		log.Info("The 'build-name' cannot be read from JFrog config due to permission denied.")
+		log.Debug("The 'build-name' cannot be read from JFrog config due to permission denied.")
 		return "", nil
 	}
 	if err != nil || !exist {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Following the changes made by https://github.com/jfrog/jfrog-cli-core/pull/668, In this PR, the log level is lowered from info to debug. A reporter of this issue noted that debugging an issue could result in confusion.