### PR TITLE
Transfer - Fix infinite speeds average when there are no working threads

### DIFF
--- a/artifactory/commands/transferfiles/state/timeestimation.go
+++ b/artifactory/commands/transferfiles/state/timeestimation.go
@@ -78,6 +78,10 @@ func (tem *TimeEstimationManager) addDataChunkStatus(chunkStatus api.ChunkStatus
 		tem.LastSpeedsSum -= tem.LastSpeeds[0]
 		tem.LastSpeeds = tem.LastSpeeds[1:]
 	}
+	if len(tem.LastSpeeds) == 0 {
+		tem.SpeedsAverage = 0
+		return
+	}
 	// Calculate speed in bytes/ms
 	tem.SpeedsAverage = tem.LastSpeedsSum / float64(len(tem.LastSpeeds))
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fix infinite speeds average, causing the saving of the transfer run status to fail.