### PR TITLE
Transfer - Progress should only represent successful storage transfer

### DIFF
--- a/utils/progressbar/progressbarmng.go
+++ b/utils/progressbar/progressbarmng.go
@@ -95,18 +95,17 @@ func (bm *ProgressBarMng) newDoubleValueProgressBar(getVal func() (firstNumerato
 				if err != nil {
 					log.Error(err)
 				}
-				numeratorString := artifactoryutils.ConvertIntToStorageSizeString(getProgressNumerator(statistics, *firstNumerator, *firstDenominator))
-				denominatorString := artifactoryutils.ConvertIntToStorageSizeString(*firstDenominator)
-				return color.Green.Render(numeratorString + "/" + denominatorString)
-			}),
-			decor.Name(" "+secondValueLine+": "), decor.Any(func(statistics decor.Statistics) string {
+				s1 := artifactoryutils.ConvertIntToStorageSizeString(*firstNumerator)
+				s2 := artifactoryutils.ConvertIntToStorageSizeString(*firstDenominator)
+				return color.Green.Render(s1 + "/" + s2)
+			}), decor.Name(" "+secondValueLine+": "), decor.Any(func(statistics decor.Statistics) string {
 				_, _, secondNumerator, secondDenominator, err := getVal()
 				if err != nil {
 					log.Error(err)
 				}
-				numeratorString := strconv.FormatInt(getProgressNumerator(statistics, *secondNumerator, *secondDenominator), 10)
-				denominatorString := strconv.Itoa(int(*secondDenominator))
-				return color.Green.Render(numeratorString + "/" + denominatorString)
+				s1 := strconv.Itoa(int(*secondNumerator))
+				s2 := strconv.Itoa(int(*secondDenominator))
+				return color.Green.Render(s1 + "/" + s2)
 			}),
 		),
 	)
@@ -189,9 +188,7 @@ func (bm *ProgressBarMng) NewHeadlineBar(msg string) *mpb.Bar {
 func (bm *ProgressBarMng) Increment(prog *TasksWithHeadlineProg) {
 	bm.barsRWMutex.RLock()
 	defer bm.barsRWMutex.RUnlock()
-	if prog.tasksProgressBar.bar.Current() < math.MaxInt64 {
-		prog.tasksProgressBar.bar.Increment()
-	}
+	prog.tasksProgressBar.bar.Increment()
 	prog.tasksProgressBar.tasksCount++
 }
 
@@ -199,9 +196,7 @@ func (bm *ProgressBarMng) Increment(prog *TasksWithHeadlineProg) {
 func (bm *ProgressBarMng) IncBy(n int, prog *TasksWithHeadlineProg) {
 	bm.barsRWMutex.RLock()
 	defer bm.barsRWMutex.RUnlock()
-	if prog.tasksProgressBar.bar.Current() < math.MaxInt64 {
-		prog.tasksProgressBar.bar.IncrBy(n)
-	}
+	prog.tasksProgressBar.bar.IncrBy(n)
 	prog.tasksProgressBar.tasksCount += int64(n)
 }
 
@@ -209,7 +204,12 @@ func (bm *ProgressBarMng) IncBy(n int, prog *TasksWithHeadlineProg) {
 func (bm *ProgressBarMng) DoneTask(prog *TasksWithHeadlineProg) {
 	bm.barsRWMutex.RLock()
 	defer bm.barsRWMutex.RUnlock()
-	prog.tasksProgressBar.bar.SetCurrent(math.MaxInt64)
+	diff := prog.tasksProgressBar.total - prog.tasksProgressBar.tasksCount
+	// Handle large number of total tasks
+	for ; diff > math.MaxInt; diff -= math.MaxInt {
+		prog.tasksProgressBar.bar.IncrBy(math.MaxInt)
+	}
+	prog.tasksProgressBar.bar.IncrBy(int(diff))
 }
 
 func (bm *ProgressBarMng) NewTasksProgressBar(totalTasks int64, windows bool, taskType string) *TasksProgressBar {
@@ -240,7 +240,7 @@ func (bm *ProgressBarMng) newTasksProgressBar(getVal func() (numerator, denomina
 		mpb.AppendDecorators(
 			decor.Name(" "+headLine+": "),
 			decor.Any(func(statistics decor.Statistics) string {
-				numeratorString := strconv.FormatInt(getProgressNumerator(statistics, *numerator, *denominator), 10)
+				numeratorString := strconv.Itoa(int(*numerator))
 				denominatorString := strconv.Itoa(int(*denominator))
 				return color.Green.Render(numeratorString + "/" + denominatorString)
 			}),
@@ -352,11 +352,4 @@ func setTerminalWidthVar() error {
 		terminalWidth = 5
 	}
 	return err
-}
-
-func getProgressNumerator(statistics decor.Statistics, numerator, denominator int64) int64 {
-	if statistics.Current == math.MaxInt64 {
-		return denominator
-	}
-	return numerator
 }

--- a/utils/progressbar/progressbarmng.go
+++ b/utils/progressbar/progressbarmng.go
@@ -205,7 +205,7 @@ func (bm *ProgressBarMng) DoneTask(prog *TasksWithHeadlineProg) {
 	bm.barsRWMutex.RLock()
 	defer bm.barsRWMutex.RUnlock()
 	diff := prog.tasksProgressBar.total - prog.tasksProgressBar.tasksCount
-	// Handle large number of total tasks
+	// diff is int64, but we can increase the progress up to math.MaxInt in a time
 	for ; diff > math.MaxInt; diff -= math.MaxInt {
 		prog.tasksProgressBar.bar.IncrBy(math.MaxInt)
 	}

--- a/utils/progressbar/transferprogressbarmanager.go
+++ b/utils/progressbar/transferprogressbarmanager.go
@@ -14,6 +14,7 @@ import (
 const (
 	phase1HeadLine          = "Phase 1: Transferring all files in the repository"
 	phase2HeadLine          = "Phase 2: Transferring newly created and modified files"
+	phase3HeadLine          = "Phase 3: Retrying transfer failures"
 	DelayedFilesContentNote = "Files to be transferred last, after all other files"
 	RetryFailureContentNote = "In Phase 3 and in subsequent executions, we'll retry transferring the failed files"
 )
@@ -183,7 +184,7 @@ func (tpm *TransferProgressMng) NewPhase3ProgressBar() *TasksWithHeadlineProg {
 		})
 		return transferredStorage, totalStorage, transferredFiles, totalFiles, err
 	}
-	pb := tpm.barMng.newDoubleHeadLineProgressBar(phase2HeadLine, tpm.transferLabels.Storage, tpm.transferLabels.Files, getVals)
+	pb := tpm.barMng.newDoubleHeadLineProgressBar(phase3HeadLine, tpm.transferLabels.Storage, tpm.transferLabels.Files, getVals)
 
 	tpm.wg.Add(1)
 	go func() {

--- a/utils/progressbar/transferprogressbarmanager.go
+++ b/utils/progressbar/transferprogressbarmanager.go
@@ -1,7 +1,6 @@
 package progressbar
 
 import (
-	"math"
 	"sync"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 const (
 	phase1HeadLine          = "Phase 1: Transferring all files in the repository"
 	phase2HeadLine          = "Phase 2: Transferring newly created and modified files"
-	phase3HeadLine          = "Phase 3: Retrying transfer failures"
 	DelayedFilesContentNote = "Files to be transferred last, after all other files"
 	RetryFailureContentNote = "In Phase 3 and in subsequent executions, we'll retry transferring the failed files"
 )
@@ -118,7 +116,7 @@ func (tpm *TransferProgressMng) NewPhase1ProgressBar() *TasksWithHeadlineProg {
 			if tpm.currentRepoShouldStop {
 				return
 			}
-			transferredStorage, totalStorage, _, _, err := getVals()
+			ptr1, ptr2, _, _, err := getVals()
 			if err != nil {
 				log.Error("Error: Couldn't get needed information about transfer status from state")
 			}
@@ -127,10 +125,8 @@ func (tpm *TransferProgressMng) NewPhase1ProgressBar() *TasksWithHeadlineProg {
 				return
 			}
 			if pb.GetTasksProgressBar() != nil {
-				pb.GetTasksProgressBar().SetGeneralProgressTotal(*totalStorage)
-				if pb.GetTasksProgressBar().GetBar().Current() < math.MaxInt64 {
-					pb.GetTasksProgressBar().GetBar().SetCurrent(*transferredStorage)
-				}
+				pb.GetTasksProgressBar().SetGeneralProgressTotal(*ptr2)
+				pb.GetTasksProgressBar().GetBar().SetCurrent(*ptr1)
 			}
 			time.Sleep(1 * time.Second)
 		}
@@ -187,7 +183,7 @@ func (tpm *TransferProgressMng) NewPhase3ProgressBar() *TasksWithHeadlineProg {
 		})
 		return transferredStorage, totalStorage, transferredFiles, totalFiles, err
 	}
-	pb := tpm.barMng.newDoubleHeadLineProgressBar(phase3HeadLine, tpm.transferLabels.Storage, tpm.transferLabels.Files, getVals)
+	pb := tpm.barMng.newDoubleHeadLineProgressBar(phase2HeadLine, tpm.transferLabels.Storage, tpm.transferLabels.Files, getVals)
 
 	tpm.wg.Add(1)
 	go func() {


### PR DESCRIPTION
This reverts commit 9b64c74d7c9426c8b610e05c8655dd515a7a22d3.

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

* Revert most of #997 changes because I figured out that the progress that didn't get filled is actually expected:
<img width="1205" alt="image" src="https://github.com/jfrog/jfrog-cli-core/assets/11367982/e9419aeb-5925-4999-a979-663aa3965eba">

Total files: 103
Delayed files: 34
Errors: 1

103 - 34 - 1 = 68.
* Keep the phase 3 label fix