### PR TITLE
Audit - Sarif output, show default location for license violation

### DIFF
--- a/xray/utils/resultstable.go
+++ b/xray/utils/resultstable.go
@@ -801,6 +801,7 @@ func simplifyViolations(scanViolations []services.Violation, multipleRoots bool)
 				continue
 			}
 			uniqueViolations[packageKey] = &services.Violation{
+				Summary:       violation.Summary,
 				Severity:      violation.Severity,
 				ViolationType: violation.ViolationType,
 				Components:    map[string]services.Component{vulnerableComponentId: violation.Components[vulnerableComponentId]},

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -230,7 +230,7 @@ func extractXrayIssuesToSarifRun(run *sarif.Run, xrayJson formats.SimpleJsonResu
 		}
 	}
 	for _, license := range xrayJson.LicensesViolations {
-		if err := addXrayLicenseViolationToSarifRun(license, run); err != nil {
+		if err := AddXrayLicenseViolationToSarifRun(license, run); err != nil {
 			return err
 		}
 	}
@@ -268,7 +268,7 @@ func addXrayCveIssueToSarifRun(issue formats.VulnerabilityOrViolationRow, run *s
 	return
 }
 
-func addXrayLicenseViolationToSarifRun(license formats.LicenseRow, run *sarif.Run) (err error) {
+func AddXrayLicenseViolationToSarifRun(license formats.LicenseRow, run *sarif.Run) (err error) {
 	formattedDirectDependencies, err := getDirectDependenciesFormatted(license.Components)
 	if err != nil {
 		return

--- a/xray/utils/resultwriter.go
+++ b/xray/utils/resultwriter.go
@@ -118,15 +118,7 @@ func (rw *ResultsWriter) PrintScanResults() error {
 	case Json:
 		return PrintJson(rw.results.GetScaScansXrayResults())
 	case Sarif:
-		sarifReport, err := GenereateSarifReportFromResults(rw.results, rw.isMultipleRoots, rw.includeLicenses, nil)
-		if err != nil {
-			return err
-		}
-		sarifFile, err := ConvertSarifReportToString(sarifReport)
-		if err != nil {
-			return err
-		}
-		log.Output(sarifFile)
+		return PrintSarif(rw.results, rw.isMultipleRoots, rw.includeLicenses)
 	}
 	return nil
 }
@@ -550,6 +542,19 @@ func PrintJson(output interface{}) error {
 		return errorutils.CheckError(err)
 	}
 	log.Output(clientUtils.IndentJson(results))
+	return nil
+}
+
+func PrintSarif(results *Results, isMultipleRoots, includeLicenses bool) error {
+	sarifReport, err := GenereateSarifReportFromResults(results, isMultipleRoots, includeLicenses, nil)
+	if err != nil {
+		return err
+	}
+	sarifFile, err := ConvertSarifReportToString(sarifReport)
+	if err != nil {
+		return err
+	}
+	log.Output(sarifFile)
 	return nil
 }
 

--- a/xray/utils/resultwriter_test.go
+++ b/xray/utils/resultwriter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/formats"
+	"github.com/jfrog/jfrog-client-go/xray/services"
 	"github.com/owenrumney/go-sarif/v2/sarif"
 	"github.com/stretchr/testify/assert"
 )
@@ -189,6 +190,189 @@ func TestGetXrayIssueLocationIfValidExists(t *testing.T) {
 			output, err := getXrayIssueLocationIfValidExists(tc.tech, tc.run)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tc.expectedOutput, output)
+			}
+		})
+	}
+}
+
+func TestConvertXrayScanToSimpleJson(t *testing.T) {
+	vulnerabilities := []services.Vulnerability{
+		{
+			IssueId:    "XRAY-1",
+			Summary:    "summary-1",
+			Severity:   "high",
+			Components: map[string]services.Component{"component-A": {}, "component-B": {}},
+		},
+		{
+			IssueId:    "XRAY-2",
+			Summary:    "summary-2",
+			Severity:   "low",
+			Components: map[string]services.Component{"component-B": {}},
+		},
+	}
+	expectedVulnerabilities := []formats.VulnerabilityOrViolationRow{
+		{
+			Summary: "summary-1",
+			IssueId: "XRAY-1",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				SeverityDetails:        formats.SeverityDetails{Severity: "high"},
+				ImpactedDependencyName: "component-A",
+			},
+		},
+		{
+			Summary: "summary-1",
+			IssueId: "XRAY-1",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				SeverityDetails:        formats.SeverityDetails{Severity: "high"},
+				ImpactedDependencyName: "component-B",
+			},
+		},
+		{
+			Summary: "summary-2",
+			IssueId: "XRAY-2",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				SeverityDetails:        formats.SeverityDetails{Severity: "low"},
+				ImpactedDependencyName: "component-B",
+			},
+		},
+	}
+
+	violations := []services.Violation{
+		{
+			IssueId:       "XRAY-1",
+			Summary:       "summary-1",
+			Severity:      "high",
+			WatchName:     "watch-1",
+			ViolationType: "security",
+			Components:    map[string]services.Component{"component-A": {}, "component-B": {}},
+		},
+		{
+			IssueId:       "XRAY-2",
+			Summary:       "summary-2",
+			Severity:      "low",
+			WatchName:     "watch-1",
+			ViolationType: "license",
+			LicenseKey:    "license-1",
+			Components:    map[string]services.Component{"component-B": {}},
+		},
+	}
+	expectedSecViolations := []formats.VulnerabilityOrViolationRow{
+		{
+			Summary: "summary-1",
+			IssueId: "XRAY-1",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				SeverityDetails:        formats.SeverityDetails{Severity: "high"},
+				ImpactedDependencyName: "component-A",
+			},
+		},
+		{
+			Summary: "summary-1",
+			IssueId: "XRAY-1",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				SeverityDetails:        formats.SeverityDetails{Severity: "high"},
+				ImpactedDependencyName: "component-B",
+			},
+		},
+	}
+	expectedLicViolations := []formats.LicenseRow{
+		{
+			LicenseKey: "license-1",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				SeverityDetails:        formats.SeverityDetails{Severity: "low"},
+				ImpactedDependencyName: "component-B",
+			},
+		},
+	}
+
+	licenses := []services.License{
+		{
+			Key:        "license-1",
+			Name:       "license-1-name",
+			Components: map[string]services.Component{"component-A": {}, "component-B": {}},
+		},
+		{
+			Key:        "license-2",
+			Name:       "license-2-name",
+			Components: map[string]services.Component{"component-B": {}},
+		},
+	}
+	expectedLicenses := []formats.LicenseRow{
+		{
+			LicenseKey:                "license-1",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{ImpactedDependencyName: "component-A"},
+		},
+		{
+			LicenseKey:                "license-1",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{ImpactedDependencyName: "component-B"},
+		},
+		{
+			LicenseKey:                "license-2",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{ImpactedDependencyName: "component-B"},
+		},
+	}
+
+	testCases := []struct {
+		name            string
+		result          services.ScanResponse
+		includeLicenses bool
+		allowedLicenses []string
+		expectedOutput  formats.SimpleJsonResults
+	}{
+		{
+			name:            "Vulnerabilities only",
+			includeLicenses: false,
+			allowedLicenses: nil,
+			result:          services.ScanResponse{Vulnerabilities: vulnerabilities, Licenses: licenses},
+			expectedOutput:  formats.SimpleJsonResults{Vulnerabilities: expectedVulnerabilities},
+		},
+		{
+			name:            "Vulnerabilities with licenses",
+			includeLicenses: true,
+			allowedLicenses: nil,
+			result:          services.ScanResponse{Vulnerabilities: vulnerabilities, Licenses: licenses},
+			expectedOutput:  formats.SimpleJsonResults{Vulnerabilities: expectedVulnerabilities, Licenses: expectedLicenses},
+		},
+		{
+			name:            "Vulnerabilities only - with allowed licenses",
+			includeLicenses: false,
+			allowedLicenses: []string{"license-1"},
+			result:          services.ScanResponse{Vulnerabilities: vulnerabilities, Licenses: licenses},
+			expectedOutput: formats.SimpleJsonResults{
+				Vulnerabilities: expectedVulnerabilities,
+				LicensesViolations: []formats.LicenseRow{
+					{
+						LicenseKey:                "license-2",
+						ImpactedDependencyDetails: formats.ImpactedDependencyDetails{ImpactedDependencyName: "component-B"},
+					},
+				},
+			},
+		},
+		{
+			name:            "Violations only",
+			includeLicenses: false,
+			allowedLicenses: nil,
+			result:          services.ScanResponse{Violations: violations, Licenses: licenses},
+			expectedOutput:  formats.SimpleJsonResults{SecurityViolations: expectedSecViolations, LicensesViolations: expectedLicViolations},
+		},
+		{
+			name:            "Violations - override allowed licenses",
+			includeLicenses: false,
+			allowedLicenses: []string{"license-1"},
+			result:          services.ScanResponse{Violations: violations, Licenses: licenses},
+			expectedOutput:  formats.SimpleJsonResults{SecurityViolations: expectedSecViolations, LicensesViolations: expectedLicViolations},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			results := NewAuditResults()
+			results.ScaResults = append(results.ScaResults, ScaScanResult{XrayResults: []services.ScanResponse{tc.result}})
+			output, err := ConvertXrayScanToSimpleJson(results, false, tc.includeLicenses, true, tc.allowedLicenses)
+			if assert.NoError(t, err) {
+				assert.ElementsMatch(t, tc.expectedOutput.Vulnerabilities, output.Vulnerabilities)
+				assert.ElementsMatch(t, tc.expectedOutput.SecurityViolations, output.SecurityViolations)
+				assert.ElementsMatch(t, tc.expectedOutput.LicensesViolations, output.LicensesViolations)
+				assert.ElementsMatch(t, tc.expectedOutput.Licenses, output.Licenses)
+				assert.ElementsMatch(t, tc.expectedOutput.OperationalRiskViolations, output.OperationalRiskViolations)
 			}
 		})
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

* Improve Audit by allowing to specify license violations with locations in Sarif format (default), this way license violations can be uploaded to places that allows only results with location (like Github), prerequisite for https://github.com/jfrog/frogbot/pull/575.

* Allow to specify `allowedLicenses` instead of `watch` to get a license violations

* Fix bug where `summary` field was not populated for `violations` in simple json