### PR TITLE
Xray SCA scan - always show results with location on Sarif output

### DIFF
--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -330,7 +330,9 @@ func getXrayIssueLocationIfValidExists(tech coreutils.Technology, run *sarif.Run
 		return
 	}
 	if strings.TrimSpace(descriptorPath) == "" {
-		return
+		descriptorPath = "Package Descriptor"
+	} else {
+		descriptorPath = "file://" + descriptorPath
 	}
 	return sarif.NewLocation().WithPhysicalLocation(sarif.NewPhysicalLocation().WithArtifactLocation(sarif.NewArtifactLocation().WithUri("file://" + descriptorPath))), nil
 }

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -331,10 +331,8 @@ func getXrayIssueLocationIfValidExists(tech coreutils.Technology, run *sarif.Run
 	}
 	if strings.TrimSpace(descriptorPath) == "" {
 		descriptorPath = "Package Descriptor"
-	} else {
-		descriptorPath = "file://" + descriptorPath
 	}
-	return sarif.NewLocation().WithPhysicalLocation(sarif.NewPhysicalLocation().WithArtifactLocation(sarif.NewArtifactLocation().WithUri(descriptorPath))), nil
+	return sarif.NewLocation().WithPhysicalLocation(sarif.NewPhysicalLocation().WithArtifactLocation(sarif.NewArtifactLocation().WithUri("file://" + descriptorPath))), nil
 }
 
 func addXrayRule(ruleId, ruleDescription, maxCveScore, summary, markdownDescription string, run *sarif.Run) {

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -334,7 +334,7 @@ func getXrayIssueLocationIfValidExists(tech coreutils.Technology, run *sarif.Run
 	} else {
 		descriptorPath = "file://" + descriptorPath
 	}
-	return sarif.NewLocation().WithPhysicalLocation(sarif.NewPhysicalLocation().WithArtifactLocation(sarif.NewArtifactLocation().WithUri("file://" + descriptorPath))), nil
+	return sarif.NewLocation().WithPhysicalLocation(sarif.NewPhysicalLocation().WithArtifactLocation(sarif.NewArtifactLocation().WithUri(descriptorPath))), nil
 }
 
 func addXrayRule(ruleId, ruleDescription, maxCveScore, summary, markdownDescription string, run *sarif.Run) {

--- a/xray/utils/resultwriter_test.go
+++ b/xray/utils/resultwriter_test.go
@@ -163,7 +163,7 @@ func TestGetXrayIssueLocationIfValidExists(t *testing.T) {
 			name:           "No descriptor information",
 			tech:           coreutils.Pip,
 			run:            CreateRunWithDummyResults().WithInvocations([]*sarif.Invocation{invocation}),
-			expectedOutput: nil,
+			expectedOutput: sarif.NewLocation().WithPhysicalLocation(sarif.NewPhysicalLocation().WithArtifactLocation(sarif.NewArtifactLocation().WithUri("file://Package Descriptor"))),
 		},
 		{
 			name:           "One descriptor information",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

## For all Xray SCA scans (`audit`, `docker scan`...) with Sarif format output:
### If location can't be determined show location with default value: `Package Descriptor`
* Fixes Github integration validation

_**Before:**_
```
{
          "ruleId": "CVE-2023-5363_debian:bookworm:openssl_3.0.11-1~deb12u1",
          "ruleIndex": 43,
          "level": "none",
          "message": {
            "text": "[CVE-2023-5363] sha256__6cd9f01fb9e511a9e611c6592d62412c0fead4b2b09dc3de7fbf6b50a8df0eed.tar"
          }
}
```
_**After:**_
```
{
          "ruleId": "CVE-2023-5363_debian:bookworm:openssl_3.0.11-1~deb12u1",
          "ruleIndex": 43,
          "level": "none",
          "message": {
            "text": "[CVE-2023-5363] sha256__6cd9f01fb9e511a9e611c6592d62412c0fead4b2b09dc3de7fbf6b50a8df0eed.tar"
          },
         "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "Package Descriptor"
                }
              }
            }
          ]
}
```