### PR TITLE
Transfer - Interruption may causes data loss

### DIFF
--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -735,3 +735,11 @@ func getUniqueErrorOrDelayFilePath(dirPath string, getFileNamePrefix func() stri
 	}
 	return
 }
+
+func deleteAllFiles(filesToDelete []string) (err error) {
+	for _, fileToDelete := range filesToDelete {
+		log.Debug("Deleting:", fileToDelete, "...")
+		err = errors.Join(err, errorutils.CheckError(os.Remove(fileToDelete)))
+	}
+	return
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Halting the "transfer-files" process while delayed artifacts are being transferred might result in the early removal of the delayed artifacts file before all the chunks are properly uploaded. As a result, these files won't be uploaded unless you employ the `--ignore-state` flag. A similar problem can occur during the handling of error files.

This image serves as an illustration of the problem:
![image](https://github.com/jfrog/jfrog-cli-core/assets/11367982/15cdfcba-b4b2-401c-a65d-aa77082270e8)
