### PR TITLE
Secrets scanners - Enable all scanners

### DIFF
--- a/xray/audit/jas/secretsscanner.go
+++ b/xray/audit/jas/secretsscanner.go
@@ -3,6 +3,9 @@ package jas
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/utils"
@@ -10,13 +13,10 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/owenrumney/go-sarif/v2/sarif"
 	"gopkg.in/yaml.v2"
-	"os"
-	"path/filepath"
 )
 
 const (
 	secretsScanCommand    = "sec"
-	secretsScannersNames  = "tokens, entropy"
 	secretsScannerType    = "secrets-scan"
 	secScanFailureMessage = "failed to run secrets scan. Cause: %s"
 )
@@ -100,7 +100,6 @@ type secretsScanConfiguration struct {
 	Roots       []string `yaml:"roots"`
 	Output      string   `yaml:"output"`
 	Type        string   `yaml:"type"`
-	Scanners    string   `yaml:"scanners"`
 	SkippedDirs []string `yaml:"skipped-folders"`
 }
 
@@ -116,7 +115,6 @@ func (s *SecretScanManager) createConfigFile() error {
 				Roots:       []string{currentDir},
 				Output:      s.resultsFileName,
 				Type:        secretsScannerType,
-				Scanners:    secretsScannersNames,
 				SkippedDirs: skippedDirs,
 			},
 		},


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
The scanner names param is used to determine which secrets scanners should run when a secrets detection is performed. 
In our use case, enabling the run of all scanners is better than maintaining this list.