### PR TITLE
Transfer - Fix phase 3 progressbar

### DIFF
--- a/artifactory/commands/transferfiles/delayedartifactshandler.go
+++ b/artifactory/commands/transferfiles/delayedartifactshandler.go
@@ -120,7 +120,7 @@ func consumeDelayFilesIfNoErrors(phase phaseBase, addedDelayFiles []string) erro
 	if len(addedDelayFiles) > 0 && phase.progressBar != nil {
 		phaseTaskProgressBar := phase.progressBar.phases[phase.phaseId].GetTasksProgressBar()
 		oldTotal := phaseTaskProgressBar.GetTotal()
-		delayCount, err := countDelayFilesContent(addedDelayFiles)
+		delayCount, _, err := countDelayFilesContent(addedDelayFiles)
 		if err != nil {
 			return err
 		}
@@ -129,16 +129,20 @@ func consumeDelayFilesIfNoErrors(phase phaseBase, addedDelayFiles []string) erro
 	return nil
 }
 
-func countDelayFilesContent(filePaths []string) (int, error) {
+func countDelayFilesContent(filePaths []string) (int, int64, error) {
 	count := 0
+	var storage int64 = 0
 	for _, file := range filePaths {
 		delayFile, err := readDelayFile(file)
 		if err != nil {
-			return 0, err
+			return 0, storage, err
 		}
 		count += len(delayFile.DelayedArtifacts)
+		for _, delay := range delayFile.DelayedArtifacts {
+			storage += delay.Size
+		}
 	}
-	return count, nil
+	return count, storage, nil
 }
 
 func handleDelayedArtifactsFiles(filesToConsume []string, base phaseBase, delayUploadComparisonFunctions []shouldDelayUpload) error {

--- a/artifactory/commands/transferfiles/delayedartifactshandler.go
+++ b/artifactory/commands/transferfiles/delayedartifactshandler.go
@@ -129,9 +129,7 @@ func consumeDelayFilesIfNoErrors(phase phaseBase, addedDelayFiles []string) erro
 	return nil
 }
 
-func countDelayFilesContent(filePaths []string) (int, int64, error) {
-	count := 0
-	var storage int64 = 0
+func countDelayFilesContent(filePaths []string) (count int, storage int64, err error) {
 	for _, file := range filePaths {
 		delayFile, err := readDelayFile(file)
 		if err != nil {
@@ -142,7 +140,7 @@ func countDelayFilesContent(filePaths []string) (int, int64, error) {
 			storage += delay.Size
 		}
 	}
-	return count, storage, nil
+	return
 }
 
 func handleDelayedArtifactsFiles(filesToConsume []string, base phaseBase, delayUploadComparisonFunctions []shouldDelayUpload) error {

--- a/artifactory/commands/transferfiles/delayedartifactshandler_test.go
+++ b/artifactory/commands/transferfiles/delayedartifactshandler_test.go
@@ -2,17 +2,18 @@ package transferfiles
 
 import (
 	"fmt"
-	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/api"
-	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/state"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/api"
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/state"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/stretchr/testify/assert"
 )
 
 var delayTestRepoKey = "delay-local-repo"
@@ -52,7 +53,7 @@ func TestDelayedArtifactsMng(t *testing.T) {
 	go func() {
 		defer writeWaitGroup.Done()
 		for i := 0; i < artifactsNumber; i++ {
-			artifactsChannelMng.channel <- api.FileRepresentation{Repo: testRepoKey, Path: "path", Name: fmt.Sprintf("name%d", i)}
+			artifactsChannelMng.channel <- api.FileRepresentation{Repo: testRepoKey, Path: "path", Name: fmt.Sprintf("name%d", i), Size: int64(i)}
 		}
 	}()
 
@@ -71,8 +72,9 @@ func TestDelayedArtifactsMng(t *testing.T) {
 	expectedNumberOfFiles := int(math.Ceil(float64(artifactsNumber) / float64(maxDelayedArtifactsInFile)))
 	validateDelayedArtifactsFiles(t, delayFiles, expectedNumberOfFiles, artifactsNumber)
 
-	delayCount, err := countDelayFilesContent(delayFiles)
+	delayCount, storage, err := countDelayFilesContent(delayFiles)
 	assert.NoError(t, err)
+	assert.Equal(t, int64(1225), storage)
 	assert.Equal(t, delayCount, artifactsNumber)
 }
 

--- a/artifactory/commands/transferfiles/status.go
+++ b/artifactory/commands/transferfiles/status.go
@@ -102,7 +102,7 @@ func setRepositoryStatus(stateManager *state.TransferStateManager, output *strin
 		if stateManager.CurrentRepoPhase == api.Phase1 {
 			addString(output, "🔢", "Phase", "Transferring all files in the repository (1/3)", 3)
 		} else {
-			addString(output, "🔢", "Phase", "Retrying transfer failures and deploy delayed files (3/3)", 3)
+			addString(output, "🔢", "Phase", "Retrying transfer failures and transfer delayed files (3/3)", 3)
 		}
 		addString(output, "🗄 ", "Storage", sizeToString(currentRepo.Phase1Info.TransferredSizeBytes)+" / "+sizeToString(currentRepo.Phase1Info.TotalSizeBytes)+calcPercentageInt64(currentRepo.Phase1Info.TransferredSizeBytes, currentRepo.Phase1Info.TotalSizeBytes), 3)
 		addString(output, "📄", "Files", fmt.Sprintf("%d / %d", currentRepo.Phase1Info.TransferredUnits, currentRepo.Phase1Info.TotalUnits)+calcPercentageInt64(currentRepo.Phase1Info.TransferredUnits, currentRepo.Phase1Info.TotalUnits), 3)

--- a/artifactory/commands/transferfiles/status.go
+++ b/artifactory/commands/transferfiles/status.go
@@ -102,7 +102,7 @@ func setRepositoryStatus(stateManager *state.TransferStateManager, output *strin
 		if stateManager.CurrentRepoPhase == api.Phase1 {
 			addString(output, "🔢", "Phase", "Transferring all files in the repository (1/3)", 3)
 		} else {
-			addString(output, "🔢", "Phase", "Retrying transfer failures (3/3)", 3)
+			addString(output, "🔢", "Phase", "Retrying transfer failures and deploy delayed files (3/3)", 3)
 		}
 		addString(output, "🗄 ", "Storage", sizeToString(currentRepo.Phase1Info.TransferredSizeBytes)+" / "+sizeToString(currentRepo.Phase1Info.TotalSizeBytes)+calcPercentageInt64(currentRepo.Phase1Info.TransferredSizeBytes, currentRepo.Phase1Info.TotalSizeBytes), 3)
 		addString(output, "📄", "Files", fmt.Sprintf("%d / %d", currentRepo.Phase1Info.TransferredUnits, currentRepo.Phase1Info.TotalUnits)+calcPercentageInt64(currentRepo.Phase1Info.TransferredUnits, currentRepo.Phase1Info.TotalUnits), 3)

--- a/artifactory/commands/transferfiles/status_test.go
+++ b/artifactory/commands/transferfiles/status_test.go
@@ -138,7 +138,7 @@ func TestShowBuildInfoRepo(t *testing.T) {
 	// Check repository status
 	assert.Contains(t, results, "Current Repository Status")
 	assert.Contains(t, results, "Name:			repo1")
-	assert.Contains(t, results, "Phase:			Retrying transfer failures and deploy delayed files (3/3)")
+	assert.Contains(t, results, "Phase:			Retrying transfer failures and transfer delayed files (3/3)")
 	assert.Contains(t, results, "Delayed files:		20 (Files to be transferred last, after all other files)")
 	assert.Contains(t, results, "Storage:			4.9 KiB / 9.8 KiB (50.0%)")
 	assert.Contains(t, results, "Files:			500 / 10000 (5.0%)")

--- a/artifactory/commands/transferfiles/status_test.go
+++ b/artifactory/commands/transferfiles/status_test.go
@@ -138,7 +138,7 @@ func TestShowBuildInfoRepo(t *testing.T) {
 	// Check repository status
 	assert.Contains(t, results, "Current Repository Status")
 	assert.Contains(t, results, "Name:			repo1")
-	assert.Contains(t, results, "Phase:			Retrying transfer failures (3/3)")
+	assert.Contains(t, results, "Phase:			Retrying transfer failures and deploy delayed files (3/3)")
 	assert.Contains(t, results, "Delayed files:		20 (Files to be transferred last, after all other files)")
 	assert.Contains(t, results, "Storage:			4.9 KiB / 9.8 KiB (50.0%)")
 	assert.Contains(t, results, "Files:			500 / 10000 (5.0%)")

--- a/utils/progressbar/transferprogressbarmanager.go
+++ b/utils/progressbar/transferprogressbarmanager.go
@@ -15,7 +15,7 @@ import (
 const (
 	phase1HeadLine          = "Phase 1: Transferring all files in the repository"
 	phase2HeadLine          = "Phase 2: Transferring newly created and modified files"
-	phase3HeadLine          = "Phase 3: Retrying transfer failures and deploy delayed files"
+	phase3HeadLine          = "Phase 3: Retrying transfer failures and transfer delayed files"
 	DelayedFilesContentNote = "Files to be transferred last, after all other files"
 	RetryFailureContentNote = "In Phase 3 and in subsequent executions, we'll retry transferring the failed files"
 )

--- a/utils/progressbar/transferprogressbarmanager.go
+++ b/utils/progressbar/transferprogressbarmanager.go
@@ -15,7 +15,7 @@ import (
 const (
 	phase1HeadLine          = "Phase 1: Transferring all files in the repository"
 	phase2HeadLine          = "Phase 2: Transferring newly created and modified files"
-	phase3HeadLine          = "Phase 3: Retrying transfer failures"
+	phase3HeadLine          = "Phase 3: Retrying transfer failures and deploy delayed files"
 	DelayedFilesContentNote = "Files to be transferred last, after all other files"
 	RetryFailureContentNote = "In Phase 3 and in subsequent executions, we'll retry transferring the failed files"
 )


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Currently, no one is calling SetTotalSizeAndFilesPhase3. This caused the progress bar to be empty in phase 3.

Before:
![image](https://github.com/jfrog/jfrog-cli-core/assets/11367982/4f3d46e5-1566-46d2-aa18-8bbd8c8ecbd6)


After:
![image](https://github.com/jfrog/jfrog-cli-core/assets/11367982/03d77401-240f-4bf9-ac8c-bace6b30fb54)

