### PR TITLE
Disable Enforcer and Checkstyle in Maven audit

### DIFF
--- a/xray/audit/java/mvn.go
+++ b/xray/audit/java/mvn.go
@@ -28,7 +28,7 @@ func buildMvnDependencyTree(insecureTls, ignoreConfigFile, useWrapper bool, mvnP
 }
 
 func runMvn(buildConfiguration *utils.BuildConfiguration, insecureTls, ignoreConfigFile, useWrapper bool, mvnProps map[string]any) (err error) {
-	goals := []string{"-B", "compile", "test-compile"}
+	goals := []string{"-B", "compile", "test-compile", "-Dcheckstyle.skip", "-Denforcer.skip"}
 	log.Debug(fmt.Sprintf("mvn command goals: %v", goals))
 	configFilePath := ""
 	if !ignoreConfigFile {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

The Maven Enforcer and the Maven Checkstyle plugin are not necessary for the dependency tree. Let's disable them.