### PR TITLE
Transfer - Empty dirs are not transferred in diffs

### DIFF
--- a/artifactory/commands/transferfiles/filediff_test.go
+++ b/artifactory/commands/transferfiles/filediff_test.go
@@ -1,0 +1,34 @@
+package transferfiles
+
+import (
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/api"
+	servicesUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var convertResultsToFileRepresentationTestCases = []struct {
+	input          servicesUtils.ResultItem
+	expectedOutput api.FileRepresentation
+}{
+	{
+		servicesUtils.ResultItem{Repo: repo1Key, Path: "path-in-repo", Name: "file-name", Type: "file", Size: 100},
+		api.FileRepresentation{Repo: repo1Key, Path: "path-in-repo", Name: "file-name", Size: 100},
+	},
+	{
+		servicesUtils.ResultItem{Repo: repo1Key, Path: "path-in-repo", Name: "folder-name", Type: "folder"},
+		api.FileRepresentation{Repo: repo1Key, Path: "path-in-repo/folder-name"},
+	},
+	{
+		servicesUtils.ResultItem{Repo: repo1Key, Path: ".", Name: "folder-name", Type: "folder"},
+		api.FileRepresentation{Repo: repo1Key, Path: "folder-name"},
+	},
+}
+
+func TestConvertResultsToFileRepresentation(t *testing.T) {
+	for _, testCase := range convertResultsToFileRepresentationTestCases {
+		files := convertResultsToFileRepresentation([]servicesUtils.ResultItem{testCase.input})
+		assert.Equal(t, []api.FileRepresentation{testCase.expectedOutput}, files)
+	}
+}

--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -163,10 +163,10 @@ func (f *filesDiffPhase) handleTimeFrameFilesDiff(pcWrapper *producerConsumerWra
 }
 
 func convertResultsToFileRepresentation(results []servicesUtils.ResultItem) (files []api.FileRepresentation) {
-	var pathInRepo string
 	for _, result := range results {
 		switch result.Type {
 		case "folder":
+			var pathInRepo string
 			if result.Path == "." {
 				pathInRepo = result.Name
 			} else {

--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -165,7 +165,8 @@ func (f *filesDiffPhase) handleTimeFrameFilesDiff(pcWrapper *producerConsumerWra
 func convertResultsToFileRepresentation(results []servicesUtils.ResultItem) (files []api.FileRepresentation) {
 	var pathInRepo string
 	for _, result := range results {
-		if result.Type == "folder" {
+		switch result.Type {
+		case "folder":
 			if result.Path == "." {
 				pathInRepo = result.Name
 			} else {
@@ -175,7 +176,7 @@ func convertResultsToFileRepresentation(results []servicesUtils.ResultItem) (fil
 				Repo: result.Repo,
 				Path: pathInRepo,
 			})
-		} else {
+		default:
 			files = append(files, api.FileRepresentation{
 				Repo: result.Repo,
 				Path: result.Path,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fix the following error happens in the phase 2 of the transfer-files command:
> unexpected error occurred during upload
org.artifactory.api.repo.exception.FileExpectedException: Expected a file but found a folder, at: repo-name:path/in/repo/dir-name

In the Diffs phase (phase 2), the JFrog CLI treats all items as files and uses the folder name as the file name. However, the Data Transfer plugin expects an empty "name" field when the item is a folder.
