### PR TITLE
Add ignore-scripts flag to npm audit

### DIFF
--- a/xray/audit/npm/npm_test.go
+++ b/xray/audit/npm/npm_test.go
@@ -76,3 +76,14 @@ func TestParseNpmDependenciesList(t *testing.T) {
 	}
 
 }
+
+func TestIgnoreScripts(t *testing.T) {
+	// Create and change directory to test workspace
+	_, cleanUp := audit.CreateTestWorkspace(t, "npm-scripts")
+	defer cleanUp()
+
+	// The package.json file contain a postinstall script running an "exit 1" command.
+	// Without the "--ignore-scripts" flag, the test will fail.
+	_, err := BuildDependencyTree([]string{})
+	assert.NoError(t, err)
+}

--- a/xray/commands/testdata/npm-scripts/package.json
+++ b/xray/commands/testdata/npm-scripts/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "npm-ignore-scripts",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "exit 1"
+  }
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add the `--ignore-scripts` flag to prevent the execution of scripts before/after `npm install`.