### PR TITLE
Transfer config - insufficient export dir permissions

### DIFF
--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -316,7 +316,7 @@ func (tcc *TransferConfigCommand) exportSourceArtifactory() (string, func() erro
 		return "", func() error { return nil }, err
 	}
 
-	if err = os.Chmod(tempDir, 0755); err != nil {
+	if err = os.Chmod(tempDir, 0777); err != nil {
 		return "", func() error { return nil }, errorutils.CheckError(err)
 	}
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fix insufficient export dir permissions that occurred in RedHat.