### PR TITLE
Remove leading slash from the remote repo env

### DIFF
--- a/utils/coreutils/utils.go
+++ b/utils/coreutils/utils.go
@@ -574,7 +574,7 @@ func GetServerIdAndRepo(remoteEnv string) (serverID string, repoName string, err
 		return "", "", nil
 	}
 	// The serverAndRepo is in the form of '<ServerID>/<RemoteRepo>'
-	lastSlashIndex := strings.LastIndex(serverAndRepo, "/")
+	lastSlashIndex := strings.Index(serverAndRepo, "/")
 	// Check that the format is valid
 	invalidFormat := lastSlashIndex == -1 || lastSlashIndex == len(serverAndRepo)-1 || lastSlashIndex == 0
 	if invalidFormat {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
- The JFROG_CLI_RELEASES_REPO format is <ServerID>\<RemoteRepo>.
- Currently, we extract the remote repo by searching for the last index.
- However, the remote repo could contain slashes, which causes the current approach to fail in extracting the correct value.
- This pull request modifies this behavior so that we now consider the first appearance of a slash as the separator, as serverId should not include slashes.