### PR TITLE
Fix non-interactive config without providing server ID

### DIFF
--- a/common/commands/config.go
+++ b/common/commands/config.go
@@ -315,7 +315,7 @@ func (cc *ConfigCommand) resolveServerId() string {
 	if cc.details.ServerId != "" {
 		return cc.details.ServerId
 	}
-	if cc.defaultDetails.ServerId != "" {
+	if cc.defaultDetails != nil && cc.defaultDetails.ServerId != "" {
 		return cc.defaultDetails.ServerId
 	}
 	return config.DefaultServerId


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Following https://github.com/jfrog/jfrog-cli/issues/2153 that was introduced in https://github.com/jfrog/jfrog-cli-core/pull/904