### PR TITLE
Transfer files - Fix `repo snapshot manager` error

### DIFF
--- a/artifactory/commands/transferfiles/state/state_test.go
+++ b/artifactory/commands/transferfiles/state/state_test.go
@@ -153,6 +153,9 @@ func getRootAndAddSnapshotData(t *testing.T, stateManager *TransferStateManager)
 	root, err := stateManager.LookUpNode(".")
 	assert.NoError(t, err)
 	assert.NoError(t, root.IncrementFilesCount())
-	assert.NoError(t, root.AddChildNode("child", nil))
+	children, err := root.GetChildren()
+	assert.NoError(t, err)
+	childNode := reposnapshot.CreateNewNode("child", root)
+	children = append(children, childNode)
 	return
 }

--- a/artifactory/commands/transferfiles/state/state_test.go
+++ b/artifactory/commands/transferfiles/state/state_test.go
@@ -153,9 +153,6 @@ func getRootAndAddSnapshotData(t *testing.T, stateManager *TransferStateManager)
 	root, err := stateManager.LookUpNode(".")
 	assert.NoError(t, err)
 	assert.NoError(t, root.IncrementFilesCount())
-	children, err := root.GetChildren()
-	assert.NoError(t, err)
-	childNode := reposnapshot.CreateNewNode("child", root)
-	children = append(children, childNode)
-	return
+	assert.NoError(t, root.AddChildNode("child"))
+	return root
 }

--- a/utils/reposnapshot/node.go
+++ b/utils/reposnapshot/node.go
@@ -157,22 +157,6 @@ func (node *Node) DecrementFilesCount() error {
 	})
 }
 
-// Adds a new child node to children map.
-// childrenPool - [Optional] Children array to check existence of a dirName in before creating a new node.
-func (node *Node) AddChildNode(dirName string, childrenPool []*Node) error {
-	return node.action(func(node *Node) error {
-		for i := range childrenPool {
-			if childrenPool[i].name == dirName {
-				childrenPool[i].parent = node
-				node.children = append(node.children, childrenPool[i])
-				return nil
-			}
-		}
-		node.children = append(node.children, CreateNewNode(dirName, node))
-		return nil
-	})
-}
-
 func (node *Node) convertAndSaveToFile(stateFilePath string) error {
 	wrapper, err := node.convertToWrapper()
 	if err != nil {
@@ -228,23 +212,32 @@ func (node *Node) RestartExploring() error {
 
 // Recursively find the node matching the path represented by the dirs array.
 // The search is done by comparing the children of each node path, till reaching the final node in the array.
-// If the node is not found, nil is returned.
+// If the node is not found, it is added and then returned.
 // For example:
 // For a structure such as repo->dir1->dir2->dir3
 // The initial call will be to the root, and for an input of ({"dir1","dir2"}), and the final output will be a pointer to dir2.
 func (node *Node) findMatchingNode(childrenDirs []string) (matchingNode *Node, err error) {
 	err = node.action(func(node *Node) error {
+		// The node was found in the cache. Let's return it.
 		if len(childrenDirs) == 0 {
 			matchingNode = node
 			return nil
 		}
+
+		// Check if any of the current node's children are parents of the current node.
 		for i := range node.children {
 			if node.children[i].name == childrenDirs[0] {
 				matchingNode, err = node.children[i].findMatchingNode(childrenDirs[1:])
 				return err
 			}
 		}
-		return nil
+
+		// None of the the current node's children are parents of the current node.
+		// This means we need to start creating the searched node parents.
+		newNode := CreateNewNode(childrenDirs[0], node)
+		node.children = append(node.children, newNode)
+		matchingNode, err = newNode.findMatchingNode(childrenDirs[1:])
+		return err
 	})
 	return
 }

--- a/utils/reposnapshot/node.go
+++ b/utils/reposnapshot/node.go
@@ -240,9 +240,10 @@ func (node *Node) findMatchingNode(childrenDirs []string) (matchingNode *Node, e
 			}
 		}
 
-		// None of the the current node's children are parents of the current node.
+		// None of the current node's children are parents of the current node.
 		// This means we need to start creating the searched node parents.
 		newNode := CreateNewNode(childrenDirs[0], node)
+		newNode.parent = node
 		node.children = append(node.children, newNode)
 		matchingNode, err = newNode.findMatchingNode(childrenDirs[1:])
 		return err

--- a/utils/reposnapshot/node.go
+++ b/utils/reposnapshot/node.go
@@ -157,6 +157,14 @@ func (node *Node) DecrementFilesCount() error {
 	})
 }
 
+// Adds a new child node to children map.
+func (node *Node) AddChildNode(dirName string) error {
+	return node.action(func(node *Node) error {
+		node.children = append(node.children, CreateNewNode(dirName, node))
+		return nil
+	})
+}
+
 func (node *Node) convertAndSaveToFile(stateFilePath string) error {
 	wrapper, err := node.convertToWrapper()
 	if err != nil {

--- a/utils/reposnapshot/snapshotmanager_test.go
+++ b/utils/reposnapshot/snapshotmanager_test.go
@@ -121,9 +121,6 @@ func TestLookUpNodeAndActualPath(t *testing.T) {
 		{"dir on root", "2", false},
 		{"complex path with separator suffix", "1/a/", false},
 		{"complex path with no separator suffix", "1/a", false},
-		{"repository provided", path.Join("test-local", "2"), true},
-		{"relative path includes root", "./2", true},
-		{"dir doesn't exist", "no/where", true},
 		{"empty path", "", true},
 	}
 

--- a/utils/reposnapshot/snapshotmanager_test.go
+++ b/utils/reposnapshot/snapshotmanager_test.go
@@ -187,22 +187,6 @@ func createNodeBase(t *testing.T, name string, filesCount int, parent *Node) *No
 	return node
 }
 
-func TestAddChildNode(t *testing.T) {
-	root := CreateNewNode(".", nil)
-	// Add child with no children pool.
-	addAndAssertChild(t, nil, root, CreateNewNode("no-pool", root))
-	// Add child with empty children pool.
-	addAndAssertChild(t, []*Node{}, root, CreateNewNode("empty-pool", root))
-	// Add child with pool.
-	exists := CreateNewNode("exists", root)
-	addAndAssertChild(t, []*Node{exists}, root, exists)
-}
-
-func addAndAssertChild(t *testing.T, childrenPool []*Node, root, expectedChild *Node) {
-	assert.NoError(t, root.AddChildNode(expectedChild.name, childrenPool))
-	assert.Equal(t, expectedChild, getChild(root, expectedChild.name))
-}
-
 func getChild(node *Node, childName string) *Node {
 	for _, child := range node.children {
 		if child.name == childName {


### PR DESCRIPTION
This fix resolves an issue with the `jf rt transfer-files` command. 
The symptom of this issue is the following error message that occasionally could be seen in the log:
```
repo snapshot manager - could not reach the representing node for path...
```
The key for fixing the issue, is the change made to the `findMatchingNode` function. The issue was that the `findMatchingNode` function could not always return the node. This is because the node may not be in the snapshot cache. It may yet to be discovered, or maybe it was discovered, but the snapshot cache didn't get a chance to get persisted yet, because of a shutdown of the command.

With this fix, the `findMatchingNode` function always fetches the node, It returns it if it's cached, and creates it and adds it to the cache if it isn't cached. As a result, the `AddChildNode` function became redundant and was left only to be used by one of tests,
