### PR TITLE
Transfer - Graceful stop does not stop immediately

### DIFF
--- a/artifactory/commands/transferfiles/manager.go
+++ b/artifactory/commands/transferfiles/manager.go
@@ -40,7 +40,8 @@ type transferDelayAction func(phase phaseBase, addedDelayFiles []string) error
 
 // Transfer files using the 'producer-consumer' mechanism and apply a delay action.
 func (ftm *transferManager) doTransferWithProducerConsumer(transferAction transferActionWithProducerConsumerType, delayAction transferDelayAction) error {
-	ftm.pcDetails = newProducerConsumerWrapper()
+	// Set the producer-consumer value into the referenced value. This allow the Graceful Stop mechanism to access ftm.pcDetails when needed to stop the transfer.
+	*ftm.pcDetails = newProducerConsumerWrapper()
 	return ftm.doTransfer(ftm.pcDetails, transferAction, delayAction)
 }
 
@@ -203,14 +204,14 @@ type producerConsumerWrapper struct {
 	errorsQueue *clientUtils.ErrorsQueue
 }
 
-func newProducerConsumerWrapper() *producerConsumerWrapper {
+func newProducerConsumerWrapper() producerConsumerWrapper {
 	chunkUploaderProducerConsumer := parallel.NewRunner(GetThreads(), tasksMaxCapacity, false)
 	chunkBuilderProducerConsumer := parallel.NewRunner(GetThreads(), tasksMaxCapacity, false)
 	chunkUploaderProducerConsumer.SetFinishedNotification(true)
 	chunkBuilderProducerConsumer.SetFinishedNotification(true)
 	errorsQueue := clientUtils.NewErrorsQueue(1)
 
-	return &producerConsumerWrapper{
+	return producerConsumerWrapper{
 		chunkUploaderProducerConsumer: chunkUploaderProducerConsumer,
 		chunkBuilderProducerConsumer:  chunkBuilderProducerConsumer,
 		errorsQueue:                   errorsQueue,

--- a/artifactory/commands/transferfiles/phase.go
+++ b/artifactory/commands/transferfiles/phase.go
@@ -145,7 +145,8 @@ func (pb *phaseBase) setStopSignal(stopSignal chan os.Signal) {
 }
 
 func createTransferPhase(i int) transferPhase {
-	curPhaseBase := phaseBase{phaseId: i}
+	// Initialize a pointer to an empty producerConsumerWrapper to allow access the real value in StopGracefully
+	curPhaseBase := phaseBase{phaseId: i, pcDetails: &producerConsumerWrapper{}}
 	switch i {
 	case api.Phase1:
 		return &fullTransferPhase{phaseBase: curPhaseBase}

--- a/artifactory/commands/transferfiles/phase_test.go
+++ b/artifactory/commands/transferfiles/phase_test.go
@@ -13,7 +13,8 @@ import (
 const zeroUint32 uint32 = 0
 
 func TestStopGracefully(t *testing.T) {
-	pBase := &phaseBase{pcDetails: newProducerConsumerWrapper()}
+	pcWrapper := newProducerConsumerWrapper()
+	pBase := &phaseBase{pcDetails: &pcWrapper}
 	chunkUploaderProducerConsumer := pBase.pcDetails.chunkUploaderProducerConsumer
 	chunkBuilderProducerConsumer := pBase.pcDetails.chunkBuilderProducerConsumer
 	go func() {

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -374,7 +374,10 @@ func interruptIfRequested(stopSignal chan os.Signal) error {
 		return err
 	}
 	if exist {
-		stopSignal <- os.Interrupt
+		select {
+		case stopSignal <- os.Interrupt:
+		default:
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fix 2 issues in the Graceful Stop mechanism of `jf rt transfer-files` command:
1. Create producerConsumerWrapper pointer in createTransferPhase to allow access it in StopGracefully:
```go
func (pb *phaseBase) StopGracefully() {
	if pb.progressBar != nil {
		pb.progressBar.StopGracefully()
	}
	if pb.pcDetails != nil { // <- Was always nil
		pb.pcDetails.chunkBuilderProducerConsumer.Cancel(true)
		pb.pcDetails.chunkUploaderProducerConsumer.Cancel(true)
	}
}
```
2. Since the Graceful stop mechanism is async and we poll interruptIfRequested every 20 seconds, there is a chance that more than 1 interruption signal will be sent to the "stopSignal" channel. This will cause the code to freeze.