### PR TITLE
Update conditions for running contextual analysis scan

### DIFF
--- a/xray/commands/audit/jas/applicability/applicabilitymanager.go
+++ b/xray/commands/audit/jas/applicability/applicabilitymanager.go
@@ -44,7 +44,7 @@ func RunApplicabilityScan(xrayResults []services.ScanResponse, directDependencie
 	scannedTechnologies []coreutils.Technology, scanner *jas.JasScanner, thirdPartyContextualAnalysis bool) (results []*sarif.Run, err error) {
 	applicabilityScanManager := newApplicabilityScanManager(xrayResults, directDependencies, scanner, thirdPartyContextualAnalysis)
 	if !applicabilityScanManager.shouldRunApplicabilityScan(scannedTechnologies) {
-		log.Debug("The technologies that have been scanned are currently not supported for contextual analysis scanning, or we couldn't find any vulnerable direct dependencies. Skipping....")
+		log.Debug("The technologies that have been scanned are currently not supported for contextual analysis scanning, or we couldn't find any vulnerable dependencies. Skipping....")
 		return
 	}
 	if err = applicabilityScanManager.scanner.Run(applicabilityScanManager); err != nil {
@@ -133,7 +133,11 @@ func (asm *ApplicabilityScanManager) Run(module jfrogappsconfig.Module) (err err
 }
 
 func (asm *ApplicabilityScanManager) shouldRunApplicabilityScan(technologies []coreutils.Technology) bool {
-	return coreutils.ContainsApplicabilityScannableTech(technologies)
+	return asm.cvesExists() && coreutils.ContainsApplicabilityScannableTech(technologies)
+}
+
+func (asm *ApplicabilityScanManager) cvesExists() bool {
+	return len(asm.indirectDependenciesCves) > 0 || len(asm.directDependenciesCves) > 0
 }
 
 type applicabilityScanConfig struct {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
- The applicability scanner returns an error when parsing a configuration file without CVEs.
- This pull request adds a condition to execute the applicability scanner only if any CVEs were found during the SCA scan.