### PR TITLE
Missing auth details while downloading an extractor

### DIFF
--- a/artifactory/utils/dependenciesutils.go
+++ b/artifactory/utils/dependenciesutils.go
@@ -229,6 +229,7 @@ func createHttpClient(artDetails *config.ServerDetails) (rtHttpClient *jfroghttp
 		return
 	}
 
+	httpClientDetails = auth.CreateHttpClientDetails()
 	rtHttpClient, err = jfroghttpclient.JfrogClientBuilder().
 		SetCertificatesPath(certsPath).
 		SetInsecureTls(artDetails.InsecureTls).

--- a/artifactory/utils/dependenciesutils_test.go
+++ b/artifactory/utils/dependenciesutils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"testing"
 
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,4 +35,19 @@ func TestGetFullRemoteRepoPath(t *testing.T) {
 		actualPath := getFullExtractorsPathInArtifactory(test.repoName, test.remoteEnv, test.downloadPath)
 		assert.Equal(t, test.expectedPath, actualPath)
 	}
+}
+
+func TestCreateHttpClient(t *testing.T) {
+	serverDetails := &config.ServerDetails{
+		Url:      "https://acme.jfrog.io",
+		User:     "elmar",
+		Password: "Egghead",
+	}
+	httpClient, httpClientDetails, err := createHttpClient(serverDetails)
+	assert.NoError(t, err)
+	assert.NotNil(t, httpClient)
+	assert.NotNil(t, httpClientDetails)
+
+	assert.Equal(t, "elmar", httpClientDetails.User)
+	assert.Equal(t, "Egghead", httpClientDetails.Password)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fix the following issue when running Maven or audit command using the `JFROG_CLI_RELEASES_REPO` environment variable:
> 05:43:21 [Info] Downloading JFrog's Dependency from  https://acme.jfrog.io/artifactory/jcenter-virtual/org/jfrog/buildinfo/build-info-extractor-maven3/2.40.0/build-info-extractor-maven3-2.40.0-uber.jar
05:43:21 [Warn] Failed to get remote file details.
 Got: server response: 401 
05:43:21 [Error] 401  received when attempting to download https://acme.jfrog.io/artifactory/jcenter-virtual/org/jfrog/buildinfo/build-info-extractor-maven3/2.40.0/build-info-extractor-maven3-2.40.0-uber.jar