### PR TITLE
Unexpected error when there are no deployable artifacts

### DIFF
--- a/artifactory/commands/utils/result.go
+++ b/artifactory/commands/utils/result.go
@@ -143,6 +143,9 @@ func unmarshalDeployableArtifactsJson(filesPath string) (*map[string][]clientuti
 		return nil, errorutils.CheckError(err)
 	}
 	var modulesMap map[string][]clientutils.DeployableArtifactDetails
+	if len(byteValue) == 0 {
+		return &modulesMap, nil
+	}
 	err = json.Unmarshal(byteValue, &modulesMap)
 	if err != nil {
 		return nil, errorutils.CheckError(err)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

When there are no deployable artifacts in Maven and Gradle, the deployable artifacts file is empty.
In this case, we may want to exit gracefully. However this error is returned:
> panic: unexpected end of JSON input
goroutine 1 [running]:
github.com/jfrog/jfrog-cli-core/v2/utils/coreutils.PanicOnError({0x100e331e0?, 0xc000012060?})
	github.com/jfrog/jfrog-cli-core/v2@v2.29.3/utils/coreutils/utils.go:101 +0x3a
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/utils.unmarshalDeployableArtifactsJson({0xc000498420?, 0xc000515408?})
	github.com/jfrog/jfrog-cli-core/v2@v2.29.3/artifactory/commands/utils/result.go:148 +0x137