### PR TITLE
`jf audit` generates invalid JSON format 

### DIFF
--- a/xray/commands/audit/generic/generic.go
+++ b/xray/commands/audit/generic/generic.go
@@ -148,8 +148,9 @@ func (auditCmd *GenericAuditCommand) Run() (err error) {
 			return
 		}
 	}
+	var messages []string
 	if !entitled {
-		log.Output("* The ‘jf audit’ command also supports the ‘Contextual Analysis’ feature, which is included as part of the ‘Advanced Security’ package.\n  This package isn't enabled on your system. Read more - https://jfrog.com/security-and-compliance/")
+		messages = []string{coreutils.PrintTitle("The ‘jf audit’ command also supports the ‘Contextual Analysis’ feature, which is included as part of the ‘Advanced Security’ package. This package isn't enabled on your system. Read more - ") + coreutils.PrintLink("https://jfrog.com/security-and-compliance")}
 	}
 	// Print Scan results on all cases except if errors accrued on Generic Audit command and no security/license issues found.
 	printScanResults := !(auditErr != nil && xrutils.IsEmptyScanResponse(results))
@@ -160,7 +161,7 @@ func (auditCmd *GenericAuditCommand) Run() (err error) {
 			auditCmd.IncludeVulnerabilities,
 			auditCmd.IncludeLicenses,
 			isMultipleRootProject,
-			auditCmd.PrintExtendedTable, false,
+			auditCmd.PrintExtendedTable, false, messages,
 		)
 		if err != nil {
 			return

--- a/xray/commands/scan/buildscan.go
+++ b/xray/commands/scan/buildscan.go
@@ -130,19 +130,19 @@ func (bsc *BuildScanCommand) runBuildScanAndPrintResults(xrayManager *xray.XrayS
 
 	if bsc.outputFormat != xrutils.Table {
 		// Print the violations and/or vulnerabilities as part of one JSON.
-		err = xrutils.PrintScanResults(extendedScanResults, nil, bsc.outputFormat, false, false, false, bsc.printExtendedTable, true)
+		err = xrutils.PrintScanResults(extendedScanResults, nil, bsc.outputFormat, false, false, false, bsc.printExtendedTable, true, nil)
 	} else {
 		// Print two different tables for violations and vulnerabilities (if needed)
 
 		// If "No Xray Fail build policy...." error received, no need to print violations
 		if !noFailBuildPolicy {
-			err = xrutils.PrintScanResults(extendedScanResults, nil, bsc.outputFormat, false, false, false, bsc.printExtendedTable, true)
+			err = xrutils.PrintScanResults(extendedScanResults, nil, bsc.outputFormat, false, false, false, bsc.printExtendedTable, true, nil)
 			if err != nil {
 				return false, err
 			}
 		}
 		if bsc.includeVulnerabilities {
-			err = xrutils.PrintScanResults(extendedScanResults, nil, bsc.outputFormat, true, false, false, bsc.printExtendedTable, true)
+			err = xrutils.PrintScanResults(extendedScanResults, nil, bsc.outputFormat, true, false, false, bsc.printExtendedTable, true, nil)
 			if err != nil {
 				return false, err
 			}

--- a/xray/commands/scan/scan.go
+++ b/xray/commands/scan/scan.go
@@ -245,7 +245,7 @@ func (scanCmd *ScanCommand) Run() (err error) {
 		scanCmd.includeVulnerabilities,
 		scanCmd.includeLicenses,
 		true,
-		scanCmd.printExtendedTable, true,
+		scanCmd.printExtendedTable, true, nil,
 	)
 	if err != nil {
 		return err

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -103,10 +103,8 @@ func printScanResultsTables(results *ExtendedScanResults, scan, includeVulnerabi
 }
 
 func printMessages(messages []string) {
-	if messages != nil {
-		for _, m := range messages {
-			printMessage(m)
-		}
+	for _, m := range messages {
+		printMessage(m)
 	}
 }
 

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -109,7 +109,7 @@ func printMessages(messages []string) {
 }
 
 func printMessage(message string) {
-	log.Output(coreutils.RemoveEmojisIfNonSupportedTerminal("💬 " + message))
+	log.Output(coreutils.RemoveEmojisIfNonSupportedTerminal("💬"), message)
 }
 
 func GenerateSarifFileFromScan(currentScan []services.ScanResponse, extendedResults *ExtendedScanResults, isMultipleRoots, simplifiedOutput bool) (string, error) {

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -41,50 +41,77 @@ type sarifProperties struct {
 	Description string
 }
 
-// PrintScanResults prints Xray scan results in the given format.
-// Note that errors are printed only on SimpleJson format.
-// If the scan argument is set to true, print the scan tables.
-func PrintScanResults(results *ExtendedScanResults, errors []formats.SimpleJsonError, format OutputFormat, includeVulnerabilities, includeLicenses, isMultipleRoots, printExtended, scan bool) error {
-	xrayScanResults := results.getXrayScanResults()
+// PrintScanResults prints the scan results in the specified format.
+// Note that errors are printed only with SimpleJson format.
+//
+// results - The scan results.
+// simpleJsonError - Errors to be added to output of the SimpleJson format.
+// format - The output format.
+// includeVulnerabilities - If trie, include all vulnerabilities as part of the output. Else, include violations only.
+// includeLicenses - If true, also include license violations as part of the output.
+// isMultipleRoots - multipleRoots is set to true, in case the given results array contains (or may contain) results of several projects (like in binary scan).
+// printExtended -If true, show extended results.
+// scan - If true, use an output layout suitable for `jf scan` or `jf docker scan` results. Otherwise, use a layout compatible for `jf audit` .
+// messages - Option array of messages, to be displayed if the format is Table
+func PrintScanResults(results *ExtendedScanResults, simpleJsonError []formats.SimpleJsonError, format OutputFormat, includeVulnerabilities, includeLicenses, isMultipleRoots, printExtended, scan bool, messages []string) error {
 	switch format {
 	case Table:
-		var err error
-		violations, vulnerabilities, licenses := SplitScanResults(xrayScanResults)
-		if len(xrayScanResults) > 0 {
-			resultsPath, err := writeJsonResults(results)
-			if err != nil {
-				return err
-			}
-			log.Output("* The full scan results are available here: " + resultsPath)
-		}
-		if includeVulnerabilities {
-			err = PrintVulnerabilitiesTable(vulnerabilities, results, isMultipleRoots, printExtended, scan)
-		} else {
-			err = PrintViolationsTable(violations, results, isMultipleRoots, printExtended, scan)
-		}
-		if err != nil {
-			return err
-		}
-		if includeLicenses {
-			err = PrintLicensesTable(licenses, printExtended, scan)
-		}
-		return err
+		return printScanResultsTables(results, scan, includeVulnerabilities, includeLicenses, isMultipleRoots, printExtended, messages)
 	case SimpleJson:
-		jsonTable, err := convertScanToSimpleJson(xrayScanResults, results, errors, isMultipleRoots, includeLicenses, false)
+		jsonTable, err := convertScanToSimpleJson(results.getXrayScanResults(), results, simpleJsonError, isMultipleRoots, includeLicenses, false)
 		if err != nil {
 			return err
 		}
 		return PrintJson(jsonTable)
 	case Json:
-		return PrintJson(xrayScanResults)
+		return PrintJson(results.getXrayScanResults())
 	case Sarif:
-		sarifFile, err := GenerateSarifFileFromScan(xrayScanResults, results, isMultipleRoots, false)
+		sarifFile, err := GenerateSarifFileFromScan(results.getXrayScanResults(), results, isMultipleRoots, false)
 		if err != nil {
 			return err
 		}
 		log.Output(sarifFile)
 	}
 	return nil
+}
+
+func printScanResultsTables(results *ExtendedScanResults, scan, includeVulnerabilities, includeLicenses, isMultipleRoots, printExtended bool, messages []string) (err error) {
+	log.Output()
+	printMessages(messages)
+	violations, vulnerabilities, licenses := SplitScanResults(results.getXrayScanResults())
+	if len(results.getXrayScanResults()) > 0 {
+		var resultsPath string
+		if resultsPath, err = writeJsonResults(results); err != nil {
+			return
+		}
+		printMessage(coreutils.PrintTitle("The full scan results are available here: ") + coreutils.PrintLink(resultsPath))
+	}
+
+	log.Output()
+	if includeVulnerabilities {
+		err = PrintVulnerabilitiesTable(vulnerabilities, results, isMultipleRoots, printExtended, scan)
+	} else {
+		err = PrintViolationsTable(violations, results, isMultipleRoots, printExtended, scan)
+	}
+	if err != nil {
+		return
+	}
+	if includeLicenses {
+		err = PrintLicensesTable(licenses, printExtended, scan)
+	}
+	return
+}
+
+func printMessages(messages []string) {
+	if messages != nil {
+		for _, m := range messages {
+			printMessage(m)
+		}
+	}
+}
+
+func printMessage(message string) {
+	log.Output("💬", message)
 }
 
 func GenerateSarifFileFromScan(currentScan []services.ScanResponse, extendedResults *ExtendedScanResults, isMultipleRoots, simplifiedOutput bool) (string, error) {

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -109,7 +109,7 @@ func printMessages(messages []string) {
 }
 
 func printMessage(message string) {
-	log.Output(coreutils.RemoveEmojisIfNonSupportedTerminal("💬"), message)
+	log.Output("💬", message)
 }
 
 func GenerateSarifFileFromScan(currentScan []services.ScanResponse, extendedResults *ExtendedScanResults, isMultipleRoots, simplifiedOutput bool) (string, error) {

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -109,7 +109,7 @@ func printMessages(messages []string) {
 }
 
 func printMessage(message string) {
-	log.Output("💬", message)
+	log.Output(coreutils.RemoveEmojisIfNonSupportedTerminal("💬 " + message))
 }
 
 func GenerateSarifFileFromScan(currentScan []services.ScanResponse, extendedResults *ExtendedScanResults, isMultipleRoots, simplifiedOutput bool) (string, error) {


### PR DESCRIPTION
* Fixes https://github.com/jfrog/jfrog-cli/issues/2012
* Improve the appearance of the messages shown at the top of the `jf audit`, `jf scan` and `jf docker scan` results table.

<img width="1440" alt="image" src="https://github.com/jfrog/jfrog-cli-core/assets/7830056/77e538cc-e9c8-4d71-ad47-d49d74e8dc57">
