### PR TITLE
Transfer config - Issue in repos assigned to projects

### DIFF
--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -474,6 +474,10 @@ func (tcc *TransferConfigCommand) createImportPollingAction(rtDetails *httputils
 		if err != nil {
 			return true, nil, err
 		}
+		tcc.TargetAccessManager, err = utils.CreateAccessServiceManager(newServerDetails, false)
+		if err != nil {
+			return true, nil, err
+		}
 		rtDetails, err = commandsUtils.CreateArtifactoryClientDetails(tcc.TargetArtifactoryManager)
 		if err != nil {
 			return true, nil, err
@@ -527,36 +531,46 @@ func (tcc *TransferConfigCommand) getWorkingDirParam() string {
 
 // Make sure that the source Artifactory version is sufficient.
 // Returns the source Artifactory version.
-func (tcc *TransferConfigCommand) validateMinVersion() error {
+func (tcc *TransferConfigCommand) validateMinVersion() (sourceArtifactoryVersion string, err error) {
 	log.Info("Verifying minimum version of the source server...")
-	sourceArtifactoryVersion, err := tcc.SourceArtifactoryManager.GetVersion()
+	sourceArtifactoryVersion, err = tcc.SourceArtifactoryManager.GetVersion()
 	if err != nil {
-		return err
+		return
 	}
-	targetArtifactoryVersion, err := tcc.TargetArtifactoryManager.GetVersion()
+	var targetArtifactoryVersion string
+	targetArtifactoryVersion, err = tcc.TargetArtifactoryManager.GetVersion()
 	if err != nil {
-		return err
+		return
 	}
 
 	// Validate minimal Artifactory version in the source server
 	err = coreutils.ValidateMinimumVersion(coreutils.Artifactory, sourceArtifactoryVersion, minTransferConfigArtifactoryVersion)
 	if err != nil {
-		return err
+		return
 	}
 
 	// Validate that the target Artifactory server version is >= than the source Artifactory server version
 	if !version.NewVersion(targetArtifactoryVersion).AtLeast(sourceArtifactoryVersion) {
-		return errorutils.CheckErrorf("The source Artifactory version (%s) can't be higher than the target Artifactory version (%s).", sourceArtifactoryVersion, targetArtifactoryVersion)
+		err = errorutils.CheckErrorf("The source Artifactory version (%s) can't be higher than the target Artifactory version (%s).", sourceArtifactoryVersion, targetArtifactoryVersion)
 	}
 
-	return nil
+	return
 }
 
-func (tcc *TransferConfigCommand) validateServerPrerequisites() error {
+func (tcc *TransferConfigCommand) validateServerPrerequisites() (err error) {
+	var sourceArtifactoryVersion string
 	// Make sure that the source Artifactory version is sufficient.
-	if err := tcc.validateMinVersion(); err != nil {
-		return err
+	if sourceArtifactoryVersion, err = tcc.validateMinVersion(); err != nil {
+		return
 	}
+
+	// Check connectivity to JFrog Access if the source Artifactory version is >= 7.0.0
+	if versionErr := coreutils.ValidateMinimumVersion(coreutils.Projects, sourceArtifactoryVersion, commandsUtils.MinJFrogProjectsArtifactoryVersion); versionErr == nil {
+		if err = tcc.ValidateAccess(tcc.SourceServerDetails, tcc.SourceAccessManager); err != nil {
+			return
+		}
+	}
+
 	// Make sure source and target Artifactory URLs are different
 	if err := tcc.ValidateDifferentServers(); err != nil {
 		return err

--- a/artifactory/commands/transferconfig/transferconfig.go
+++ b/artifactory/commands/transferconfig/transferconfig.go
@@ -566,14 +566,14 @@ func (tcc *TransferConfigCommand) validateServerPrerequisites() (err error) {
 
 	// Check connectivity to JFrog Access if the source Artifactory version is >= 7.0.0
 	if versionErr := coreutils.ValidateMinimumVersion(coreutils.Projects, sourceArtifactoryVersion, commandsUtils.MinJFrogProjectsArtifactoryVersion); versionErr == nil {
-		if err = tcc.ValidateAccess(tcc.SourceServerDetails, tcc.SourceAccessManager); err != nil {
+		if err = tcc.ValidateAccessServerConnection(tcc.SourceServerDetails, tcc.SourceAccessManager); err != nil {
 			return
 		}
 	}
 
 	// Make sure source and target Artifactory URLs are different
-	if err := tcc.ValidateDifferentServers(); err != nil {
-		return err
+	if err = tcc.ValidateDifferentServers(); err != nil {
+		return
 	}
 	// Make sure that the target Artifactory is empty and the config-import plugin is installed
 	return tcc.validateTargetServer()

--- a/artifactory/commands/transferconfig/transferconfig_test.go
+++ b/artifactory/commands/transferconfig/transferconfig_test.go
@@ -266,7 +266,7 @@ func TestValidateMinVersion(t *testing.T) {
 	}
 }
 
-func TestValidateAccess(t *testing.T) {
+func TestValidateAccessServerConnection(t *testing.T) {
 	// Create transfer config command
 	testServer, serverDetails, accessManager := commonTests.CreateAccessRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.RequestURI {
@@ -275,16 +275,15 @@ func TestValidateAccess(t *testing.T) {
 		default:
 			assert.Fail(t, "Unexpected request URI: "+r.RequestURI)
 		}
-
 	})
 	defer testServer.Close()
 
 	transferConfigCmd := createTransferConfigCommand(t, nil, nil)
-	err := transferConfigCmd.ValidateAccess(serverDetails, accessManager)
+	err := transferConfigCmd.ValidateAccessServerConnection(serverDetails, accessManager)
 	assert.NoError(t, err)
 }
 
-func TestValidateAccessForbidden(t *testing.T) {
+func TestValidateAccessServerConnectionForbidden(t *testing.T) {
 	// Create transfer config command
 	testServer, serverDetails, accessManager := commonTests.CreateAccessRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.RequestURI {
@@ -298,6 +297,6 @@ func TestValidateAccessForbidden(t *testing.T) {
 
 	transferConfigCmd := createTransferConfigCommand(t, nil, nil)
 	// Assert access token invalid error
-	err := transferConfigCmd.ValidateAccess(serverDetails, accessManager)
+	err := transferConfigCmd.ValidateAccessServerConnection(serverDetails, accessManager)
 	assert.ErrorContains(t, err, "the 'test-server' instance Access Token is not valid. Please provide a valid access token by running the 'jf c edit test-server'")
 }

--- a/artifactory/commands/transferconfig/transferconfig_test.go
+++ b/artifactory/commands/transferconfig/transferconfig_test.go
@@ -255,12 +255,49 @@ func TestValidateMinVersion(t *testing.T) {
 		t.Run(testCase.testName, func(t *testing.T) {
 			sourceRtVersion = testCase.sourceVersion
 			targetRtVersion = testCase.targetVersion
-			err := createTransferConfigCommand(t, sourceServerDetails, targetServerDetails).validateMinVersion()
+			actualSourceRtVersion, err := createTransferConfigCommand(t, sourceServerDetails, targetServerDetails).validateMinVersion()
 			if testCase.expectedError == "" {
 				assert.NoError(t, err)
+				assert.Equal(t, sourceRtVersion, actualSourceRtVersion)
 			} else {
 				assert.ErrorContains(t, err, testCase.expectedError)
 			}
 		})
 	}
+}
+
+func TestValidateAccess(t *testing.T) {
+	// Create transfer config command
+	testServer, serverDetails, accessManager := commonTests.CreateAccessRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		case "/access/api/v1/system/ping":
+			w.WriteHeader(http.StatusOK)
+		default:
+			assert.Fail(t, "Unexpected request URI: "+r.RequestURI)
+		}
+
+	})
+	defer testServer.Close()
+
+	transferConfigCmd := createTransferConfigCommand(t, nil, nil)
+	err := transferConfigCmd.ValidateAccess(serverDetails, accessManager)
+	assert.NoError(t, err)
+}
+
+func TestValidateAccessForbidden(t *testing.T) {
+	// Create transfer config command
+	testServer, serverDetails, accessManager := commonTests.CreateAccessRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		case "/access/api/v1/system/ping":
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			assert.Fail(t, "Unexpected request URI: "+r.RequestURI)
+		}
+	})
+	defer testServer.Close()
+
+	transferConfigCmd := createTransferConfigCommand(t, nil, nil)
+	// Assert access token invalid error
+	err := transferConfigCmd.ValidateAccess(serverDetails, accessManager)
+	assert.ErrorContains(t, err, "the 'test-server' instance Access Token is not valid. Please provide a valid access token by running the 'jf c edit test-server'")
 }

--- a/artifactory/commands/transferconfigmerge/transferconfigmerge.go
+++ b/artifactory/commands/transferconfigmerge/transferconfigmerge.go
@@ -10,10 +10,8 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
-	"github.com/jfrog/jfrog-client-go/access"
 	accessServices "github.com/jfrog/jfrog-client-go/access/services"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
-	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"golang.org/x/exp/slices"
 )
@@ -21,10 +19,9 @@ import (
 type ConflictType string
 
 const (
-	Repository                         ConflictType = "Repository"
-	Project                            ConflictType = "Project"
-	logFilePrefix                                   = "transfer-config-conflicts"
-	minJFrogProjectsArtifactoryVersion              = "7.0.0"
+	Repository    ConflictType = "Repository"
+	Project       ConflictType = "Project"
+	logFilePrefix              = "transfer-config-conflicts"
 )
 
 // Repository key that should be filtered when comparing repositories (all must be lowercase)
@@ -34,8 +31,6 @@ type TransferConfigMergeCommand struct {
 	commandsUtils.TransferConfigBase
 	includeProjectsPatterns []string
 	excludeProjectsPatterns []string
-	sourceAccessManager     access.AccessServicesManager
-	targetAccessManager     access.AccessServicesManager
 }
 
 func NewTransferConfigMergeCommand(sourceServer, targetServer *config.ServerDetails) *TransferConfigMergeCommand {
@@ -104,7 +99,7 @@ func (tcmc *TransferConfigMergeCommand) initServiceManagersAndValidateServers() 
 		return
 	}
 	// Check if JFrog Projects supported by Source Artifactory version
-	versionErr := coreutils.ValidateMinimumVersion(coreutils.Projects, sourceArtifactoryVersion, minJFrogProjectsArtifactoryVersion)
+	versionErr := coreutils.ValidateMinimumVersion(coreutils.Projects, sourceArtifactoryVersion, commandsUtils.MinJFrogProjectsArtifactoryVersion)
 	if versionErr != nil {
 		// Projects not supported by Source Artifactory version
 		return
@@ -112,37 +107,13 @@ func (tcmc *TransferConfigMergeCommand) initServiceManagersAndValidateServers() 
 
 	projectsSupported = true
 
-	tcmc.sourceAccessManager, err = createAccessManagerAndValidateToken(tcmc.SourceServerDetails)
-	if err != nil {
+	if err = tcmc.ValidateAccess(tcmc.SourceServerDetails, tcmc.SourceAccessManager); err != nil {
+		return
+	}
+	if err = tcmc.ValidateAccess(tcmc.TargetServerDetails, tcmc.TargetAccessManager); err != nil {
 		return
 	}
 
-	tcmc.targetAccessManager, err = createAccessManagerAndValidateToken(tcmc.TargetServerDetails)
-	if err != nil {
-		return
-	}
-
-	return
-}
-
-func createAccessManagerAndValidateToken(serverDetails *config.ServerDetails) (accessManager access.AccessServicesManager, err error) {
-	if serverDetails.Password != "" {
-		err = fmt.Errorf("it looks like you configured the '%[1]s' instance with username and password.\n"+
-			"The transfer-config-merge command can be used with admin Access Token only.\n"+
-			"Please use the 'jf c edit %[1]s' command to configure the Access Token, and then re-run the command", serverDetails.ServerId)
-		return
-	}
-
-	manager, err := utils.CreateAccessServiceManager(serverDetails, false)
-	if err != nil {
-		return
-	}
-
-	if _, err = manager.Ping(); err != nil {
-		err = errorutils.CheckErrorf("The '%[1]s' instance Access Token is not valid. Please provide a valid access token by running the 'jf c edit %[1]s'", serverDetails.ServerId)
-		return
-	}
-	accessManager = *manager
 	return
 }
 
@@ -202,12 +173,12 @@ func (tcmc *TransferConfigMergeCommand) transferEntities(mergeEntities mergeEnti
 
 func (tcmc *TransferConfigMergeCommand) mergeProjects(conflicts *[]Conflict) (projectsToTransfer []accessServices.Project, err error) {
 	log.Info("Getting all Projects from the source ...")
-	sourceProjects, err := tcmc.sourceAccessManager.GetAllProjects()
+	sourceProjects, err := tcmc.SourceAccessManager.GetAllProjects()
 	if err != nil {
 		return
 	}
 	log.Info("Getting all Projects from the target ...")
-	targetProjects, err := tcmc.targetAccessManager.GetAllProjects()
+	targetProjects, err := tcmc.TargetAccessManager.GetAllProjects()
 	if err != nil {
 		return
 	}
@@ -373,7 +344,7 @@ func compareInterfaces(first, second interface{}, filteredKeys ...string) (diff 
 func (tcmc *TransferConfigMergeCommand) transferProjectsToTarget(reposToTransfer []accessServices.Project) (err error) {
 	for _, project := range reposToTransfer {
 		log.Info(fmt.Sprintf("Transferring project '%s' ...", project.DisplayName))
-		if err = tcmc.targetAccessManager.CreateProject(accessServices.ProjectParams{ProjectDetails: project}); err != nil {
+		if err = tcmc.TargetAccessManager.CreateProject(accessServices.ProjectParams{ProjectDetails: project}); err != nil {
 			return
 		}
 	}

--- a/artifactory/commands/transferconfigmerge/transferconfigmerge.go
+++ b/artifactory/commands/transferconfigmerge/transferconfigmerge.go
@@ -107,10 +107,10 @@ func (tcmc *TransferConfigMergeCommand) initServiceManagersAndValidateServers() 
 
 	projectsSupported = true
 
-	if err = tcmc.ValidateAccess(tcmc.SourceServerDetails, tcmc.SourceAccessManager); err != nil {
+	if err = tcmc.ValidateAccessServerConnection(tcmc.SourceServerDetails, tcmc.SourceAccessManager); err != nil {
 		return
 	}
-	if err = tcmc.ValidateAccess(tcmc.TargetServerDetails, tcmc.TargetAccessManager); err != nil {
+	if err = tcmc.ValidateAccessServerConnection(tcmc.TargetServerDetails, tcmc.TargetAccessManager); err != nil {
 		return
 	}
 

--- a/artifactory/commands/utils/transferconfigbase.go
+++ b/artifactory/commands/utils/transferconfigbase.go
@@ -2,12 +2,15 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jfrog/gofrog/datastructures"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-client-go/access"
 	"github.com/jfrog/jfrog-client-go/artifactory"
 	clientUtils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -17,8 +20,9 @@ import (
 )
 
 const (
-	defaultAdminUsername = "admin"
-	defaultAdminPassword = "password"
+	MinJFrogProjectsArtifactoryVersion = "7.0.0"
+	defaultAdminUsername               = "admin"
+	defaultAdminPassword               = "password"
 )
 
 type TransferConfigBase struct {
@@ -26,6 +30,8 @@ type TransferConfigBase struct {
 	TargetServerDetails      *config.ServerDetails
 	SourceArtifactoryManager artifactory.ArtifactoryServicesManager
 	TargetArtifactoryManager artifactory.ArtifactoryServicesManager
+	SourceAccessManager      *access.AccessServicesManager
+	TargetAccessManager      *access.AccessServicesManager
 	IncludeReposPatterns     []string
 	ExcludeReposPatterns     []string
 	FederatedMembersRemoved  bool
@@ -56,12 +62,36 @@ func (tcb *TransferConfigBase) GetRepoFilter() *utils.IncludeExcludeFilter {
 }
 
 func (tcb *TransferConfigBase) CreateServiceManagers(dryRun bool) (err error) {
-	tcb.SourceArtifactoryManager, err = utils.CreateServiceManager(tcb.SourceServerDetails, -1, 0, dryRun)
-	if err != nil {
+	if tcb.SourceArtifactoryManager, err = utils.CreateServiceManager(tcb.SourceServerDetails, -1, 0, dryRun); err != nil {
 		return err
 	}
-	tcb.TargetArtifactoryManager, err = utils.CreateServiceManager(tcb.TargetServerDetails, -1, 0, dryRun)
+	if tcb.TargetArtifactoryManager, err = utils.CreateServiceManager(tcb.TargetServerDetails, -1, 0, dryRun); err != nil {
+		return err
+	}
+	if tcb.SourceAccessManager, err = utils.CreateAccessServiceManager(tcb.SourceServerDetails, false); err != nil {
+		return
+	}
+	if tcb.TargetAccessManager, err = utils.CreateAccessServiceManager(tcb.TargetServerDetails, false); err != nil {
+		return
+	}
+
 	return err
+}
+
+// Make sure that the server is configured with a valid admin Access Token.
+// serverDetails - The server to check
+// accessManager - Access Manager to run ping
+func (tcb *TransferConfigBase) ValidateAccess(serverDetails *config.ServerDetails, accessManager *access.AccessServicesManager) error {
+	if serverDetails.Password != "" {
+		return fmt.Errorf("it looks like you configured the '%[1]s' instance with username and password.\n"+
+			"This command can be used with admin Access Token only.\n"+
+			"Please use the 'jf c edit %[1]s' command to configure the Access Token, and then re-run the command", serverDetails.ServerId)
+	}
+
+	if _, err := accessManager.Ping(); err != nil {
+		return errors.Join(err, fmt.Errorf("the '%[1]s' instance Access Token is not valid. Please provide a valid access token by running the 'jf c edit %[1]s'", serverDetails.ServerId))
+	}
+	return nil
 }
 
 // Make sure source and target Artifactory URLs are different.
@@ -122,7 +152,7 @@ func (tcb *TransferConfigBase) DeactivateKeyEncryption() (reactivateKeyEncryptio
 func (tcb *TransferConfigBase) TransferRepositoriesToTarget(reposToTransfer map[utils.RepoType][]string, remoteRepositories []interface{}) (err error) {
 	// Transfer remote repositories
 	for i, remoteRepositoryName := range reposToTransfer[utils.Remote] {
-		if err = tcb.TargetArtifactoryManager.CreateRepositoryWithParams(remoteRepositories[i], remoteRepositoryName); err != nil {
+		if err = tcb.createRepositoryAndAssignToProject(remoteRepositories[i], remoteRepositoryName); err != nil {
 			return
 		}
 	}
@@ -169,7 +199,7 @@ func (tcb *TransferConfigBase) transferSpecificRepositoriesToTarget(reposToTrans
 				return
 			}
 		}
-		if err = tcb.TargetArtifactoryManager.CreateRepositoryWithParams(params, repoKey); err != nil {
+		if err = tcb.createRepositoryAndAssignToProject(params, repoKey); err != nil {
 			return
 		}
 	}
@@ -197,7 +227,7 @@ func (tcb *TransferConfigBase) transferVirtualRepositoriesToTarget(reposToTransf
 		// Create virtual repository without included repositories
 		repositories := singleRepoParamsMap["repositories"]
 		delete(singleRepoParamsMap, "repositories")
-		if err = tcb.TargetArtifactoryManager.CreateRepositoryWithParams(singleRepoParamsMap, repoKey); err != nil {
+		if err = tcb.createRepositoryAndAssignToProject(singleRepoParamsMap, repoKey); err != nil {
 			return
 		}
 
@@ -288,14 +318,68 @@ func (tcb *TransferConfigBase) removeFederatedMembers(federatedRepoParams interf
 	if _, exist := repoMap["members"]; exist {
 		delete(repoMap, "members")
 		tcb.FederatedMembersRemoved = true
+	} else {
+		return federatedRepoParams, nil
 	}
-	repoBytes, err := json.Marshal(repoMap)
+	response, err := MapToInterface(repoMap)
 	if err != nil {
-		return nil, errorutils.CheckError(err)
+		return nil, err
 	}
-	var response interface{}
-	err = json.Unmarshal(repoBytes, &response)
 	return response, errorutils.CheckError(err)
+}
+
+// Create a repository in the target server and assign the repository to the required project, if any.
+// repoParams - Repository parameters
+// repoKey    - Repository key
+func (tcb *TransferConfigBase) createRepositoryAndAssignToProject(repoParams interface{}, repoKey string) (err error) {
+	var projectKey string
+	repoParams, projectKey, err = removeProjectKeyIfNeeded(repoParams, repoKey)
+	if err != nil {
+		return
+	}
+	if projectKey != "" {
+		// Workaround - It's possible that the repository could be assigned to a project in the access.bootstrap.json.
+		// This is why we make sure to detach it before actually creating the repository.
+		// If the project isn't linked to the repository, an error might come up, but we ignore it because we can't
+		// be certain whether the repository was actually assigned to the project or not.
+		_ = tcb.TargetAccessManager.UnassignRepoFromProject(repoKey)
+	}
+	if err = tcb.TargetArtifactoryManager.CreateRepositoryWithParams(repoParams, repoKey); err != nil {
+		return
+	}
+	if projectKey != "" {
+		return tcb.TargetAccessManager.AssignRepoToProject(repoKey, projectKey, true)
+	}
+	return
+}
+
+// Remove non-default project key from the repository parameters if existed and the repository key does not start with it.
+// This is needed to allow creating repository assigned to projects so that the repository name is not st
+func removeProjectKeyIfNeeded(repoParams interface{}, repoKey string) (interface{}, string, error) {
+	var projectKey string
+	repoMap, err := InterfaceToMap(repoParams)
+	if err != nil {
+		return nil, "", err
+	}
+	if value, exist := repoMap["projectKey"]; exist {
+		var ok bool
+		if projectKey, ok = value.(string); !ok {
+			return nil, "", errorutils.CheckErrorf("couldn't parse the 'projectKey' value '%v' of repository '%s'", value, repoKey)
+		}
+		if projectKey == "default" || strings.HasPrefix(repoKey, projectKey+"-") {
+			// The repository key is starting with the project key prefix:
+			// <project-key>-<repo-name>
+			return repoParams, "", nil
+		}
+		delete(repoMap, "projectKey")
+	} else {
+		return repoParams, "", nil
+	}
+	response, err := MapToInterface(repoMap)
+	if err != nil {
+		return nil, "", err
+	}
+	return response, projectKey, errorutils.CheckError(err)
 }
 
 // During the transfer-config commands we remove federated members, if existed.
@@ -318,4 +402,16 @@ func InterfaceToMap(jsonInterface interface{}) (map[string]interface{}, error) {
 	newMap := make(map[string]interface{})
 	err = errorutils.CheckError(json.Unmarshal(b, &newMap))
 	return newMap, err
+}
+
+// Convert the input map to JSON interface.
+// mapToTransfer - Map of string to interface, such as repository name
+func MapToInterface(mapToTransfer map[string]interface{}) (interface{}, error) {
+	repoBytes, err := json.Marshal(mapToTransfer)
+	if err != nil {
+		return nil, errorutils.CheckError(err)
+	}
+	var response interface{}
+	err = json.Unmarshal(repoBytes, &response)
+	return response, errorutils.CheckError(err)
 }

--- a/common/tests/utils.go
+++ b/common/tests/utils.go
@@ -1,15 +1,17 @@
 package tests
 
 import (
-	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
-	testsutils "github.com/jfrog/jfrog-cli-core/v2/utils/config/tests"
-	"github.com/jfrog/jfrog-client-go/artifactory"
-	"github.com/jfrog/jfrog-client-go/distribution"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	testsutils "github.com/jfrog/jfrog-cli-core/v2/utils/config/tests"
+	"github.com/jfrog/jfrog-client-go/access"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/jfrog/jfrog-client-go/distribution"
+	"github.com/stretchr/testify/assert"
 )
 
 func ConfigTestServer(t *testing.T) (cleanUp func(), err error) {
@@ -43,9 +45,18 @@ func CreateRestsMockServer(testHandler restsTestHandler) *httptest.Server {
 
 func CreateRtRestsMockServer(t *testing.T, testHandler restsTestHandler) (*httptest.Server, *config.ServerDetails, artifactory.ArtifactoryServicesManager) {
 	testServer := CreateRestsMockServer(testHandler)
-	serverDetails := &config.ServerDetails{ArtifactoryUrl: testServer.URL + "/"}
+	serverDetails := &config.ServerDetails{Url: testServer.URL + "/", ArtifactoryUrl: testServer.URL + "/"}
 
 	serviceManager, err := utils.CreateServiceManager(serverDetails, -1, 0, false)
+	assert.NoError(t, err)
+	return testServer, serverDetails, serviceManager
+}
+
+func CreateAccessRestsMockServer(t *testing.T, testHandler restsTestHandler) (*httptest.Server, *config.ServerDetails, *access.AccessServicesManager) {
+	testServer := CreateRestsMockServer(testHandler)
+	serverDetails := &config.ServerDetails{Url: testServer.URL + "/", ServerId: "test-server"}
+
+	serviceManager, err := utils.CreateAccessServiceManager(serverDetails, false)
 	assert.NoError(t, err)
 	return testServer, serverDetails, serviceManager
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fix the following problem in `transfer-config` and `transfer-config-merge` commands:
```
09:24:39 [Debug] Sending HTTP PUT request to: https://acme.jfrog.io/artifactory/api/repositories/repo-name
09:24:39 [🚨Error] server response: 400 
{
  "errors": [
    {
      "status": 400,
      "message": "The repository key 'repo-name' should start with the project key and a dash: 'proj-'\n"
    }
  ]
}
```

**Algorithm**
For each repository, prior to its creation in the target location, follow these steps:
If the repository is linked to a project and its name doesn't commence with the project key prefix, perform the subsequent REST operations:
1. `DELETE https://acme.jfrog.io/access/api/v1/projects/_/attach/repositories/repo-name` - Delete the metadata in Access.
2. `PUT https://acme.jfrog.io/artifactory/api/repositories/repo-name` - Create the repository.
3. `PUT https://acme.jfrog.io/access/api/v1/projects/_/attach/repositories/repo-name/proj?force=true` - Assign repository to project.