### PR TITLE
Fix switch statements and cleanup code

### DIFF
--- a/artifactory/commands/repository/template.go
+++ b/artifactory/commands/repository/template.go
@@ -588,8 +588,7 @@ func getLocalRepoConfKeys(pkgType string) []prompt.Suggest {
 	optionalKeys := []string{utils.SaveAndExit}
 	optionalKeys = append(optionalKeys, baseLocalRepoConfKeys...)
 	switch pkgType {
-	case Gradle:
-	case Maven:
+	case Maven, Gradle:
 		optionalKeys = append(optionalKeys, mavenGradleLocalRepoConfKeys...)
 	case Rpm:
 		optionalKeys = append(optionalKeys, rpmLocalRepoConfKeys...)
@@ -610,8 +609,7 @@ func getRemoteRepoConfKeys(pkgType, templateType string) []prompt.Suggest {
 	}
 	optionalKeys = append(optionalKeys, baseRemoteRepoConfKeys...)
 	switch pkgType {
-	case Gradle:
-	case Maven:
+	case Maven, Gradle:
 		optionalKeys = append(optionalKeys, mavenGradleRemoteRepoConfKeys...)
 	case Cocoapods:
 		optionalKeys = append(optionalKeys, cocoapodsRemoteRepoConfKeys...)
@@ -647,8 +645,7 @@ func getVirtualRepoConfKeys(pkgType string) []prompt.Suggest {
 	optionalKeys := []string{utils.SaveAndExit}
 	optionalKeys = append(optionalKeys, baseVirtualRepoConfKeys...)
 	switch pkgType {
-	case Gradle:
-	case Maven:
+	case Maven, Gradle:
 		optionalKeys = append(optionalKeys, mavenGradleVirtualRepoConfKeys...)
 	case Nuget:
 		optionalKeys = append(optionalKeys, nugetVirtualRepoConfKeys...)

--- a/artifactory/commands/transferfiles/delayedartifactshandler.go
+++ b/artifactory/commands/transferfiles/delayedartifactshandler.go
@@ -3,15 +3,16 @@ package transferfiles
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/api"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"os"
-	"path"
-	"path/filepath"
 )
 
 var maxDelayedArtifactsInFile = 50000
@@ -217,11 +218,7 @@ type shouldDelayUpload func(string) bool
 // Returns an array of functions to control the order of deployment.
 func getDelayUploadComparisonFunctions(packageType string) []shouldDelayUpload {
 	switch packageType {
-	case maven:
-		fallthrough
-	case gradle:
-		fallthrough
-	case ivy:
+	case maven, gradle, ivy:
 		return []shouldDelayUpload{func(fileName string) bool {
 			return filepath.Ext(fileName) == ".pom"
 		}}

--- a/general/cisetup/utils.go
+++ b/general/cisetup/utils.go
@@ -110,9 +110,7 @@ func convertBuildCmd(data *CiSetupData) (buildCmd string, err error) {
 		if err != nil {
 			return "", err
 		}
-	case coreutils.Maven:
-		fallthrough
-	case coreutils.Gradle:
+	case coreutils.Maven, coreutils.Gradle:
 		buildCmd, err = replaceCmdWithRegexp(data.BuiltTechnology.BuildCmd, mvnGradleRegexp, mvnGradleRegexpReplacement)
 		if err != nil {
 			return "", err

--- a/utils/progressbar/progressbarmng.go
+++ b/utils/progressbar/progressbarmng.go
@@ -85,9 +85,8 @@ func (bm *ProgressBarMng) newDoubleValueProgressBar(getVal func() (firstNumerato
 	pb := TasksProgressBar{}
 	windows := coreutils.IsWindows()
 	padding, filler := paddingAndFiller(windows)
-	filter := filterColor(GREEN, windows)
 	pb.bar = bm.container.New(0,
-		mpb.BarStyle().Lbound("|").Filler(filter).Tip(filter).Padding(padding).Filler(filler).Refiller("").Rbound("|"),
+		mpb.BarStyle().Lbound("|").Tip(filler).Padding(padding).Filler(filler).Refiller("").Rbound("|"),
 		mpb.BarRemoveOnComplete(),
 		mpb.AppendDecorators(
 			decor.Name(" "+firstValueLine+": "),
@@ -216,12 +215,11 @@ func (bm *ProgressBarMng) DoneTask(prog *TasksWithHeadlineProg) {
 func (bm *ProgressBarMng) NewTasksProgressBar(totalTasks int64, windows bool, taskType string) *TasksProgressBar {
 	padding, filler := paddingAndFiller(windows)
 	pb := &TasksProgressBar{}
-	filter := filterColor(GREEN, windows)
 	if taskType == "" {
 		taskType = "Tasks"
 	}
 	pb.bar = bm.container.New(0,
-		mpb.BarStyle().Lbound("|").Filler(filter).Tip(filter).Padding(padding).Filler(filler).Refiller("").Rbound("|"),
+		mpb.BarStyle().Lbound("|").Tip(filler).Padding(padding).Filler(filler).Refiller("").Rbound("|"),
 		mpb.BarRemoveOnComplete(),
 		mpb.AppendDecorators(
 			decor.Name(" "+taskType+": "),
@@ -235,10 +233,9 @@ func (bm *ProgressBarMng) NewTasksProgressBar(totalTasks int64, windows bool, ta
 func (bm *ProgressBarMng) newTasksProgressBar(getVal func() (numerator, denominator *int64), headLine string) *TasksProgressBar {
 	padding, filler := paddingAndFiller(coreutils.IsWindows())
 	pb := &TasksProgressBar{}
-	filter := filterColor(GREEN, coreutils.IsWindows())
 	numerator, denominator := getVal()
 	pb.bar = bm.container.New(0,
-		mpb.BarStyle().Lbound("|").Filler(filter).Tip(filter).Padding(padding).Filler(filler).Refiller("").Rbound("|"),
+		mpb.BarStyle().Lbound("|").Tip(filler).Padding(padding).Filler(filler).Refiller("").Rbound("|"),
 		mpb.BarRemoveOnComplete(),
 		mpb.AppendDecorators(
 			decor.Name(" "+headLine+": "),
@@ -310,22 +307,6 @@ func (bm *ProgressBarMng) GetBarsWg() *sync.WaitGroup {
 
 func (bm *ProgressBarMng) GetLogFile() *os.File {
 	return bm.logFile
-}
-
-func filterColor(color Color, windows bool) (filter string) {
-	if windows {
-		filter = "●"
-		return
-	}
-	switch color {
-	case GREEN:
-		filter = "🟩"
-	case WHITE:
-		fallthrough
-	default:
-		filter = "⬜"
-	}
-	return
 }
 
 func paddingAndFiller(windows bool) (padding, filler string) {

--- a/utils/progressbar/progressbarmng.go
+++ b/utils/progressbar/progressbarmng.go
@@ -318,11 +318,11 @@ func filterColor(color Color, windows bool) (filter string) {
 		return
 	}
 	switch color {
-	default:
-		filter = "⬜"
 	case GREEN:
 		filter = "🟩"
 	case WHITE:
+		fallthrough
+	default:
 		filter = "⬜"
 	}
 	return


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR introduces the following changes:

1. Fixes a minor bug regarding gradle cases in some switch cases. (The `go` default switch behavior **is not** to fall through cases. To achieve that, the ',' notation or the keywords `fallthrough` is necessary)
2.  Replace the fallthrough with the ',' notation for better readability .
3.  Remove the `filterColor` that I believe was not used.
