### PR TITLE
Transfer - If plugin not install log information

### DIFF
--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -713,7 +713,14 @@ func validateDataTransferPluginMinimumVersion(currentVersion string) error {
 func getAndValidateDataTransferPlugin(srcUpService *srcUserPluginService) error {
 	verifyResponse, err := srcUpService.verifyCompatibilityRequest()
 	if err != nil {
-		return err
+		errMsg := err.Error()
+		reason := ""
+		if strings.Contains(errMsg, "The execution name '") && strings.Contains(errMsg, "' could not be found") {
+			start := strings.Index(errMsg, "'")
+			missingApi := errMsg[start+1 : strings.Index(errMsg[start+1:], "'")+start+1]
+			reason = fmt.Sprintf(" This is because the '%s' API exposed by the plugin returns a '404 Not Found' response.", missingApi)
+		}
+		return fmt.Errorf("%w; It looks like the 'data-transfer' user plugin isn't installed on the source instance.%s Please refer to the documentation available at https://www.jfrog.com/confluence/display/JFROG/Transfer+Artifactory+Configuration+and+Files+to+JFrog+Cloud for installation instructions", err, reason)
 	}
 
 	err = validateDataTransferPluginMinimumVersion(verifyResponse.Version)

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -720,7 +720,7 @@ func getAndValidateDataTransferPlugin(srcUpService *srcUserPluginService) error 
 			missingApi := errMsg[start+1 : strings.Index(errMsg[start+1:], "'")+start+1]
 			reason = fmt.Sprintf(" This is because the '%s' API exposed by the plugin returns a '404 Not Found' response.", missingApi)
 		}
-		return fmt.Errorf("%w; It looks like the 'data-transfer' user plugin isn't installed on the source instance.%s Please refer to the documentation available at https://www.jfrog.com/confluence/display/JFROG/Transfer+Artifactory+Configuration+and+Files+to+JFrog+Cloud for installation instructions", err, reason)
+		return fmt.Errorf("%w;\nIt looks like the 'data-transfer' user plugin isn't installed on the source instance.%s Please refer to the documentation available at https://www.jfrog.com/confluence/display/JFROG/Transfer+Artifactory+Configuration+and+Files+to+JFrog+Cloud for installation instructions", err, reason)
 	}
 
 	err = validateDataTransferPluginMinimumVersion(verifyResponse.Version)

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -720,7 +720,7 @@ func getAndValidateDataTransferPlugin(srcUpService *srcUserPluginService) error 
 			missingApi := errMsg[start+1 : strings.Index(errMsg[start+1:], "'")+start+1]
 			reason = fmt.Sprintf(" This is because the '%s' API exposed by the plugin returns a '404 Not Found' response.", missingApi)
 		}
-		return fmt.Errorf("%w;\nIt looks like the 'data-transfer' user plugin isn't installed on the source instance.%s Please refer to the documentation available at https://www.jfrog.com/confluence/display/JFROG/Transfer+Artifactory+Configuration+and+Files+to+JFrog+Cloud for installation instructions", err, reason)
+		return fmt.Errorf("%w;\nIt looks like the 'data-transfer' user plugin isn't installed on the source instance.%s Please refer to the documentation available at https://www.jfrog.com/confluence/display/JFROG/Transfer+Artifactory+Configuration+and+Files+to+JFrog+Cloud for installation instructions", errMsg, reason)
 	}
 
 	err = validateDataTransferPluginMinimumVersion(verifyResponse.Version)

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -720,7 +720,7 @@ func getAndValidateDataTransferPlugin(srcUpService *srcUserPluginService) error 
 			missingApi := errMsg[start+1 : strings.Index(errMsg[start+1:], "'")+start+1]
 			reason = fmt.Sprintf(" This is because the '%s' API exposed by the plugin returns a '404 Not Found' response.", missingApi)
 		}
-		return fmt.Errorf("%w;\nIt looks like the 'data-transfer' user plugin isn't installed on the source instance.%s Please refer to the documentation available at https://www.jfrog.com/confluence/display/JFROG/Transfer+Artifactory+Configuration+and+Files+to+JFrog+Cloud for installation instructions", errMsg, reason)
+		return fmt.Errorf("%s;\nIt looks like the 'data-transfer' user plugin isn't installed on the source instance.%s Please refer to the documentation available at https://www.jfrog.com/confluence/display/JFROG/Transfer+Artifactory+Configuration+and+Files+to+JFrog+Cloud for installation instructions", errMsg, reason)
 	}
 
 	err = validateDataTransferPluginMinimumVersion(verifyResponse.Version)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
If the Transfer user plugin was not installed / not installed correctly we will give more information to point the user to the installation instructions, the error will be shown as followed:
![image](https://user-images.githubusercontent.com/49212512/227770046-d3d5b98a-41d2-4d9f-a8f2-c92ba3b1c706.png)
![image](https://user-images.githubusercontent.com/49212512/227770051-8c941b0a-f165-4e02-ade1-4969f4b350f1.png)

