### PR TITLE
Transfer - exit on unrecoverable errors

### DIFF
--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -29,8 +29,8 @@ const (
 	uploadChunkSize = 16
 	// Size of the channel where the transfer's go routines write the transfer errors
 	fileWritersChannelSize       = 500000
-	retries                      = 1000
-	retriesWaitMilliSecs         = 1000
+	retries                      = 10000
+	retriesWaitMilliSecs         = 5000
 	dataTransferPluginMinVersion = "1.7.0"
 )
 
@@ -452,9 +452,7 @@ func (tdc *TransferFilesCommand) startPhase(newPhase *transferPhase, repo string
 	printPhaseChange("Running '" + (*newPhase).getPhaseName() + "' for repo '" + repo + "'...")
 	err = (*newPhase).run()
 	if err != nil {
-		// We do not return the error returned from the phase's run function,
-		// because the phase is expected to recover from some errors, such as HTTP connection errors.
-		log.Error(err.Error())
+		return err
 	}
 	printPhaseChange("Done running '" + (*newPhase).getPhaseName() + "' for repo '" + repo + "'.")
 	return (*newPhase).phaseDone()


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

This pull request designates certain types of errors as unrecoverable due to the potential risk of data loss without proper reporting. The specified errors that are considered unrecoverable include:

* Transfer action error: Occurs when there is an error in AQL (Artifactory Query Language) or cache retrieval.
* Errors channel error: Refers to errors encountered while writing to the error files.
* Delayed artifact manager error: Indicates errors that arise when writing to the delayed artifacts files.
* Execution error: Relates to errors within the producer-consumer mechanism.
* Interruption error: Occurs when the user interrupts the transfer process by pressing Ctrl+C or running jf rt transfer-files --stop.

By identifying these errors as unrecoverable, the pull request aims to ensure that appropriate actions are taken to prevent data loss and facilitate accurate reporting.

However, one potential concern that may arise is the long recovery process from system restarts.
To address the concern mentioned, this pull request proposes two changes. Firstly, it suggests increasing the wait time between HTTP request attempts from 1 second to 5 seconds. This adjustment aims to alleviate the load on heavily loaded systems that often encounter timeouts. By allowing a longer interval between retries, the strain on these systems can be reduced.

Secondly, the PR suggests increasing the number of retries from 1000 to 10000. The objective is to extend the duration that the system can remain offline without triggering a complete process exit. The calculation is as follows: (5 seconds of sleep + 1 second for the REST) * (10000 retry attempts) = 60000 (1 hour). It is anticipated that any crash and subsequent recovery time will be shorter than one hour.