### PR TITLE
SCA scan - Remove space in default descriptor

### DIFF
--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -330,7 +330,7 @@ func getXrayIssueLocationIfValidExists(tech coreutils.Technology, run *sarif.Run
 		return
 	}
 	if strings.TrimSpace(descriptorPath) == "" {
-		descriptorPath = "Package Descriptor"
+		descriptorPath = "Package-Descriptor"
 	}
 	return sarif.NewLocation().WithPhysicalLocation(sarif.NewPhysicalLocation().WithArtifactLocation(sarif.NewArtifactLocation().WithUri("file://" + descriptorPath))), nil
 }

--- a/xray/utils/resultwriter_test.go
+++ b/xray/utils/resultwriter_test.go
@@ -163,7 +163,7 @@ func TestGetXrayIssueLocationIfValidExists(t *testing.T) {
 			name:           "No descriptor information",
 			tech:           coreutils.Pip,
 			run:            CreateRunWithDummyResults().WithInvocations([]*sarif.Invocation{invocation}),
-			expectedOutput: sarif.NewLocation().WithPhysicalLocation(sarif.NewPhysicalLocation().WithArtifactLocation(sarif.NewArtifactLocation().WithUri("file://Package Descriptor"))),
+			expectedOutput: sarif.NewLocation().WithPhysicalLocation(sarif.NewPhysicalLocation().WithArtifactLocation(sarif.NewArtifactLocation().WithUri("file://Package-Descriptor"))),
 		},
 		{
 			name:           "One descriptor information",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Remove space character from the value of the default descriptor for SCA scan results.
This issue causes:
```
Error: Code Scanning could not process the submitted SARIF file:
an invalid URI was provided as a SARIF location: parse "file://Package Descriptor": invalid character " " in host name
```