### PR TITLE
Transfer - Fix "close of closed channel" panic

### DIFF
--- a/artifactory/commands/transferfiles/delayedartifactshandler.go
+++ b/artifactory/commands/transferfiles/delayedartifactshandler.go
@@ -369,6 +369,11 @@ func (w *SplitContentWriter) closeCurrentFile() error {
 		if err := w.writer.Close(); err != nil {
 			return err
 		}
+		defer func() {
+			// Reset writer and counter.
+			w.recordCount = 0
+			w.writer = nil
+		}()
 		if w.writer.GetFilePath() != "" {
 			fullPath, err := getUniqueErrorOrDelayFilePath(w.dirPath, func() string {
 				return w.filePrefix
@@ -384,9 +389,6 @@ func (w *SplitContentWriter) closeCurrentFile() error {
 			w.fileIndex++
 		}
 	}
-	// Reset writer and counter.
-	w.recordCount = 0
-	w.writer = nil
 	return nil
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fix the following panic:
```
05:22:01 [Info] ========== Running 'Full Transfer Phase' for repo 'docker-local-big'... ==========
panic: close of closed channel

goroutine 280 [running]:
github.com/jfrog/jfrog-client-go/utils/io/content.(*ContentWriter).Close(0xc011ab7180)
        /Users/yahavi/code/cli/jfrog-client-go/utils/io/content/contentwriter.go:167 +0x37
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.(*SplitContentWriter).closeCurrentFile(0xc0002183f0)
        /Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/delayedartifactshandler.go:367 +0x45
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.(*SplitContentWriter).close(...)
        /Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/delayedartifactshandler.go:392
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.(*TransferDelayedArtifactsMng).start.func1()
        /Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/delayedartifactshandler.go:65 +0x2f
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.(*TransferDelayedArtifactsMng).start(0xc0008c4240)
        /Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/delayedartifactshandler.go:81 +0x4fb
github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.(*transferManager).doTransfer.func2()
        /Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/manager.go:83 +0x65
created by github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.(*transferManager).doTransfer
        /Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/transferfiles/manager.go:81 +0x345
```

In the `closeCurrentFile` function, there's a chance that either `getUniqueErrorOrDelayFilePath` or `MoveFile` could result in an error. If that happens, `w.writer` won't be nil, potentially leading to `writer.Close` being called twice.