### PR TITLE
Transfer - Missing files in large repositories

### DIFF
--- a/artifactory/commands/transferfiles/fulltransfer.go
+++ b/artifactory/commands/transferfiles/fulltransfer.go
@@ -169,7 +169,7 @@ func (m *fullTransferPhase) searchAndHandleFolderContents(params folderParams, p
 	var lastPage bool
 	paginationI := 0
 	for !lastPage && !ShouldStop(&m.phaseBase, &delayHelper, errorsChannelMng) {
-		result, lastPage, err = m.getDirectoryContentsAql(params.relativePath, paginationI)
+		result, lastPage, err = m.getDirectoryContentAql(params.relativePath, paginationI)
 		if err != nil {
 			return
 		}
@@ -256,8 +256,8 @@ func getFolderRelativePath(folderName, relativeLocation string) string {
 	return path.Join(relativeLocation, folderName)
 }
 
-func (m *fullTransferPhase) getDirectoryContentsAql(relativePath string, paginationOffset int) (result []servicesUtils.ResultItem, lastPage bool, err error) {
-	query := generateFolderContentsAqlQuery(m.repoKey, relativePath, paginationOffset)
+func (m *fullTransferPhase) getDirectoryContentAql(relativePath string, paginationOffset int) (result []servicesUtils.ResultItem, lastPage bool, err error) {
+	query := generateFolderContentAqlQuery(m.repoKey, relativePath, paginationOffset)
 	aqlResults, err := runAql(m.context, m.srcRtDetails, query)
 	if err != nil {
 		return []servicesUtils.ResultItem{}, false, err
@@ -268,7 +268,7 @@ func (m *fullTransferPhase) getDirectoryContentsAql(relativePath string, paginat
 	return
 }
 
-func generateFolderContentsAqlQuery(repoKey, relativePath string, paginationOffset int) string {
+func generateFolderContentAqlQuery(repoKey, relativePath string, paginationOffset int) string {
 	query := fmt.Sprintf(`items.find({"type":"any","$or":[{"$and":[{"repo":"%s","path":{"$match":"%s"},"name":{"$match":"*"}}]}]})`, repoKey, relativePath)
 	query += `.include("repo","path","name","type","size")`
 	query += fmt.Sprintf(`.sort({"$asc":["name"]}).offset(%d).limit(%d)`, paginationOffset*AqlPaginationLimit, AqlPaginationLimit)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

The transfer files command utilizes an AQL to retrieve pages of 10,000 files within a repository directory. We determine that it is the last page when the AQL results are less than 10,000.

The introduction of the locally generated filter in the pull request at https://github.com/jfrog/jfrog-cli-core/pull/751 modifies this behavior. In certain package types, such as npm, certain items are filtered out, resulting in a decrease in the number of search results. Consequently, this decrease in search results from 10,000 may erroneously indicate that we are on the last page.

This pull request resolves the issue by implementing a fix that addresses the problem. The fix involves counting the size of the search results before applying any filtering. By doing so, the issue of incorrectly determining the last page due to decreased search results after filtering is resolved.