### PR TITLE
Support providing an encryption key by environment variable

### DIFF
--- a/utils/config/config_test.go
+++ b/utils/config/config_test.go
@@ -2,14 +2,16 @@ package config
 
 import (
 	"encoding/json"
-	configtests "github.com/jfrog/jfrog-cli-core/v2/utils/config/tests"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
-	testsutils "github.com/jfrog/jfrog-client-go/utils/tests"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/google/uuid"
+	configtests "github.com/jfrog/jfrog-cli-core/v2/utils/config/tests"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
+	testsutils "github.com/jfrog/jfrog-client-go/utils/tests"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/log"
@@ -176,7 +178,6 @@ func TestConfigEncryption(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Config file encryption should be updated, so Enc=true. Secrets should be decrypted to be used in the rest of the execution.
-	assert.True(t, readConfig.Enc)
 	verifyEncryptionStatus(t, originalConfig, readConfig, false)
 	// Config file should be encrypted.
 	encryptedConfig := readConfFromFile(t)
@@ -185,10 +186,69 @@ func TestConfigEncryption(t *testing.T) {
 	// Verify successfully decrypting.
 	readConfig, err = readConf()
 	assert.NoError(t, err)
-	assert.True(t, readConfig.Enc)
 	verifyEncryptionStatus(t, originalConfig, readConfig, false)
 }
 
+func TestConfigEncryptionEnvVar(t *testing.T) {
+	// Config
+	cleanUpTempEnv := configtests.CreateTempEnv(t, false)
+	defer cleanUpTempEnv()
+
+	// Set encryption key in JFROG_CLI_ENCRYPTION_KEY environment variable
+	key := uuid.NewString()[:32]
+	assert.NoError(t, os.Setenv(coreutils.EncryptionKey, key))
+	defer os.Unsetenv(coreutils.EncryptionKey)
+
+	// Save the config and ensure the secrets were updated
+	expectedConfig := createEncryptionTestConfig()
+	assert.NoError(t, saveConfig(expectedConfig))
+	actualConfig := readConfFromFile(t)
+	verifyEncryptionStatus(t, expectedConfig, actualConfig, true)
+
+	// Read config and ensure the server details are decrypted
+	actualConfig, err := readConf()
+	assert.NoError(t, err)
+	verifyEncryptionStatus(t, expectedConfig, actualConfig, false)
+}
+
+func TestConfigEncryptionEnvVarUpdate(t *testing.T) {
+	// Set testing environment
+	cleanUpJfrogHome, err := tests.SetJfrogHome()
+	assert.NoError(t, err)
+	defer cleanUpJfrogHome()
+
+	assert.NoError(t, saveConfig(createEncryptionTestConfig()))
+	expectedConfig := createEncryptionTestConfig()
+	actualConfig := readConfFromFile(t)
+
+	verifyEncryptionStatus(t, expectedConfig, actualConfig, false)
+
+	// Set encryption key in JFROG_CLI_ENCRYPTION_KEY environment variable
+	key := uuid.NewString()[:32]
+	assert.NoError(t, os.Setenv(coreutils.EncryptionKey, key))
+	defer os.Unsetenv(coreutils.EncryptionKey)
+
+	// Read config and ensure that the config was decrypted
+	actualConfig, err = readConf()
+	assert.NoError(t, err)
+	verifyEncryptionStatus(t, expectedConfig, actualConfig, false)
+}
+
+func createEncryptionTestConfig() *Config {
+	return &Config{ConfigV6{ConfigV5{
+		Version: strconv.Itoa(coreutils.GetCliConfigVersion()),
+		Servers: []*ServerDetails{{
+			ServerId:      "test-server",
+			Url:           "http://acme.jfrog.io",
+			User:          "elmar",
+			Password:      "Wabbit",
+			AccessToken:   "DewiciousWegOfWamb",
+			SshPassphrase: "KiwwTheWabbit",
+		}}},
+	}}
+}
+
+// Read config file "as-is" - without decryption
 func readConfFromFile(t *testing.T) *Config {
 	confFilePath, err := getConfFilePath()
 	assert.NoError(t, err)
@@ -309,8 +369,10 @@ func TestHandleSecrets(t *testing.T) {
 	original := new(Config)
 	original.Servers = []*ServerDetails{{User: "user", Password: "password", Url: "http://localhost:8080/artifactory/", AccessToken: "accessToken",
 		RefreshToken: "refreshToken", SshPassphrase: "sshPass"}}
+	original.Enc = true
 
-	newConf := copyConfig(t, original)
+	newConf, err := original.Clone()
+	assert.NoError(t, err)
 
 	// Encrypt decrypted
 	assert.NoError(t, handleSecrets(original, encrypt, masterKey))
@@ -318,19 +380,12 @@ func TestHandleSecrets(t *testing.T) {
 
 	// Decrypt encrypted
 	assert.NoError(t, handleSecrets(original, decrypt, masterKey))
+	newConf.Enc = false
 	verifyEncryptionStatus(t, original, newConf, false)
 }
 
-func copyConfig(t *testing.T, original *Config) *Config {
-	b, err := json.Marshal(&original)
-	assert.NoError(t, err)
-	newConf := new(Config)
-	err = json.Unmarshal(b, &newConf)
-	assert.NoError(t, err)
-	return newConf
-}
-
 func verifyEncryptionStatus(t *testing.T, original, actual *Config, encryptionExpected bool) {
+	assert.Equal(t, len(original.Servers), len(actual.Servers))
 	var equals []bool
 	for i := range actual.Servers {
 		if original.Servers[i].Password != "" {
@@ -342,6 +397,7 @@ func verifyEncryptionStatus(t *testing.T, original, actual *Config, encryptionEx
 		if original.Servers[i].RefreshToken != "" {
 			equals = append(equals, original.Servers[i].RefreshToken == actual.Servers[i].RefreshToken)
 		}
+		assert.Equal(t, encryptionExpected, actual.Enc)
 	}
 
 	if encryptionExpected {
@@ -357,9 +413,6 @@ func assertCertsMigration(t *testing.T) {
 	certsDir, err := coreutils.GetJfrogCertsDir()
 	assert.NoError(t, err)
 	assert.DirExists(t, certsDir)
-	secFile, err := coreutils.GetJfrogSecurityConfFilePath()
-	assert.NoError(t, err)
-	assert.FileExists(t, secFile)
 	files, err := os.ReadDir(certsDir)
 	assert.NoError(t, err)
 	// Verify only the certs were moved

--- a/utils/config/configtoken.go
+++ b/utils/config/configtoken.go
@@ -85,7 +85,7 @@ func Export(details *ServerDetails) (string, error) {
 	}
 	// If config is encrypted, ask for master key.
 	if conf.Enc {
-		masterKeyFromFile, _, err := getMasterKeyFromSecurityConfFile()
+		masterKeyFromFile, err := getMasterKey()
 		if err != nil {
 			return "", err
 		}

--- a/utils/config/encryption.go
+++ b/utils/config/encryption.go
@@ -5,7 +5,6 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/json"
 	"io"
 	"os"
 	"strconv"
@@ -33,7 +32,7 @@ type secretHandler func(string, string) (string, error)
 
 // Encrypt config file if security configuration file exists and contains master key.
 func (config *Config) encrypt() error {
-	key, _, err := getMasterKeyFromSecurityConfFile()
+	key, err := getMasterKey()
 	if err != nil || key == "" {
 		return err
 	}
@@ -47,43 +46,24 @@ func (config *Config) decrypt() error {
 	if !config.Enc {
 		return updateEncryptionIfNeeded(config)
 	}
-	key, secFileExists, err := getMasterKeyFromSecurityConfFile()
+	key, err := getMasterKey()
 	if err != nil {
 		return err
 	}
-	if !secFileExists {
-		return errorutils.CheckErrorf(decryptErrorPrefix + "security configuration file was not found")
-	}
 	if key == "" {
-		return errorutils.CheckErrorf(decryptErrorPrefix + "security configuration file does not contain a master key")
+		return errorutils.CheckErrorf(decryptErrorPrefix+"security configuration file was not found or the '%s' environment variable was not configured", coreutils.EncryptionKey)
 	}
+	config.Enc = false
 	return handleSecrets(config, decrypt, key)
 }
 
-// Encrypt the config file if it is decrypted while security configuration file exists and contains a master key.
-func updateEncryptionIfNeeded(originalConfig *Config) error {
-	masterKey, _, err := getMasterKeyFromSecurityConfFile()
+// Encrypt the config file if it is decrypted while security configuration file exists and contains a master key, or if the JFROG_CLI_ENCRYPTION_KEY environment variable exist.
+func updateEncryptionIfNeeded(config *Config) error {
+	masterKey, err := getMasterKey()
 	if err != nil || masterKey == "" {
 		return err
 	}
-
-	// Marshalling and unmarshalling to get a new separate config struct, to prevent modifying the config for the rest of the execution.
-	decryptedContent, err := originalConfig.getContent()
-	if err != nil {
-		return err
-	}
-	tmpEncConfig := new(Config)
-	err = json.Unmarshal(decryptedContent, &tmpEncConfig)
-	if err != nil {
-		return errorutils.CheckError(err)
-	}
-	err = saveConfig(tmpEncConfig)
-	if err != nil {
-		return err
-	}
-	// Mark that config file is encrypted
-	originalConfig.Enc = true
-	return nil
+	return saveConfig(config)
 }
 
 // Encrypt/Decrypt all secrets in the provided config, with the provided master key.
@@ -114,14 +94,21 @@ func handleSecrets(config *Config, handler secretHandler, key string) error {
 	return nil
 }
 
-func getMasterKeyFromSecurityConfFile() (key string, secFileExists bool, err error) {
+func getMasterKey() (string, error) {
+	if key, exist := os.LookupEnv(coreutils.EncryptionKey); exist {
+		return key, nil
+	}
+	return getMasterKeyFromSecurityConfFile()
+}
+
+func getMasterKeyFromSecurityConfFile() (key string, err error) {
 	secFile, err := coreutils.GetJfrogSecurityConfFilePath()
 	if err != nil {
-		return "", false, err
+		return "", err
 	}
 	exists, err := fileutils.IsFileExists(secFile, false)
 	if err != nil || !exists {
-		return "", false, err
+		return "", err
 	}
 
 	config := viper.New()
@@ -134,14 +121,17 @@ func getMasterKeyFromSecurityConfFile() (key string, secFileExists bool, err err
 		}
 	}()
 	if err != nil {
-		return "", false, errorutils.CheckError(err)
+		return "", errorutils.CheckError(err)
 	}
 	err = config.ReadConfig(f)
 	if err != nil {
-		return "", false, errorutils.CheckError(err)
+		return "", errorutils.CheckError(err)
 	}
 	key = config.GetString(masterKeyField)
-	return key, true, nil
+	if key == "" {
+		return "", errorutils.CheckErrorf(decryptErrorPrefix + "security configuration file does not contain a master key")
+	}
+	return key, nil
 }
 
 func readMasterKeyFromConsole() (string, error) {

--- a/utils/coreutils/coreconsts.go
+++ b/utils/coreutils/coreconsts.go
@@ -48,8 +48,9 @@ const (
 
 // Although these vars are constant, they are defined inside a vars section and not a constants section because the tests modify these values.
 var (
-	HomeDir     = "JFROG_CLI_HOME_DIR"
-	BuildName   = "JFROG_CLI_BUILD_NAME"
-	BuildNumber = "JFROG_CLI_BUILD_NUMBER"
-	Project     = "JFROG_CLI_BUILD_PROJECT"
+	HomeDir       = "JFROG_CLI_HOME_DIR"
+	BuildName     = "JFROG_CLI_BUILD_NAME"
+	BuildNumber   = "JFROG_CLI_BUILD_NUMBER"
+	Project       = "JFROG_CLI_BUILD_PROJECT"
+	EncryptionKey = "JFROG_CLI_ENCRYPTION_KEY"
 )


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Introduce JFROG_CLI_ENCRYPTION_KEY environment variable. If set, the CLI configuration will be encrypted.