### PR TITLE
Refine gradle projects indicators

### DIFF
--- a/utils/coreutils/techutils.go
+++ b/utils/coreutils/techutils.go
@@ -70,7 +70,7 @@ var technologiesData = map[Technology]TechData{
 		applicabilityScannable: true,
 	},
 	Gradle: {
-		indicators:             []string{".gradle", ".gradle.kts"},
+		indicators:             []string{"build.gradle", "build.gradle.kts"},
 		ciSetupSupport:         true,
 		packageDescriptors:     []string{"build.gradle", "build.gradle.kts"},
 		applicabilityScannable: true,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
- The build.gradle/build.gradle.kts file is generally mandatory for Gradle projects. The build.gradle file is where you define the configuration for your project, including dependencies, plugins, tasks, and other build-related settings. 
- This is why it serves as a sufficient indicator that a directory represents a Gradle project.

