### PR TITLE
skip-folders flag

### DIFF
--- a/xray/audit/jas/applicabilitymanager_test.go
+++ b/xray/audit/jas/applicabilitymanager_test.go
@@ -411,7 +411,7 @@ func TestGetExtendedScanResults_AnalyzerManagerReturnsError(t *testing.T) {
 	analyzerManagerExecuter = &analyzerManagerMock{}
 
 	// Act
-	extendedResults, err := GetExtendedScanResults(fakeBasicXrayResults, fakeBasicDependencyGraph, &fakeServerDetails)
+	extendedResults, err := GetExtendedScanResults(fakeBasicXrayResults, fakeBasicDependencyGraph, &fakeServerDetails, "")
 
 	// Assert
 	assert.Error(t, err)

--- a/xray/audit/jas/jasmanager.go
+++ b/xray/audit/jas/jasmanager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/xray/services"
 	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
 	"os"
+	"strings"
 )
 
 const serverDetailsErrorMessage = "cant get xray server details"
@@ -20,7 +21,7 @@ var (
 )
 
 func GetExtendedScanResults(xrayResults []services.ScanResponse, dependencyTrees []*xrayUtils.GraphNode,
-	serverDetails *config.ServerDetails) (*utils.ExtendedScanResults, error) {
+	serverDetails *config.ServerDetails, skipFoldersFlagContent string) (*utils.ExtendedScanResults, error) {
 	if serverDetails == nil {
 		return nil, errors.New(serverDetailsErrorMessage)
 	}
@@ -38,6 +39,9 @@ func GetExtendedScanResults(xrayResults []services.ScanResponse, dependencyTrees
 	}
 	if err = utils.CreateAnalyzerManagerLogDir(); err != nil {
 		return nil, err
+	}
+	if skipFoldersFlagContent != "" {
+		skippedDirs = strings.Split(skipFoldersFlagContent, ",")
 	}
 	applicabilityScanResults, eligibleForApplicabilityScan, err := getApplicabilityScanResults(xrayResults,
 		dependencyTrees, serverDetails, analyzerManagerExecuter)

--- a/xray/audit/jas/jasmanager_test.go
+++ b/xray/audit/jas/jasmanager_test.go
@@ -63,7 +63,7 @@ func TestGetExtendedScanResults_AnalyzerManagerDoesntExist(t *testing.T) {
 	analyzerManagerExecuter = &analyzerManagerMock{}
 
 	// Act
-	extendedResults, err := GetExtendedScanResults(fakeBasicXrayResults, fakeBasicDependencyGraph, &fakeServerDetails)
+	extendedResults, err := GetExtendedScanResults(fakeBasicXrayResults, fakeBasicDependencyGraph, &fakeServerDetails, "")
 
 	// Assert
 	assert.NoError(t, err)
@@ -74,7 +74,7 @@ func TestGetExtendedScanResults_AnalyzerManagerDoesntExist(t *testing.T) {
 
 func TestGetExtendedScanResults_ServerNotValid(t *testing.T) {
 	// Act
-	extendedResults, err := GetExtendedScanResults(fakeBasicXrayResults, fakeBasicDependencyGraph, nil)
+	extendedResults, err := GetExtendedScanResults(fakeBasicXrayResults, fakeBasicDependencyGraph, nil, "")
 
 	// Assert
 	assert.Nil(t, extendedResults)

--- a/xray/commands/audit/generic/generic.go
+++ b/xray/commands/audit/generic/generic.go
@@ -19,6 +19,7 @@ type GenericAuditCommand struct {
 	projectKey             string
 	targetRepoPath         string
 	minSeverityFilter      string
+	jasSkipFolders         string
 	fixableOnly            bool
 	IncludeVulnerabilities bool
 	IncludeLicenses        bool
@@ -81,6 +82,11 @@ func (auditCmd *GenericAuditCommand) SetFixableOnly(fixable bool) *GenericAuditC
 	return auditCmd
 }
 
+func (auditCmd *GenericAuditCommand) SetJasSkipFolders(skippedFolders string) *GenericAuditCommand {
+	auditCmd.jasSkipFolders = skippedFolders
+	return auditCmd
+}
+
 func (auditCmd *GenericAuditCommand) CreateXrayGraphScanParams() *services.XrayGraphScanParams {
 	params := &services.XrayGraphScanParams{
 		RepoPath: auditCmd.targetRepoPath,
@@ -138,7 +144,7 @@ func (auditCmd *GenericAuditCommand) Run() (err error) {
 	extendedScanResults := &xrutils.ExtendedScanResults{XrayResults: results, ApplicabilityScanResults: nil, EntitledForJas: false}
 	// Try to run contextual analysis only if the user is entitled for advance security
 	if entitled {
-		extendedScanResults, err = jas.GetExtendedScanResults(results, auditParams.FullDependenciesTree(), serverDetails)
+		extendedScanResults, err = jas.GetExtendedScanResults(results, auditParams.FullDependenciesTree(), serverDetails, auditCmd.jasSkipFolders)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

The purpose of this PR:

* Adding a new flag: "skip-folders" to the audit command.
* This flag determines which folders will not be scanned by Jas scanners.
* When the user is not using this flag, the default value is (same as in vs code): "/test/", "/venv/", "/node_modules/", "/target/"
