### PR TITLE
Set analyzer manager version by environment variable 

### DIFF
--- a/xray/commands/audit/jasrunner.go
+++ b/xray/commands/audit/jasrunner.go
@@ -2,7 +2,6 @@ package audit
 
 import (
 	"errors"
-	"github.com/jfrog/gofrog/version"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/commands/audit/jas"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/commands/audit/jas/applicability"
@@ -49,7 +48,7 @@ func runJasScannersAndSetResults(scanResults *utils.ExtendedScanResults, directD
 	if err != nil {
 		return
 	}
-	if !version.NewVersion(utils.AnalyzerManagerVersion).AtLeast(utils.MinAnalyzerManagerVersionForSast) {
+	if !utils.IsSastSupported() {
 		return
 	}
 	if progress != nil {

--- a/xray/utils/analyzermanager.go
+++ b/xray/utils/analyzermanager.go
@@ -57,7 +57,7 @@ const (
 	unsupportedCommandExitCode                = 13
 	unsupportedOsExitCode                     = 55
 	ErrFailedScannerRun                       = "failed to run %s scan. Exit code received: %s"
-	JfrogCliAnalyzerManagerVersionEnvVariable = "JFROG_CLI_ANALYZER_MANAGER_VERSION"
+	jfrogCliAnalyzerManagerVersionEnvVariable = "JFROG_CLI_ANALYZER_MANAGER_VERSION"
 )
 
 type ApplicabilityStatus string
@@ -148,7 +148,7 @@ func GetAnalyzerManagerDownloadPath() (string, error) {
 }
 
 func GetAnalyzerManagerVersion() string {
-	if analyzerManagerVersion, exists := os.LookupEnv(JfrogCliAnalyzerManagerVersionEnvVariable); exists {
+	if analyzerManagerVersion, exists := os.LookupEnv(jfrogCliAnalyzerManagerVersionEnvVariable); exists {
 		return analyzerManagerVersion
 	}
 	return defaultAnalyzerManagerVersion

--- a/xray/utils/analyzermanager.go
+++ b/xray/utils/analyzermanager.go
@@ -39,24 +39,25 @@ var (
 )
 
 const (
-	EntitlementsMinVersion           = "3.66.5"
-	ApplicabilityFeatureId           = "contextual_analysis"
-	AnalyzerManagerZipName           = "analyzerManager.zip"
-	defaultAnalyzerManagerVersion    = "1.2.4.1953469"
-	minAnalyzerManagerVersionForSast = "1.3"
-	analyzerManagerDownloadPath      = "xsc-gen-exe-analyzer-manager-local/v1"
-	analyzerManagerDirName           = "analyzerManager"
-	analyzerManagerExecutableName    = "analyzerManager"
-	analyzerManagerLogDirName        = "analyzerManagerLogs"
-	jfUserEnvVariable                = "JF_USER"
-	jfPasswordEnvVariable            = "JF_PASS"
-	jfTokenEnvVariable               = "JF_TOKEN"
-	jfPlatformUrlEnvVariable         = "JF_PLATFORM_URL"
-	logDirEnvVariable                = "AM_LOG_DIRECTORY"
-	notEntitledExitCode              = 31
-	unsupportedCommandExitCode       = 13
-	unsupportedOsExitCode            = 55
-	ErrFailedScannerRun              = "failed to run %s scan. Exit code received: %s"
+	EntitlementsMinVersion                    = "3.66.5"
+	ApplicabilityFeatureId                    = "contextual_analysis"
+	AnalyzerManagerZipName                    = "analyzerManager.zip"
+	defaultAnalyzerManagerVersion             = "1.2.4.1953469"
+	minAnalyzerManagerVersionForSast          = "1.3"
+	analyzerManagerDownloadPath               = "xsc-gen-exe-analyzer-manager-local/v1"
+	analyzerManagerDirName                    = "analyzerManager"
+	analyzerManagerExecutableName             = "analyzerManager"
+	analyzerManagerLogDirName                 = "analyzerManagerLogs"
+	jfUserEnvVariable                         = "JF_USER"
+	jfPasswordEnvVariable                     = "JF_PASS"
+	jfTokenEnvVariable                        = "JF_TOKEN"
+	jfPlatformUrlEnvVariable                  = "JF_PLATFORM_URL"
+	logDirEnvVariable                         = "AM_LOG_DIRECTORY"
+	notEntitledExitCode                       = 31
+	unsupportedCommandExitCode                = 13
+	unsupportedOsExitCode                     = 55
+	ErrFailedScannerRun                       = "failed to run %s scan. Exit code received: %s"
+	JfrogCliAnalyzerManagerVersionEnvVariable = "JFROG_CLI_ANALYZER_MANAGER_VERSION"
 )
 
 type ApplicabilityStatus string
@@ -147,7 +148,7 @@ func GetAnalyzerManagerDownloadPath() (string, error) {
 }
 
 func GetAnalyzerManagerVersion() string {
-	if analyzerManagerVersion, exists := os.LookupEnv("JFROG_CLI_ANALYZER_MANAGER_VERSION"); exists {
+	if analyzerManagerVersion, exists := os.LookupEnv(JfrogCliAnalyzerManagerVersionEnvVariable); exists {
 		return analyzerManagerVersion
 	}
 	return defaultAnalyzerManagerVersion

--- a/xray/utils/analyzermanager.go
+++ b/xray/utils/analyzermanager.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"github.com/jfrog/gofrog/version"
 	"os"
 	"os/exec"
 	"path"
@@ -41,8 +42,8 @@ const (
 	EntitlementsMinVersion           = "3.66.5"
 	ApplicabilityFeatureId           = "contextual_analysis"
 	AnalyzerManagerZipName           = "analyzerManager.zip"
-	AnalyzerManagerVersion           = "1.2.4.1953469"
-	MinAnalyzerManagerVersionForSast = "1.3"
+	defaultAnalyzerManagerVersion    = "1.2.4.1953469"
+	minAnalyzerManagerVersionForSast = "1.3"
 	analyzerManagerDownloadPath      = "xsc-gen-exe-analyzer-manager-local/v1"
 	analyzerManagerDirName           = "analyzerManager"
 	analyzerManagerExecutableName    = "analyzerManager"
@@ -142,7 +143,18 @@ func GetAnalyzerManagerDownloadPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(analyzerManagerDownloadPath, AnalyzerManagerVersion, osAndArc, AnalyzerManagerZipName), nil
+	return path.Join(analyzerManagerDownloadPath, GetAnalyzerManagerVersion(), osAndArc, AnalyzerManagerZipName), nil
+}
+
+func GetAnalyzerManagerVersion() string {
+	if analyzerManagerVersion, exists := os.LookupEnv("JFROG_CLI_ANALYZER_MANAGER_VERSION"); exists {
+		return analyzerManagerVersion
+	}
+	return defaultAnalyzerManagerVersion
+}
+
+func IsSastSupported() bool {
+	return version.NewVersion(GetAnalyzerManagerVersion()).AtLeast(minAnalyzerManagerVersionForSast)
 }
 
 func GetAnalyzerManagerDirAbsolutePath() (string, error) {

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jfrog/gofrog/version"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/formats"
 	clientUtils "github.com/jfrog/jfrog-client-go/utils"
@@ -114,7 +113,7 @@ func printScanResultsTables(results *ExtendedScanResults, isBinaryScan, includeV
 	if err = PrintIacTable(results.IacScanResults, results.EntitledForJas); err != nil {
 		return
 	}
-	if !version.NewVersion(AnalyzerManagerVersion).AtLeast(MinAnalyzerManagerVersionForSast) {
+	if !IsSastSupported() {
 		return
 	}
 	return PrintSastTable(results.SastResults, results.EntitledForJas)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Use JFROG_CLI_ANALYZER_MANAGER_VERSION to set analyzer manager version