### PR TITLE
Npm audit may skip some dependencies

### DIFF
--- a/xray/audit/npm/npm.go
+++ b/xray/audit/npm/npm.go
@@ -33,11 +33,16 @@ func BuildDependencyTree(npmArgs []string) (dependencyTree []*xrayUtils.GraphNod
 	npmArgs = addIgnoreScriptsFlag(npmArgs)
 
 	// Calculate npm dependencies
-	dependenciesList, err := biutils.CalculateNpmDependenciesList(npmExecutablePath, currentDir, packageInfo.BuildInfoModuleId(), npmArgs, false, log.Logger)
+	dependenciesMap, err := biutils.CalculateDependenciesMap(npmExecutablePath, currentDir, packageInfo.BuildInfoModuleId(), npmArgs, log.Logger)
 	if err != nil {
 		log.Info("Used npm version:", npmVersion.GetVersion())
 		return
 	}
+	var dependenciesList []buildinfo.Dependency
+	for _, dependency := range dependenciesMap {
+		dependenciesList = append(dependenciesList, dependency.Dependency)
+	}
+
 	// Parse the dependencies into Xray dependency tree format
 	dependencyTree = []*xrayUtils.GraphNode{parseNpmDependenciesList(dependenciesList, packageInfo)}
 	return


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

When auditing npm projects with `jf audit`, bundled and peer dependencies may be skipped if they do not appear in the local cache.

To replicate the issue, follow these steps:

1. Clone the repository https://github.com/npm/cli.
2. Execute the command jf audit.
3. Observe that instead of scanning 399 dependencies, only 2 are being scanned.