### PR TITLE
Transfer - Increase locally generated concurrency

### DIFF
--- a/artifactory/commands/transferfiles/localgeneratedfilter.go
+++ b/artifactory/commands/transferfiles/localgeneratedfilter.go
@@ -20,7 +20,7 @@ import (
 const (
 	locallyGeneratedApi                      = "api/localgenerated/filter/paths"
 	minArtifactoryVersionForLocallyGenerated = "7.55.0"
-	maxConcurrentLocallyGeneratedRequests    = 2
+	maxConcurrentLocallyGeneratedRequests    = 5
 )
 
 // The request and response payload of POST '/api/localgenerated/filter/paths'


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Increase the max number of `/api/localgenerated` REST in parallel to 5. Without this change, we see that the number of running threads can't go above 30 in Docker repositories.