### PR TITLE
Transfer - Limit local generated filter requests

### DIFF
--- a/artifactory/commands/transferfiles/localgeneratedfilter.go
+++ b/artifactory/commands/transferfiles/localgeneratedfilter.go
@@ -29,22 +29,23 @@ type LocallyGeneratedPayload struct {
 	Paths   []string `json:"paths,omitempty"`
 }
 
-type LocallyGeneratedFilter struct {
+type locallyGeneratedFilter struct {
 	httpDetails          *httputils.HttpClientDetails
 	targetServiceDetails auth.ServiceDetails
 	context              context.Context
-	sem                  semaphore.Weighted
-	enabled              bool
+	// Semaphore to limit the max concurrent Locally Generated requests to 2
+	sem     semaphore.Weighted
+	enabled bool
 }
 
-func NewLocallyGenerated(context context.Context, serviceManager artifactory.ArtifactoryServicesManager, artifactoryVersion string) *LocallyGeneratedFilter {
+func NewLocallyGenerated(context context.Context, serviceManager artifactory.ArtifactoryServicesManager, artifactoryVersion string) *locallyGeneratedFilter {
 	serviceDetails := serviceManager.GetConfig().GetServiceDetails()
 	httpDetails := serviceDetails.CreateHttpClientDetails()
 	utils.SetContentType("application/json", &httpDetails.Headers)
 
 	enabled := version.NewVersion(artifactoryVersion).AtLeast(minArtifactoryVersionForLocallyGenerated)
 	log.Debug("Locally generated filter enabled:", enabled)
-	return &LocallyGeneratedFilter{
+	return &locallyGeneratedFilter{
 		enabled:              enabled,
 		targetServiceDetails: serviceDetails,
 		httpDetails:          &httpDetails,
@@ -56,7 +57,7 @@ func NewLocallyGenerated(context context.Context, serviceManager artifactory.Art
 // Filters out locally generated files.
 // Files that are generated automatically by Artifactory on the target instance (also known as "locally generated files") should not be transferred.
 // aqlResults - Directory content in phase 1 or 15 minutes interval results in phase 2.
-func (lg *LocallyGeneratedFilter) FilterLocallyGenerated(aqlResultItems []utils.ResultItem) ([]utils.ResultItem, error) {
+func (lg *locallyGeneratedFilter) FilterLocallyGenerated(aqlResultItems []utils.ResultItem) ([]utils.ResultItem, error) {
 	if !lg.enabled || len(aqlResultItems) == 0 {
 		return aqlResultItems, nil
 	}
@@ -81,7 +82,7 @@ func (lg *LocallyGeneratedFilter) FilterLocallyGenerated(aqlResultItems []utils.
 // Send 'POST /localgenerated/filter/paths' request under Semaphore restriction to prevent more than 2 requests in parallel.
 // We limit the number of request by 2 to prevent excessive load on the target server.
 // content - The rest API body which is a byte array of LocallyGeneratedPayload.
-func (lg *LocallyGeneratedFilter) doFilterLocallyGenerated(content []byte) (resp *http.Response, body []byte, err error) {
+func (lg *locallyGeneratedFilter) doFilterLocallyGenerated(content []byte) (resp *http.Response, body []byte, err error) {
 	if err := lg.sem.Acquire(lg.context, 1); err != nil {
 		return nil, []byte{}, errorutils.CheckError(err)
 	}
@@ -91,13 +92,13 @@ func (lg *LocallyGeneratedFilter) doFilterLocallyGenerated(content []byte) (resp
 
 // Return true if should filter Artifactory locally generated files in the JFrog CLI
 // False if should filter Artifactory locally generated files in the Data Transfer plugin
-func (lg *LocallyGeneratedFilter) IsEnabled() bool {
+func (lg *locallyGeneratedFilter) IsEnabled() bool {
 	return lg.enabled
 }
 
 // Create payload for the POST '/api/localgenerated/filter/paths' REST API
 // aqlResultItems - Directory content in phase 1 or 15 minutes interval results in phase 2
-func (lg *LocallyGeneratedFilter) createPayload(aqlResultItems []utils.ResultItem) ([]byte, error) {
+func (lg *locallyGeneratedFilter) createPayload(aqlResultItems []utils.ResultItem) ([]byte, error) {
 	payload := &LocallyGeneratedPayload{
 		RepoKey: aqlResultItems[0].Repo,
 		Paths:   make([]string, 0, len(aqlResultItems)),
@@ -123,7 +124,7 @@ func (lg *LocallyGeneratedFilter) createPayload(aqlResultItems []utils.ResultIte
 // resp - Response status from Artifactory
 // body - Response body from Artifactory
 // Return a set of non locally generated paths - the files and directories to transfer.
-func (lg *LocallyGeneratedFilter) parseResponse(resp *http.Response, body []byte) (*datastructures.Set[string], error) {
+func (lg *locallyGeneratedFilter) parseResponse(resp *http.Response, body []byte) (*datastructures.Set[string], error) {
 	if err := errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK); err != nil {
 		return nil, err
 	}
@@ -145,7 +146,7 @@ func (lg *LocallyGeneratedFilter) parseResponse(resp *http.Response, body []byte
 // Get the non-locally-generated AQL results.
 // aqlResultItems - Directory content in phase 1 or 15 minutes interval results in phase 2
 // nonLocallyGeneratedPaths - Non locally generated paths
-func (lg *LocallyGeneratedFilter) getNonLocallyGeneratedResults(aqlResultItems []utils.ResultItem, nonLocallyGeneratedPaths *datastructures.Set[string]) (nonLocallyGeneratedAqlResults []utils.ResultItem) {
+func (lg *locallyGeneratedFilter) getNonLocallyGeneratedResults(aqlResultItems []utils.ResultItem, nonLocallyGeneratedPaths *datastructures.Set[string]) (nonLocallyGeneratedAqlResults []utils.ResultItem) {
 	nonLocallyGeneratedAqlResults = make([]utils.ResultItem, 0, nonLocallyGeneratedPaths.Size())
 	for i := range aqlResultItems {
 		pathInRepo := getPathInRepo(&aqlResultItems[i])

--- a/artifactory/commands/transferfiles/localgeneratedfilter_test.go
+++ b/artifactory/commands/transferfiles/localgeneratedfilter_test.go
@@ -82,9 +82,9 @@ func TestFilterLocallyGeneratedMaxRequests(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			_, err := locallyGenerated.FilterLocallyGenerated([]utils.ResultItem{{Path: "a", Name: "b"}})
 			assert.NoError(t, err)
-			wg.Done()
 		}()
 	}
 	wg.Wait()

--- a/artifactory/commands/transferfiles/localgeneratedfilter_test.go
+++ b/artifactory/commands/transferfiles/localgeneratedfilter_test.go
@@ -1,9 +1,13 @@
 package transferfiles
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/jfrog/jfrog-cli-core/v2/common/tests"
 	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
@@ -31,8 +35,8 @@ func TestFilterLocallyGenerated(t *testing.T) {
 		}
 	})
 	defer testServer.Close()
-	locallyGeneratedEnabled := NewLocallyGenerated(servicesManager, minArtifactoryVersionForLocallyGenerated)
-	locallyGeneratedDisabled := NewLocallyGenerated(servicesManager, "7.0.0")
+	locallyGeneratedEnabled := NewLocallyGenerated(context.Background(), servicesManager, minArtifactoryVersionForLocallyGenerated)
+	locallyGeneratedDisabled := NewLocallyGenerated(context.Background(), servicesManager, "7.0.0")
 
 	for _, testCase := range filterLocallyGeneratedCases {
 		t.Run("", func(t *testing.T) {
@@ -54,12 +58,44 @@ func TestFilterLocallyGenerated(t *testing.T) {
 	}
 }
 
+func TestFilterLocallyGeneratedMaxRequests(t *testing.T) {
+	var parallelRequestsCount int32
+	testServer, _, servicesManager := tests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		// Make sure the number of requests in parallel is less than 2
+		assert.Less(t, parallelRequestsCount, int32(maxConcurrentLocallyGeneratedRequests))
+
+		// Increment the number of parallel requests
+		atomic.AddInt32(&parallelRequestsCount, 1)
+		defer atomic.AddInt32(&parallelRequestsCount, -1)
+
+		// Send the response
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("{}"))
+		assert.NoError(t, err)
+		time.Sleep(time.Millisecond * 10)
+	})
+	defer testServer.Close()
+	locallyGenerated := NewLocallyGenerated(context.Background(), servicesManager, minArtifactoryVersionForLocallyGenerated)
+
+	// Run FilterLocallyGenerated 10 times concurrently
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			_, err := locallyGenerated.FilterLocallyGenerated([]utils.ResultItem{{Path: "a", Name: "b"}})
+			assert.NoError(t, err)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
 func TestFilterLocallyGeneratedEnabled(t *testing.T) {
 	testServer, _, servicesManager := tests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {})
 	defer testServer.Close()
 
-	assert.True(t, NewLocallyGenerated(servicesManager, minArtifactoryVersionForLocallyGenerated).IsEnabled())
-	assert.True(t, NewLocallyGenerated(servicesManager, "8.0.0").IsEnabled())
-	assert.False(t, NewLocallyGenerated(servicesManager, "7.54.5").IsEnabled())
-	assert.False(t, NewLocallyGenerated(servicesManager, "6.0.0").IsEnabled())
+	assert.True(t, NewLocallyGenerated(context.Background(), servicesManager, minArtifactoryVersionForLocallyGenerated).IsEnabled())
+	assert.True(t, NewLocallyGenerated(context.Background(), servicesManager, "8.0.0").IsEnabled())
+	assert.False(t, NewLocallyGenerated(context.Background(), servicesManager, "7.54.5").IsEnabled())
+	assert.False(t, NewLocallyGenerated(context.Background(), servicesManager, "6.0.0").IsEnabled())
 }

--- a/artifactory/commands/transferfiles/phase.go
+++ b/artifactory/commands/transferfiles/phase.go
@@ -31,7 +31,7 @@ type transferPhase interface {
 	getPhaseName() string
 	setProgressBar(*TransferProgressMng)
 	setStateManager(stateManager *state.TransferStateManager)
-	setLocallyGeneratedFilter(locallyGeneratedFilter *LocallyGeneratedFilter)
+	setLocallyGeneratedFilter(locallyGeneratedFilter *locallyGeneratedFilter)
 	initProgressBar() error
 	setProxyKey(proxyKey string)
 	setBuildInfo(setBuildInfo bool)
@@ -57,7 +57,7 @@ type phaseBase struct {
 	pcDetails                 *producerConsumerWrapper
 	transferManager           *transferManager
 	stateManager              *state.TransferStateManager
-	locallyGeneratedFilter    *LocallyGeneratedFilter
+	locallyGeneratedFilter    *locallyGeneratedFilter
 	stopSignal                chan os.Signal
 }
 
@@ -128,7 +128,7 @@ func (pb *phaseBase) setStateManager(stateManager *state.TransferStateManager) {
 	pb.stateManager = stateManager
 }
 
-func (pb *phaseBase) setLocallyGeneratedFilter(locallyGeneratedFilter *LocallyGeneratedFilter) {
+func (pb *phaseBase) setLocallyGeneratedFilter(locallyGeneratedFilter *locallyGeneratedFilter) {
 	pb.locallyGeneratedFilter = locallyGeneratedFilter
 }
 

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -569,7 +569,7 @@ func (tdc *TransferFilesCommand) initLocallyGeneratedFilter() error {
 	if err != nil {
 		return err
 	}
-	tdc.locallyGeneratedFilter = NewLocallyGenerated(servicesManager, targetArtifactoryVersion)
+	tdc.locallyGeneratedFilter = NewLocallyGenerated(tdc.context, servicesManager, targetArtifactoryVersion)
 	return err
 }
 

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -53,7 +53,7 @@ type TransferFilesCommand struct {
 	stopSignal                chan os.Signal
 	stateManager              *state.TransferStateManager
 	preChecks                 bool
-	locallyGeneratedFilter    *LocallyGeneratedFilter
+	locallyGeneratedFilter    *locallyGeneratedFilter
 }
 
 func NewTransferFilesCommand(sourceServer, targetServer *config.ServerDetails) (*TransferFilesCommand, error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

JFrog CLI tests: https://github.com/jfrog/jfrog-cli/pull/2018
Limit the number of concurrent 'POST /localgenerated/filter/paths' requests to 2, to reduce the load on the target server.