### PR TITLE
Adjust `Contextual Analysis` run conditions message

### DIFF
--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/formats"
 	clientUtils "github.com/jfrog/jfrog-client-go/utils"
@@ -12,8 +15,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
 	"github.com/owenrumney/go-sarif/v2/sarif"
-	"strconv"
-	"strings"
 )
 
 type OutputFormat string
@@ -54,7 +55,7 @@ func PrintScanResults(results *ExtendedScanResults, errors []formats.SimpleJsonE
 			if err != nil {
 				return err
 			}
-			log.Output("The full scan results are available here: " + resultsPath)
+			log.Output("* The full scan results are available here: " + resultsPath)
 		}
 		if includeVulnerabilities {
 			err = PrintVulnerabilitiesTable(vulnerabilities, results, isMultipleRoots, printExtended, scan)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
This PR introduces the following changes:

- The contextual analysis logic will run only if the user is entitled to advance security. (instead of throwing an error).
- Display a clear message if the user is not entitled.