### PR TITLE
Transfer - Fix repositories were not found issue

### DIFF
--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -520,11 +520,12 @@ func (tdc *TransferFilesCommand) getAllLocalRepos(serverDetails *config.ServerDe
 	if err != nil {
 		return []string{}, []string{}, err
 	}
-	localRepos, err := utils.GetFilteredRepositoriesByNameAndType(serviceManager, tdc.includeReposPatterns, tdc.excludeReposPatterns, utils.Local)
+	repoExclusionPatternsWithBuildInfo := append(tdc.excludeReposPatterns, "*-build-info")
+	localRepos, err := utils.GetFilteredRepositoriesByNameAndType(serviceManager, tdc.includeReposPatterns, repoExclusionPatternsWithBuildInfo, utils.Local)
 	if err != nil {
 		return []string{}, []string{}, err
 	}
-	federatedRepos, err := utils.GetFilteredRepositoriesByNameAndType(serviceManager, tdc.includeReposPatterns, tdc.excludeReposPatterns, utils.Federated)
+	federatedRepos, err := utils.GetFilteredRepositoriesByNameAndType(serviceManager, tdc.includeReposPatterns, repoExclusionPatternsWithBuildInfo, utils.Federated)
 	if err != nil {
 		return []string{}, []string{}, err
 	}

--- a/artifactory/commands/transferfiles/transfer_test.go
+++ b/artifactory/commands/transferfiles/transfer_test.go
@@ -339,7 +339,8 @@ func TestGetAllLocalRepositories(t *testing.T) {
 		case "/api/repositories?type=federated&packageType=":
 			// Response for GetWithFilter
 			w.WriteHeader(http.StatusOK)
-			response := &[]services.RepositoryDetails{{Key: "federated-repo-1"}, {Key: "federated-repo-2"}}
+			// We add a build info repository to the response to cover cases whereby a federated build-info repository is returned
+			response := &[]services.RepositoryDetails{{Key: "federated-repo-1"}, {Key: "federated-repo-2"}, {Key: "proj-build-info"}}
 			bytes, err := json.Marshal(response)
 			assert.NoError(t, err)
 			_, err = w.Write(bytes)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fix the following issue:
> one or more of the requested repositories were not found

**Root cause:**
The GetFilteredRepositoriesByNameAndType REST API does not include the build-info repositories in its return results. However, if the build-info repository is federated, it will be included in the response of this REST API. In such a scenario, the build-info might appear twice in the return value of the method.

**Solution**
Exclude the build-info repositories from the GetFilteredRepositoriesByNameAndType() requests.