### PR TITLE
Run contextual analysis and secret detection in Docker scans #1035

### DIFF
--- a/xray/commands/audit/audit.go
+++ b/xray/commands/audit/audit.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/utils/dependencies"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/scangraph"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray"
 	"github.com/jfrog/jfrog-client-go/xray/services"
 	"golang.org/x/sync/errgroup"
@@ -157,7 +156,7 @@ func RunAudit(auditParams *AuditParams) (results *xrayutils.Results, err error) 
 		return
 	}
 	results.XrayVersion = auditParams.xrayVersion
-	results.ExtendedScanResults.EntitledForJas, err = isEntitledForJas(xrayManager, auditParams.xrayVersion)
+	results.ExtendedScanResults.EntitledForJas, err = xrayutils.IsEntitledForJas(xrayManager, auditParams.xrayVersion)
 	if err != nil {
 		return
 	}
@@ -180,14 +179,5 @@ func RunAudit(auditParams *AuditParams) (results *xrayutils.Results, err error) 
 	if results.ExtendedScanResults.EntitledForJas {
 		results.JasError = runJasScannersAndSetResults(results, auditParams.DirectDependencies(), serverDetails, auditParams.workingDirs, auditParams.Progress(), auditParams.xrayGraphScanParams.MultiScanId, auditParams.thirdPartyApplicabilityScan)
 	}
-	return
-}
-
-func isEntitledForJas(xrayManager *xray.XrayServicesManager, xrayVersion string) (entitled bool, err error) {
-	if e := clientutils.ValidateMinimumVersion(clientutils.Xray, xrayVersion, xrayutils.EntitlementsMinVersion); e != nil {
-		log.Debug(e)
-		return
-	}
-	entitled, err = xrayManager.IsEntitled(xrayutils.ApplicabilityFeatureId)
 	return
 }

--- a/xray/commands/audit/jas/applicability/applicabilitymanager.go
+++ b/xray/commands/audit/jas/applicability/applicabilitymanager.go
@@ -67,8 +67,8 @@ func RunApplicabilityScan(xrayResults []services.ScanResponse, directDependencie
 // bool: true if the user is entitled to the applicability scan, false otherwise.
 // error: An error object (if any).
 func RunApplicabilityWithScanCves(xrayResults []services.ScanResponse, cveList []string,
-	scannedTechnologies []coreutils.Technology, scanner *jas.JasScanner, thirdPartyContextualAnalysis bool) (results []*sarif.Run, err error) {
-	applicabilityScanManager := newApplicabilityScanManagerCves(xrayResults, cveList, scanner, thirdPartyContextualAnalysis)
+	scannedTechnologies []coreutils.Technology, scanner *jas.JasScanner) (results []*sarif.Run, err error) {
+	applicabilityScanManager := newApplicabilityScanManagerCves(xrayResults, cveList, scanner)
 	if err = applicabilityScanManager.scanner.Run(applicabilityScanManager); err != nil {
 		err = utils.ParseAnalyzerManagerError(utils.Applicability, err)
 		return
@@ -77,13 +77,13 @@ func RunApplicabilityWithScanCves(xrayResults []services.ScanResponse, cveList [
 	return
 }
 
-func newApplicabilityScanManagerCves(xrayScanResults []services.ScanResponse, cveList []string, scanner *jas.JasScanner, thirdPartyScan bool) (manager *ApplicabilityScanManager) {
+func newApplicabilityScanManagerCves(xrayScanResults []services.ScanResponse, cveList []string, scanner *jas.JasScanner) (manager *ApplicabilityScanManager) {
 	return &ApplicabilityScanManager{
 		applicabilityScanResults: []*sarif.Run{},
 		directDependenciesCves:   cveList,
 		xrayResults:              xrayScanResults,
 		scanner:                  scanner,
-		thirdPartyScan:           thirdPartyScan,
+		thirdPartyScan:           false,
 		commandType:              applicabilityDockerScanScanType,
 	}
 }

--- a/xray/commands/audit/jas/applicability/applicabilitymanager.go
+++ b/xray/commands/audit/jas/applicability/applicabilitymanager.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	applicabilityScanType      = "analyze-applicability"
-	applicabilityScanCommand   = "ca"
-	applicabilityDocsUrlSuffix = "contextual-analysis"
+	applicabilityScanType           = "analyze-applicability"
+	applicabilityScanCommand        = "ca"
+	applicabilityDocsUrlSuffix      = "contextual-analysis"
+	applicabilityDockerScanScanType = "analyze-applicability-docker-scan"
 )
 
 type ApplicabilityScanManager struct {
@@ -29,6 +30,7 @@ type ApplicabilityScanManager struct {
 	xrayResults              []services.ScanResponse
 	scanner                  *jas.JasScanner
 	thirdPartyScan           bool
+	commandType              string
 }
 
 // The getApplicabilityScanResults function runs the applicability scan flow, which includes the following steps:
@@ -55,6 +57,37 @@ func RunApplicabilityScan(xrayResults []services.ScanResponse, directDependencie
 	return
 }
 
+// The getApplicabilityScanResults function runs the applicability scan flow, which includes the following steps:
+// Creating an ApplicabilityScanManager object.
+// Checking if the scanned project is eligible for applicability scan.
+// Running the analyzer manager executable.
+// Parsing the analyzer manager results.
+// Return values:
+// map[string]string: A map containing the applicability result of each XRAY CVE.
+// bool: true if the user is entitled to the applicability scan, false otherwise.
+// error: An error object (if any).
+func RunApplicabilityWithScanCves(xrayResults []services.ScanResponse, cveList []string,
+	scannedTechnologies []coreutils.Technology, scanner *jas.JasScanner, thirdPartyContextualAnalysis bool) (results []*sarif.Run, err error) {
+	applicabilityScanManager := newApplicabilityScanManagerCves(xrayResults, cveList, scanner, thirdPartyContextualAnalysis)
+	if err = applicabilityScanManager.scanner.Run(applicabilityScanManager); err != nil {
+		err = utils.ParseAnalyzerManagerError(utils.Applicability, err)
+		return
+	}
+	results = applicabilityScanManager.applicabilityScanResults
+	return
+}
+
+func newApplicabilityScanManagerCves(xrayScanResults []services.ScanResponse, cveList []string, scanner *jas.JasScanner, thirdPartyScan bool) (manager *ApplicabilityScanManager) {
+	return &ApplicabilityScanManager{
+		applicabilityScanResults: []*sarif.Run{},
+		directDependenciesCves:   cveList,
+		xrayResults:              xrayScanResults,
+		scanner:                  scanner,
+		thirdPartyScan:           thirdPartyScan,
+		commandType:              applicabilityDockerScanScanType,
+	}
+}
+
 func newApplicabilityScanManager(xrayScanResults []services.ScanResponse, directDependencies []string, scanner *jas.JasScanner, thirdPartyScan bool) (manager *ApplicabilityScanManager) {
 	directDependenciesCves, indirectDependenciesCves := extractDependenciesCvesFromScan(xrayScanResults, directDependencies)
 	return &ApplicabilityScanManager{
@@ -64,6 +97,7 @@ func newApplicabilityScanManager(xrayScanResults []services.ScanResponse, direct
 		xrayResults:              xrayScanResults,
 		scanner:                  scanner,
 		thirdPartyScan:           thirdPartyScan,
+		commandType:              applicabilityScanType,
 	}
 }
 
@@ -152,6 +186,7 @@ type scanConfiguration struct {
 	CveWhitelist         []string `yaml:"cve-whitelist"`
 	IndirectCveWhitelist []string `yaml:"indirect-cve-whitelist"`
 	SkippedDirs          []string `yaml:"skipped-folders"`
+	ScanType             string   `yaml:"scantype"`
 }
 
 func (asm *ApplicabilityScanManager) createConfigFile(module jfrogappsconfig.Module) error {
@@ -169,7 +204,7 @@ func (asm *ApplicabilityScanManager) createConfigFile(module jfrogappsconfig.Mod
 			{
 				Roots:                roots,
 				Output:               asm.scanner.ResultsFileName,
-				Type:                 applicabilityScanType,
+				Type:                 asm.commandType,
 				GrepDisable:          false,
 				CveWhitelist:         asm.directDependenciesCves,
 				IndirectCveWhitelist: asm.indirectDependenciesCves,

--- a/xray/commands/audit/jas/secrets/secretsscanner.go
+++ b/xray/commands/audit/jas/secrets/secretsscanner.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	secretsScanCommand       = "sec"
-	SecretsScannerType       = "secrets-scan"
+	SecretsScannerType       = "secrets-scan" // #nosec
 	SecretsScannerDockerType = "secrets-docker-scan"
 	secretsDocsUrlSuffix     = "secrets"
 )

--- a/xray/commands/audit/jas/secrets/secretsscanner.go
+++ b/xray/commands/audit/jas/secrets/secretsscanner.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	secretsScanCommand       = "sec"
-	SecretsScannerType       = "secrets-scan" // #nosec
-	SecretsScannerDockerType = "secrets-docker-scan"
+	SecretsScannerType       = "secrets-scan"        // #nosec
+	SecretsScannerDockerType = "secrets-docker-scan" // #nosec
 	secretsDocsUrlSuffix     = "secrets"
 )
 

--- a/xray/commands/audit/jas/secrets/secretsscanner.go
+++ b/xray/commands/audit/jas/secrets/secretsscanner.go
@@ -12,14 +12,16 @@ import (
 )
 
 const (
-	secretsScanCommand   = "sec"
-	secretsScannerType   = "secrets-scan"
-	secretsDocsUrlSuffix = "secrets"
+	secretsScanCommand       = "sec"
+	SecretsScannerType       = "secrets-scan"
+	SecretsScannerDockerType = "secrets-docker-scan"
+	secretsDocsUrlSuffix     = "secrets"
 )
 
 type SecretScanManager struct {
 	secretsScannerResults []*sarif.Run
 	scanner               *jas.JasScanner
+	scanType              string
 }
 
 // The getSecretsScanResults function runs the secrets scan flow, which includes the following steps:
@@ -29,8 +31,8 @@ type SecretScanManager struct {
 // Return values:
 // []utils.IacOrSecretResult: a list of the secrets that were found.
 // error: An error object (if any).
-func RunSecretsScan(scanner *jas.JasScanner) (results []*sarif.Run, err error) {
-	secretScanManager := newSecretsScanManager(scanner)
+func RunSecretsScan(scanner *jas.JasScanner, scanType string) (results []*sarif.Run, err error) {
+	secretScanManager := newSecretsScanManager(scanner, scanType)
 	log.Info("Running secrets scanning...")
 	if err = secretScanManager.scanner.Run(secretScanManager); err != nil {
 		err = utils.ParseAnalyzerManagerError(utils.Secrets, err)
@@ -43,10 +45,11 @@ func RunSecretsScan(scanner *jas.JasScanner) (results []*sarif.Run, err error) {
 	return
 }
 
-func newSecretsScanManager(scanner *jas.JasScanner) (manager *SecretScanManager) {
+func newSecretsScanManager(scanner *jas.JasScanner, scanType string) (manager *SecretScanManager) {
 	return &SecretScanManager{
 		secretsScannerResults: []*sarif.Run{},
 		scanner:               scanner,
+		scanType:              scanType,
 	}
 }
 
@@ -89,7 +92,7 @@ func (s *SecretScanManager) createConfigFile(module jfrogappsconfig.Module) erro
 			{
 				Roots:       roots,
 				Output:      s.scanner.ResultsFileName,
-				Type:        secretsScannerType,
+				Type:        s.scanType,
 				SkippedDirs: jas.GetExcludePatterns(module, module.Scanners.Secrets),
 			},
 		},

--- a/xray/commands/audit/jas/secrets/secretsscanner.go
+++ b/xray/commands/audit/jas/secrets/secretsscanner.go
@@ -12,10 +12,10 @@ import (
 )
 
 const (
-	secretsScanCommand       = "sec"
-	SecretsScannerType       = "secrets-scan"        // #nosec
-	SecretsScannerDockerType = "secrets-docker-scan" // #nosec
-	secretsDocsUrlSuffix     = "secrets"
+	secretsScanCommand           = "sec"
+	SecretsScannerType           = "secrets-scan"        // #nosec
+	SecretsScannerDockerScanType = "secrets-docker-scan" // #nosec
+	secretsDocsUrlSuffix         = "secrets"
 )
 
 type SecretScanManager struct {

--- a/xray/commands/audit/jas/secrets/secretsscanner_test.go
+++ b/xray/commands/audit/jas/secrets/secretsscanner_test.go
@@ -15,7 +15,7 @@ import (
 func TestNewSecretsScanManager(t *testing.T) {
 	scanner, cleanUp := jas.InitJasTest(t)
 	defer cleanUp()
-	secretScanManager := newSecretsScanManager(scanner)
+	secretScanManager := newSecretsScanManager(scanner, SecretsScannerType)
 
 	assert.NotEmpty(t, secretScanManager)
 	assert.NotEmpty(t, secretScanManager.scanner.ConfigFileName)
@@ -26,7 +26,7 @@ func TestNewSecretsScanManager(t *testing.T) {
 func TestSecretsScan_CreateConfigFile_VerifyFileWasCreated(t *testing.T) {
 	scanner, cleanUp := jas.InitJasTest(t)
 	defer cleanUp()
-	secretScanManager := newSecretsScanManager(scanner)
+	secretScanManager := newSecretsScanManager(scanner, SecretsScannerType)
 
 	currWd, err := coreutils.GetWorkingDirectory()
 	assert.NoError(t, err)
@@ -53,7 +53,7 @@ func TestRunAnalyzerManager_ReturnsGeneralError(t *testing.T) {
 	scanner, cleanUp := jas.InitJasTest(t)
 	defer cleanUp()
 
-	secretScanManager := newSecretsScanManager(scanner)
+	secretScanManager := newSecretsScanManager(scanner, SecretsScannerType)
 	assert.Error(t, secretScanManager.runAnalyzerManager())
 }
 
@@ -61,7 +61,7 @@ func TestParseResults_EmptyResults(t *testing.T) {
 	scanner, cleanUp := jas.InitJasTest(t)
 	defer cleanUp()
 	// Arrange
-	secretScanManager := newSecretsScanManager(scanner)
+	secretScanManager := newSecretsScanManager(scanner, SecretsScannerType)
 	secretScanManager.scanner.ResultsFileName = filepath.Join(jas.GetTestDataPath(), "secrets-scan", "no-secrets.sarif")
 
 	// Act
@@ -84,7 +84,7 @@ func TestParseResults_ResultsContainSecrets(t *testing.T) {
 	scanner, cleanUp := jas.InitJasTest(t)
 	defer cleanUp()
 
-	secretScanManager := newSecretsScanManager(scanner)
+	secretScanManager := newSecretsScanManager(scanner, SecretsScannerType)
 	secretScanManager.scanner.ResultsFileName = filepath.Join(jas.GetTestDataPath(), "secrets-scan", "contain-secrets.sarif")
 
 	// Act
@@ -107,7 +107,7 @@ func TestGetSecretsScanResults_AnalyzerManagerReturnsError(t *testing.T) {
 	scanner, cleanUp := jas.InitJasTest(t)
 	defer cleanUp()
 
-	secretsResults, err := RunSecretsScan(scanner)
+	secretsResults, err := RunSecretsScan(scanner, SecretsScannerType)
 
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "failed to run Secrets scan")

--- a/xray/commands/audit/jasrunner.go
+++ b/xray/commands/audit/jasrunner.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"errors"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/commands/audit/jas"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/commands/audit/jas/applicability"
@@ -41,7 +42,7 @@ func runJasScannersAndSetResults(scanResults *utils.Results, directDependencies 
 	if progress != nil {
 		progress.SetHeadlineMsg("Running secrets scanning")
 	}
-	scanResults.ExtendedScanResults.SecretsScanResults, err = secrets.RunSecretsScan(scanner)
+	scanResults.ExtendedScanResults.SecretsScanResults, err = secrets.RunSecretsScan(scanner, secrets.SecretsScannerType)
 	if err != nil {
 		return
 	}

--- a/xray/commands/scan/jasrunner_cves.go
+++ b/xray/commands/scan/jasrunner_cves.go
@@ -1,0 +1,53 @@
+package scan
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/xray/commands/audit/jas"
+	"github.com/jfrog/jfrog-cli-core/v2/xray/commands/audit/jas/applicability"
+	"github.com/jfrog/jfrog-cli-core/v2/xray/commands/audit/jas/secrets"
+
+	"github.com/jfrog/jfrog-cli-core/v2/xray/utils"
+	"github.com/jfrog/jfrog-client-go/utils/io"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+func runJasScannersAndSetResults(scanResults *utils.Results, cveList []string,
+	serverDetails *config.ServerDetails, workingDirs []string, progress io.ProgressMgr, multiScanId string, thirdPartyApplicabilityScan bool) (err error) {
+
+	if serverDetails == nil || len(serverDetails.Url) == 0 {
+		log.Warn("To include 'Advanced Security' scan as part of the audit output, please run the 'jf c add' command before running this command.")
+		return
+	}
+
+	scanner, err := jas.NewJasScanner(workingDirs, serverDetails, multiScanId)
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		cleanup := scanner.ScannerDirCleanupFunc
+		err = errors.Join(err, cleanup())
+	}()
+
+	// if progress != nil {
+	// 	progress.SetHeadlineMsg("Running applicability scanning")
+	// }
+
+	scanResults.ExtendedScanResults.ApplicabilityScanResults, err = applicability.RunApplicabilityWithScanCves(scanResults.GetScaScansXrayResults(), cveList, scanResults.GetScaScannedTechnologies(), scanner, thirdPartyApplicabilityScan)
+	if err != nil {
+		fmt.Println("there was an error:", err)
+		return
+	}
+
+	// if progress != nil {
+	// 	progress.SetHeadlineMsg("Running secrets scanning")
+	// }
+	scanResults.ExtendedScanResults.SecretsScanResults, err = secrets.RunSecretsScan(scanner, secrets.SecretsScannerDockerType)
+	if err != nil {
+		return
+	}
+	return
+}

--- a/xray/commands/scan/jasrunner_cves.go
+++ b/xray/commands/scan/jasrunner_cves.go
@@ -37,7 +37,7 @@ func runJasScannersAndSetResults(scanResults *utils.Results, cveList []string,
 		return
 	}
 
-	scanResults.ExtendedScanResults.SecretsScanResults, err = secrets.RunSecretsScan(scanner, secrets.SecretsScannerDockerType)
+	scanResults.ExtendedScanResults.SecretsScanResults, err = secrets.RunSecretsScan(scanner, secrets.SecretsScannerDockerScanType)
 	if err != nil {
 		return
 	}

--- a/xray/commands/scan/jasrunner_cves.go
+++ b/xray/commands/scan/jasrunner_cves.go
@@ -10,12 +10,11 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/xray/commands/audit/jas/secrets"
 
 	"github.com/jfrog/jfrog-cli-core/v2/xray/utils"
-	"github.com/jfrog/jfrog-client-go/utils/io"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 func runJasScannersAndSetResults(scanResults *utils.Results, cveList []string,
-	serverDetails *config.ServerDetails, workingDirs []string, progress io.ProgressMgr, multiScanId string, thirdPartyApplicabilityScan bool) (err error) {
+	serverDetails *config.ServerDetails, workingDirs []string, multiScanId string, thirdPartyApplicabilityScan bool) (err error) {
 
 	if serverDetails == nil || len(serverDetails.Url) == 0 {
 		log.Warn("To include 'Advanced Security' scan as part of the audit output, please run the 'jf c add' command before running this command.")
@@ -32,19 +31,12 @@ func runJasScannersAndSetResults(scanResults *utils.Results, cveList []string,
 		err = errors.Join(err, cleanup())
 	}()
 
-	// if progress != nil {
-	// 	progress.SetHeadlineMsg("Running applicability scanning")
-	// }
-
 	scanResults.ExtendedScanResults.ApplicabilityScanResults, err = applicability.RunApplicabilityWithScanCves(scanResults.GetScaScansXrayResults(), cveList, scanResults.GetScaScannedTechnologies(), scanner, thirdPartyApplicabilityScan)
 	if err != nil {
 		fmt.Println("there was an error:", err)
 		return
 	}
 
-	// if progress != nil {
-	// 	progress.SetHeadlineMsg("Running secrets scanning")
-	// }
 	scanResults.ExtendedScanResults.SecretsScanResults, err = secrets.RunSecretsScan(scanner, secrets.SecretsScannerDockerType)
 	if err != nil {
 		return

--- a/xray/commands/scan/jasrunner_cves.go
+++ b/xray/commands/scan/jasrunner_cves.go
@@ -14,13 +14,13 @@ import (
 )
 
 func runJasScannersAndSetResults(scanResults *utils.Results, cveList []string,
-	serverDetails *config.ServerDetails, workingDirs []string, multiScanId string, thirdPartyApplicabilityScan bool) (err error) {
+	serverDetails *config.ServerDetails, workingDirs []string) (err error) {
 
 	if serverDetails == nil || len(serverDetails.Url) == 0 {
 		log.Warn("To include 'Advanced Security' scan as part of the audit output, please run the 'jf c add' command before running this command.")
 		return
 	}
-
+	multiScanId := "" // Also empty for audit
 	scanner, err := jas.NewJasScanner(workingDirs, serverDetails, multiScanId)
 	if err != nil {
 		return
@@ -31,7 +31,7 @@ func runJasScannersAndSetResults(scanResults *utils.Results, cveList []string,
 		err = errors.Join(err, cleanup())
 	}()
 
-	scanResults.ExtendedScanResults.ApplicabilityScanResults, err = applicability.RunApplicabilityWithScanCves(scanResults.GetScaScansXrayResults(), cveList, scanResults.GetScaScannedTechnologies(), scanner, thirdPartyApplicabilityScan)
+	scanResults.ExtendedScanResults.ApplicabilityScanResults, err = applicability.RunApplicabilityWithScanCves(scanResults.GetScaScansXrayResults(), cveList, scanResults.GetScaScannedTechnologies(), scanner)
 	if err != nil {
 		fmt.Println("there was an error:", err)
 		return

--- a/xray/commands/scan/scan.go
+++ b/xray/commands/scan/scan.go
@@ -8,8 +8,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strings"
+
+	"golang.org/x/exp/slices"
 
 	rtutils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/scangraph"

--- a/xray/commands/scan/scan.go
+++ b/xray/commands/scan/scan.go
@@ -267,7 +267,7 @@ func (scanCmd *ScanCommand) Run() (err error) {
 		cveList := cveListFromVulnerabilities(flatResults)
 		multiScanId := "" // Also empty for audit
 		thirdPartyApplicabilityScan := false
-		workingDirs := []string{(*(*scanCmd).spec).Files[0].Pattern}
+		workingDirs := []string{(*scanCmd).spec.Files[0].Pattern}
 		scanResults.JasError = runJasScannersAndSetResults(scanResults, cveList, scanCmd.serverDetails, workingDirs, scanCmd.progress, multiScanId, thirdPartyApplicabilityScan)
 	}
 

--- a/xray/commands/scan/scan.go
+++ b/xray/commands/scan/scan.go
@@ -265,10 +265,8 @@ func (scanCmd *ScanCommand) Run() (err error) {
 
 	if scanResults.ExtendedScanResults.EntitledForJas {
 		cveList := cveListFromVulnerabilities(flatResults)
-		multiScanId := "" // Also empty for audit
-		thirdPartyApplicabilityScan := false
 		workingDirs := []string{scanCmd.spec.Files[0].Pattern}
-		scanResults.JasError = runJasScannersAndSetResults(scanResults, cveList, scanCmd.serverDetails, workingDirs, multiScanId, thirdPartyApplicabilityScan)
+		scanResults.JasError = runJasScannersAndSetResults(scanResults, cveList, scanCmd.serverDetails, workingDirs)
 	}
 
 	if err = xrutils.NewResultsWriter(scanResults).

--- a/xray/commands/scan/scan.go
+++ b/xray/commands/scan/scan.go
@@ -268,7 +268,7 @@ func (scanCmd *ScanCommand) Run() (err error) {
 		multiScanId := "" // Also empty for audit
 		thirdPartyApplicabilityScan := false
 		workingDirs := []string{(*scanCmd).spec.Files[0].Pattern}
-		scanResults.JasError = runJasScannersAndSetResults(scanResults, cveList, scanCmd.serverDetails, workingDirs, scanCmd.progress, multiScanId, thirdPartyApplicabilityScan)
+		scanResults.JasError = runJasScannersAndSetResults(scanResults, cveList, scanCmd.serverDetails, workingDirs, multiScanId, thirdPartyApplicabilityScan)
 	}
 
 	if err = xrutils.NewResultsWriter(scanResults).

--- a/xray/commands/scan/scan.go
+++ b/xray/commands/scan/scan.go
@@ -267,7 +267,7 @@ func (scanCmd *ScanCommand) Run() (err error) {
 		cveList := cveListFromVulnerabilities(flatResults)
 		multiScanId := "" // Also empty for audit
 		thirdPartyApplicabilityScan := false
-		workingDirs := []string{(*scanCmd).spec.Files[0].Pattern}
+		workingDirs := []string{scanCmd.spec.Files[0].Pattern}
 		scanResults.JasError = runJasScannersAndSetResults(scanResults, cveList, scanCmd.serverDetails, workingDirs, multiScanId, thirdPartyApplicabilityScan)
 	}
 

--- a/xray/commands/scan/scan.go
+++ b/xray/commands/scan/scan.go
@@ -487,7 +487,7 @@ func cveListFromVulnerabilities(flatResults []services.ScanResponse) []string {
 				}
 			}
 			if !slices.Contains(technologiesList, vulnerability.Technology) && (vulnerability.Technology != "") {
-				cveList = append(technologiesList, vulnerability.Technology)
+				technologiesList = append(technologiesList, vulnerability.Technology)
 			}
 		}
 	}

--- a/xray/formats/conversion.go
+++ b/xray/formats/conversion.go
@@ -28,6 +28,7 @@ func ConvertToVulnerabilityScanTableRow(rows []VulnerabilityOrViolationRow) (tab
 		tableRows = append(tableRows, vulnerabilityScanTableRow{
 			severity:               rows[i].Severity,
 			severityNumValue:       rows[i].SeverityNumValue,
+			applicable:             rows[i].Applicable,
 			impactedPackageName:    rows[i].ImpactedDependencyName,
 			impactedPackageVersion: rows[i].ImpactedDependencyVersion,
 			ImpactedPackageType:    rows[i].ImpactedDependencyType,

--- a/xray/formats/table.go
+++ b/xray/formats/table.go
@@ -20,7 +20,8 @@ type vulnerabilityTableRow struct {
 }
 
 type vulnerabilityScanTableRow struct {
-	severity string `col-name:"Severity"`
+	severity   string `col-name:"Severity"`
+	applicable string `col-name:"Contextual\nAnalysis" omitempty:"true"`
 	// For sorting
 	severityNumValue       int
 	directPackages         []directPackagesTableRow `embed-table:"true"`

--- a/xray/utils/jasutils.go
+++ b/xray/utils/jasutils.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/jfrog/jfrog-client-go/xray"
+)
+
+func IsEntitledForJas(xrayManager *xray.XrayServicesManager, xrayVersion string) (entitled bool, err error) {
+	if e := clientutils.ValidateMinimumVersion(clientutils.Xray, xrayVersion, EntitlementsMinVersion); e != nil {
+		log.Debug(e)
+		return
+	}
+	entitled, err = xrayManager.IsEntitled(ApplicabilityFeatureId)
+	return
+}


### PR DESCRIPTION
## Description
This PR adds to the ``docker scan`` command support for JFrog Advanced Security. Searching for applicable vulnerabilities and secrets.

## Status
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Changes for #1035 

Regarding tests - I am not sure how to add tests for this, if you could point me up to where? It looks like there is some coverage because I had to fix some tests.
Static analysis - I fixed gosec but the other looks like code unrelated to what I changd

I have read the CLA Document and I hereby sign the CLA