### PR TITLE
Transfer - Improve time estimation algorithm

### DIFF
--- a/artifactory/commands/transferfiles/state/runstatus.go
+++ b/artifactory/commands/transferfiles/state/runstatus.go
@@ -24,6 +24,7 @@ type ActionOnStatusFunc func(transferRunStatus *TransferRunStatus) error
 // This state is used to allow showing the current run status by the 'jf rt transfer-files --status' command.
 // It is also used for the time estimation and more.
 type TransferRunStatus struct {
+	// Timestamp since the beginning of the current transfer execution
 	startTimestamp    time.Time
 	lastSaveTimestamp time.Time
 	// This variable holds the total/transferred number of repositories (not their files).

--- a/artifactory/commands/transferfiles/state/runstatus.go
+++ b/artifactory/commands/transferfiles/state/runstatus.go
@@ -24,6 +24,7 @@ type ActionOnStatusFunc func(transferRunStatus *TransferRunStatus) error
 // This state is used to allow showing the current run status by the 'jf rt transfer-files --status' command.
 // It is also used for the time estimation and more.
 type TransferRunStatus struct {
+	startTimestamp    time.Time
 	lastSaveTimestamp time.Time
 	// This variable holds the total/transferred number of repositories (not their files).
 	OverallTransfer   ProgressState      `json:"overall_transfer,omitempty"`

--- a/artifactory/commands/transferfiles/state/statemanager.go
+++ b/artifactory/commands/transferfiles/state/statemanager.go
@@ -61,6 +61,14 @@ func (ts *TransferStateManager) UnlockTransferStateManager() error {
 	return ts.unlockStateManager()
 }
 
+func (ts *TransferStateManager) SetStartTimestamp(startTimestamp time.Time) {
+	ts.startTimestamp = startTimestamp
+}
+
+func (ts *TransferStateManager) GetStartTimestamp() time.Time {
+	return ts.startTimestamp
+}
+
 // Set the repository state.
 // repoKey        - Repository key
 // totalSizeBytes - Repository size in bytes
@@ -394,21 +402,39 @@ func (ts *TransferStateManager) tryLockStateManager() error {
 	return nil
 }
 
-func getStartTimestamp() (int64, error) {
+func (ts *TransferStateManager) IsRunning() (isRunning bool, err error) {
 	lockDirPath, err := coreutils.GetJfrogTransferLockDir()
 	if err != nil {
-		return 0, err
+		return false, err
 	}
-	return lock.GetLastLockTimestamp(lockDirPath)
+	var startTimestamp int64
+	startTimestamp, err = lock.GetLastLockTimestamp(lockDirPath)
+	return err == nil && startTimestamp != 0, err
 }
 
-func GetRunningTime() (runningTime string, isRunning bool, err error) {
-	startTimestamp, err := getStartTimestamp()
-	if err != nil || startTimestamp == 0 {
-		return
+func (ts *TransferStateManager) InitStartTimestamp() (isRunning bool, err error) {
+	if !ts.startTimestamp.IsZero() {
+		return true, nil
 	}
-	runningSecs := int64(time.Since(time.Unix(0, startTimestamp)).Seconds())
-	return SecondsToLiteralTime(runningSecs, ""), true, nil
+	lockDirPath, err := coreutils.GetJfrogTransferLockDir()
+	if err != nil {
+		return false, err
+	}
+	var startTimestamp int64
+	startTimestamp, err = lock.GetLastLockTimestamp(lockDirPath)
+	if err != nil || startTimestamp == 0 {
+		return false, err
+	}
+	ts.startTimestamp = time.Unix(0, startTimestamp)
+	return true, nil
+}
+
+func (ts *TransferStateManager) GetRunningTimeString() (runningTime string) {
+	if ts.startTimestamp.IsZero() {
+		return ""
+	}
+	runningSecs := int64(time.Since(ts.startTimestamp).Seconds())
+	return SecondsToLiteralTime(runningSecs, "")
 }
 
 func UpdateChunkInState(stateManager *TransferStateManager, chunk *api.ChunkStatus) (err error) {

--- a/artifactory/commands/transferfiles/state/statemanager.go
+++ b/artifactory/commands/transferfiles/state/statemanager.go
@@ -402,7 +402,7 @@ func (ts *TransferStateManager) tryLockStateManager() error {
 	return nil
 }
 
-func (ts *TransferStateManager) Running() (isRunning bool, err error) {
+func (ts *TransferStateManager) Running() (running bool, err error) {
 	lockDirPath, err := coreutils.GetJfrogTransferLockDir()
 	if err != nil {
 		return false, err

--- a/artifactory/commands/transferfiles/state/statemanager.go
+++ b/artifactory/commands/transferfiles/state/statemanager.go
@@ -402,7 +402,7 @@ func (ts *TransferStateManager) tryLockStateManager() error {
 	return nil
 }
 
-func (ts *TransferStateManager) IsRunning() (isRunning bool, err error) {
+func (ts *TransferStateManager) Running() (isRunning bool, err error) {
 	lockDirPath, err := coreutils.GetJfrogTransferLockDir()
 	if err != nil {
 		return false, err
@@ -412,7 +412,7 @@ func (ts *TransferStateManager) IsRunning() (isRunning bool, err error) {
 	return err == nil && startTimestamp != 0, err
 }
 
-func (ts *TransferStateManager) InitStartTimestamp() (isRunning bool, err error) {
+func (ts *TransferStateManager) InitStartTimestamp() (running bool, err error) {
 	if !ts.startTimestamp.IsZero() {
 		return true, nil
 	}

--- a/artifactory/commands/transferfiles/state/timeestimation.go
+++ b/artifactory/commands/transferfiles/state/timeestimation.go
@@ -33,7 +33,7 @@ type TimeEstimationManager struct {
 	LastSpeedsSum float64 `json:"last_speeds_sum,omitempty"`
 	// The last calculated sum of speeds, in bytes/ms
 	SpeedsAverage float64 `json:"speeds_average,omitempty"`
-	// Total transferred bytes since the beginning of the current transfer running
+	// Total transferred bytes since the beginning of the current transfer execution
 	CurrentTotalTransferredBytes uint64 `json:"current_total_transferred_bytes,omitempty"`
 	// The state manager
 	stateManager *TransferStateManager
@@ -95,7 +95,7 @@ func (tem *TimeEstimationManager) getSpeed() float64 {
 	return tem.SpeedsAverage * bytesPerMilliSecToMBPerSec
 }
 
-// GetSpeedString gets the transfer speed in an easy-to-read string.
+// GetSpeedString gets the transfer speed as an easy-to-read string.
 func (tem *TimeEstimationManager) GetSpeedString() string {
 	if len(tem.LastSpeeds) == 0 {
 		return "Not available yet"
@@ -103,7 +103,7 @@ func (tem *TimeEstimationManager) GetSpeedString() string {
 	return fmt.Sprintf("%.3f MB/s", tem.getSpeed())
 }
 
-// GetEstimatedRemainingTimeString gets the estimated remaining time in an easy-to-read string.
+// GetEstimatedRemainingTimeString gets the estimated remaining time as an easy-to-read string.
 // Return "Not available yet" in the following cases:
 // 1. 5 minutes not passed since the beginning of the transfer
 // 2. No files transferred

--- a/artifactory/commands/transferfiles/state/timeestimation.go
+++ b/artifactory/commands/transferfiles/state/timeestimation.go
@@ -2,21 +2,18 @@ package state
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/api"
-	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 const (
-	milliSecsInSecond          = 1000
-	bytesInMB                  = 1024 * 1024
-	bytesPerMilliSecToMBPerSec = float64(milliSecsInSecond) / float64(bytesInMB)
-	// Precalculated average index time per build info, in seconds. This constant is used to estimate the processing time of all
-	// the build info files about to be transferred. Since the build info indexing time is not related to its file size,
-	// the estimation approach we use with data is irrelevant.
-	buildInfoAverageIndexTimeSec = 1.25
+	milliSecsInSecond               = 1000
+	bytesInMB                       = 1024 * 1024
+	bytesPerMilliSecToMBPerSec      = float64(milliSecsInSecond) / float64(bytesInMB)
+	minTransferTimeToShowEstimation = time.Minute * 5
 )
 
 type timeTypeSingular string
@@ -36,15 +33,14 @@ type TimeEstimationManager struct {
 	LastSpeedsSum float64 `json:"last_speeds_sum,omitempty"`
 	// The last calculated sum of speeds, in bytes/ms
 	SpeedsAverage float64 `json:"speeds_average,omitempty"`
-	// Data estimated remaining time is saved so that it can be used when handling a build-info repository and speed cannot be calculated.
-	DataEstimatedRemainingTime int64 `json:"data_estimated_remaining_time,omitempty"`
+	// Total transferred bytes since the beginning of the current transfer running
+	CurrentTotalTransferredBytes uint64 `json:"current_total_transferred_bytes,omitempty"`
 	// The state manager
 	stateManager *TransferStateManager
 }
 
 func (tem *TimeEstimationManager) AddChunkStatus(chunkStatus api.ChunkStatus, durationMillis int64) {
-	// Build info repository requires no action here (transferred counter is updated in the state manager and no other calculation is needed).
-	if durationMillis == 0 || tem.stateManager.BuildInfoRepo {
+	if durationMillis == 0 {
 		return
 	}
 
@@ -54,7 +50,10 @@ func (tem *TimeEstimationManager) AddChunkStatus(chunkStatus api.ChunkStatus, du
 func (tem *TimeEstimationManager) addDataChunkStatus(chunkStatus api.ChunkStatus, durationMillis int64) {
 	var chunkSizeBytes int64
 	for _, file := range chunkStatus.Files {
-		if file.Status == api.Success && !file.ChecksumDeployed {
+		if file.Status != api.Fail {
+			tem.CurrentTotalTransferredBytes += uint64(file.SizeBytes)
+		}
+		if (file.Status == api.Success || file.Status == api.SkippedLargeProps) && !file.ChecksumDeployed {
 			chunkSizeBytes += file.SizeBytes
 		}
 	}
@@ -98,101 +97,42 @@ func (tem *TimeEstimationManager) getSpeed() float64 {
 
 // GetSpeedString gets the transfer speed in an easy-to-read string.
 func (tem *TimeEstimationManager) GetSpeedString() string {
-	if tem.stateManager.BuildInfoRepo {
-		return "Not available while transferring a build-info repository"
-	}
 	if len(tem.LastSpeeds) == 0 {
 		return "Not available yet"
 	}
 	return fmt.Sprintf("%.3f MB/s", tem.getSpeed())
 }
 
-// getEstimatedRemainingTime gets the estimated remaining time in seconds.
-// The estimated remaining time is the sum of:
-// 1. Data estimated remaining time, derived by the average speed and remaining data size.
-// 2. Build info estimated remaining time, derived by a precalculated average time per build info.
-func (tem *TimeEstimationManager) getEstimatedRemainingTime() (int64, error) {
-	err := tem.calculateDataEstimatedRemainingTime()
-	if err != nil {
-		return 0, err
-	}
-	return tem.DataEstimatedRemainingTime + tem.getBuildInfoEstimatedRemainingTime(), nil
-}
-
-// calculateDataEstimatedRemainingTime calculates the data estimated remaining time in seconds, and sets it to the corresponding
-// variable in the estimation manager.
-func (tem *TimeEstimationManager) calculateDataEstimatedRemainingTime() error {
-	// If a build info repository is currently being handled, use the data estimated time previously calculated.
-	// Else, start calculating when the speeds average is set.
-	if tem.stateManager.BuildInfoRepo || tem.SpeedsAverage == 0 {
-		return nil
-	}
-	transferredSizeBytes, err := tem.stateManager.GetTransferredSizeBytes()
-	if err != nil {
-		return err
-	}
-
-	// In case we reach a situation where we transfer more data than expected, we cannot estimate how long transferring the remaining data will take.
-	if tem.stateManager.OverallTransfer.TotalSizeBytes <= transferredSizeBytes {
-		tem.DataEstimatedRemainingTime = 0
-		return nil
-	}
-
-	// We only convert to int64 at the end to avoid a scenario where the conversion of SpeedsAverage returns zero.
-	remainingTime := float64(tem.stateManager.OverallTransfer.TotalSizeBytes-transferredSizeBytes) / tem.SpeedsAverage
-	// Convert from milliseconds to seconds.
-	tem.DataEstimatedRemainingTime = int64(remainingTime) / milliSecsInSecond
-	return nil
-}
-
-func (tem *TimeEstimationManager) getBuildInfoEstimatedRemainingTime() int64 {
-	if tem.stateManager.OverallBiFiles.TotalUnits <= tem.stateManager.OverallBiFiles.TransferredUnits {
-		return 0
-	}
-
-	workingThreads, err := tem.getWorkingThreadsForBuildInfoEstimation()
-	if err != nil {
-		log.Error("Couldn't calculate time estimation:", err.Error())
-		return 0
-	}
-
-	remainingBiFiles := float64(tem.stateManager.OverallBiFiles.TotalUnits - tem.stateManager.OverallBiFiles.TransferredUnits)
-	remainingTime := remainingBiFiles * buildInfoAverageIndexTimeSec / float64(workingThreads)
-	return int64(remainingTime)
-}
-
-func (tem *TimeEstimationManager) getWorkingThreadsForBuildInfoEstimation() (int, error) {
-	workingThreads, err := tem.stateManager.GetWorkingThreads()
-	if err != nil {
-		return 0, err
-	}
-	// If the uploader didn't start working, temporarily display estimation according to one thread.
-	if workingThreads == 0 {
-		return 1, nil
-	}
-	// If currently handling a data repository and the number of threads is high, show build info estimation according to the build info threads limit.
-	if workingThreads > utils.MaxBuildInfoThreads {
-		return utils.MaxBuildInfoThreads, nil
-	}
-	return workingThreads, nil
-}
-
 // GetEstimatedRemainingTimeString gets the estimated remaining time in an easy-to-read string.
+// Return "Not available yet" in the following cases:
+// 1. 5 minutes not passed since the beginning of the transfer
+// 2. No files transferred
+// 3. The transfer speed is less than 1 byte per second
 func (tem *TimeEstimationManager) GetEstimatedRemainingTimeString() string {
-	if !tem.isTimeEstimationAvailable() {
-		return "Not available in this phase"
-	}
-	if !tem.stateManager.BuildInfoRepo && len(tem.LastSpeeds) == 0 {
+	remainingTimeSec := tem.getEstimatedRemainingSeconds()
+	if remainingTimeSec == 0 {
 		return "Not available yet"
 	}
-	remainingTimeSec, err := tem.getEstimatedRemainingTime()
-	if err != nil {
-		return err.Error()
-	}
 
-	return SecondsToLiteralTime(remainingTimeSec, "About ")
+	return SecondsToLiteralTime(int64(remainingTimeSec), "About ")
 }
 
-func (tem *TimeEstimationManager) isTimeEstimationAvailable() bool {
-	return tem.stateManager.CurrentRepoPhase == api.Phase1 || tem.stateManager.CurrentRepoPhase == api.Phase3
+func (tem *TimeEstimationManager) getEstimatedRemainingSeconds() uint64 {
+	if tem.CurrentTotalTransferredBytes == 0 {
+		// No files transferred
+		return 0
+	}
+	duration := time.Since(tem.stateManager.startTimestamp)
+	if duration < minTransferTimeToShowEstimation {
+		// 5 minutes not yet passed
+		return 0
+	}
+
+	transferredBytesInSeconds := tem.CurrentTotalTransferredBytes / uint64(duration.Seconds())
+	if transferredBytesInSeconds == 0 {
+		// Less than 1 byte per second
+		return 0
+	}
+	remainingBytes := tem.stateManager.OverallTransfer.TotalSizeBytes - tem.stateManager.OverallTransfer.TransferredSizeBytes
+	return uint64(remainingBytes) / transferredBytesInSeconds
 }

--- a/artifactory/commands/transferfiles/status.go
+++ b/artifactory/commands/transferfiles/status.go
@@ -20,7 +20,12 @@ const sizeUnits = "KMGTPE"
 
 func ShowStatus() error {
 	var output strings.Builder
-	runningTime, isRunning, err := state.GetRunningTime()
+	stateManager, err := state.NewTransferStateManager(true)
+	if err != nil {
+		return err
+	}
+
+	isRunning, err := stateManager.InitStartTimestamp()
 	if err != nil {
 		return err
 	}
@@ -39,11 +44,7 @@ func ShowStatus() error {
 		return nil
 	}
 
-	stateManager, err := state.NewTransferStateManager(true)
-	if err != nil {
-		return err
-	}
-	addOverallStatus(stateManager, &output, runningTime)
+	addOverallStatus(stateManager, &output, stateManager.GetRunningTimeString())
 	if stateManager.CurrentRepoKey != "" {
 		transferState, exists, err := state.LoadTransferState(stateManager.CurrentRepoKey, false)
 		if err != nil {

--- a/artifactory/commands/transferfiles/status_test.go
+++ b/artifactory/commands/transferfiles/status_test.go
@@ -68,7 +68,7 @@ func TestShowStatus(t *testing.T) {
 	assert.Contains(t, results, "Repositories:		15 / 1111 (1.4%)")
 	assert.Contains(t, results, "Working threads:		16")
 	assert.Contains(t, results, "Transfer speed:		0.011 MB/s")
-	assert.Contains(t, results, "Estimated time remaining:	Less than a minute")
+	assert.Contains(t, results, "Estimated time remaining:	Not available yet")
 	assert.Contains(t, results, "Transfer failures:		223 (In Phase 3 and in subsequent executions, we'll retry transferring the failed files)")
 
 	// Check repository status
@@ -100,7 +100,7 @@ func TestShowStatusDiffPhase(t *testing.T) {
 	assert.Contains(t, results, "Repositories:		15 / 1111 (1.4%)")
 	assert.Contains(t, results, "Working threads:		16")
 	assert.Contains(t, results, "Transfer speed:		0.011 MB/s")
-	assert.Contains(t, results, "Estimated time remaining:	Not available in this phase")
+	assert.Contains(t, results, "Estimated time remaining:	Not available yet")
 	assert.Contains(t, results, "Transfer failures:		223 (In Phase 3 and in subsequent executions, we'll retry transferring the failed files)")
 
 	// Check repository status
@@ -131,8 +131,8 @@ func TestShowBuildInfoRepo(t *testing.T) {
 	assert.Contains(t, results, "Storage:			4.9 KiB / 10.9 KiB (45.0%)")
 	assert.Contains(t, results, "Repositories:		15 / 1111 (1.4%)")
 	assert.Contains(t, results, "Working threads:		16")
-	assert.Contains(t, results, "Transfer speed:		Not available while transferring a build-info repository")
-	assert.Contains(t, results, "Estimated time remaining:	Less than a minute")
+	assert.Contains(t, results, "Transfer speed:		0.011 MB/s")
+	assert.Contains(t, results, "Estimated time remaining:	Not available yet")
 	assert.Contains(t, results, "Transfer failures:		223")
 
 	// Check repository status
@@ -179,6 +179,7 @@ func createStateManager(t *testing.T, phase int, buildInfoRepo bool, staleChunks
 	stateManager.OverallTransfer.TotalSizeBytes = 11111
 	stateManager.TotalRepositories.TotalUnits = 1111
 	stateManager.TotalRepositories.TransferredUnits = 15
+	stateManager.CurrentTotalTransferredBytes = 15
 	stateManager.WorkingThreads = 16
 	stateManager.VisitedFolders = 15
 	stateManager.DelayedFiles = 20

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -703,11 +703,11 @@ func (tdc *TransferFilesCommand) handleMaxUniqueSnapshots(repoSummary *serviceUt
 
 // Create the '~/.jfrog/transfer/stop' file to mark the transfer-file process to stop
 func (tdc *TransferFilesCommand) signalStop() error {
-	isRunning, err := tdc.stateManager.IsRunning()
+	running, err := tdc.stateManager.Running()
 	if err != nil {
 		return err
 	}
-	if !isRunning {
+	if !running {
 		return errorutils.CheckErrorf("There is no active file transfer process.")
 	}
 

--- a/utils/progressbar/transferprogressbarmanager.go
+++ b/utils/progressbar/transferprogressbarmanager.go
@@ -281,8 +281,8 @@ func (tpm *TransferProgressMng) GetBarMng() *ProgressBarMng {
 
 func (tpm *TransferProgressMng) NewRunningTimeProgressBar() *TasksProgressBar {
 	return tpm.barMng.NewStringProgressBar(tpm.transferLabels.RunningFor, func() string {
-		runningTime, isRunning, err := state.GetRunningTime()
-		if err != nil || !isRunning {
+		runningTime := tpm.stateMng.GetRunningTimeString()
+		if runningTime == "" {
 			runningTime = "Running time not available"
 		}
 		return color.Green.Render(runningTime)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Introduce a new time estimation algorithm for the `jf rt transfer-files` command:
**Divide the transferred bytes in the ongoing process by the remaining size.**

The time estimation will only show up if these conditions are fulfilled:
1. Five minutes have elapsed since the transfer started.
2. A minimum of one file has been successfully transferred.
3. The calculated speed is at least one byte per second.