### PR TITLE
Transfer - Fix delayed artifacts mechanism

### DIFF
--- a/artifactory/commands/transferfiles/delayedartifactshandler_test.go
+++ b/artifactory/commands/transferfiles/delayedartifactshandler_test.go
@@ -143,9 +143,8 @@ var sortDelayedArtifactsCases = []struct {
 }
 
 func TestSortDelayedArtifacts(t *testing.T) {
-	for _, testCase := range sortDelayedArtifactsCases {
-		delayedArtifactsFile := DelayedArtifactsFile{DelayedArtifacts: testCase.delayedArtifacts}
+	for i, testCase := range sortDelayedArtifactsCases {
 		delayHelper := delayUploadHelper{shouldDelayFunctions: testCase.shouldDelayFunctions}
-		assert.Equal(t, testCase.sortedDelayedArtifacts, sortDelayedArtifacts(delayedArtifactsFile, delayHelper))
+		assert.Equal(t, testCase.sortedDelayedArtifacts, sortDelayedArtifacts(&sortDelayedArtifactsCases[i].delayedArtifacts, delayHelper))
 	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Tests PR: https://github.com/jfrog/jfrog-cli/pull/2204

Enhance and optimize the following elements:
   - Delaying pom.xml files, not just `*.pom`.
   - Eliminating the need for recursion in delaying artifacts. Instead, transfer them in a sorted manner. This approach is significantly more efficient, especially considering that in Docker and Conan repositories, we triggered 2-3 invocations of doTransferWithProducerConsumer.
