### PR TITLE
Fix - scan SCA recursive only when workingDirs not provided

### DIFF
--- a/xray/commands/audit/scarunner.go
+++ b/xray/commands/audit/scarunner.go
@@ -72,10 +72,10 @@ func runScaScan(params *AuditParams, results *xrayutils.Results) (err error) {
 
 // Calculate the scans to preform
 func getScaScansToPreform(currentWorkingDir string, params *AuditParams) (scansToPreform []*xrayutils.ScaScanResult) {
-	requestedDirectories, recursive := getRequestedDirectoriesToScan(currentWorkingDir, params)
+	requestedDirectories, isRecursive := getRequestedDirectoriesToScan(currentWorkingDir, params)
 	for _, requestedDirectory := range requestedDirectories {
 		// Detect descriptors and technologies in the requested directory.
-		techToWorkingDirs, err := coreutils.DetectTechnologiesDescriptors(requestedDirectory, recursive, params.Technologies(), getRequestedDescriptors(params), getExcludePattern(params, recursive))
+		techToWorkingDirs, err := coreutils.DetectTechnologiesDescriptors(requestedDirectory, isRecursive, params.Technologies(), getRequestedDescriptors(params), getExcludePattern(params, isRecursive))
 		if err != nil {
 			log.Warn("Couldn't detect technologies in", requestedDirectory, "directory.", err.Error())
 			continue
@@ -116,6 +116,9 @@ func getExcludePattern(params *AuditParams, recursive bool) string {
 	return fspatterns.PrepareExcludePathPattern(exclusions, clientutils.WildCardPattern, recursive)
 }
 
+// Get the directories to scan base on the given parameters.
+// If no working directories were specified, the current working directory will be returned with recursive mode.
+// If working directories were specified, the recursive mode will be false.
 func getRequestedDirectoriesToScan(currentWorkingDir string, params *AuditParams) ([]string, bool) {
 	workingDirs := datastructures.MakeSet[string]()
 	for _, wd := range params.workingDirs {

--- a/xray/commands/audit/scarunner.go
+++ b/xray/commands/audit/scarunner.go
@@ -72,8 +72,8 @@ func runScaScan(params *AuditParams, results *xrayutils.Results) (err error) {
 
 // Calculate the scans to preform
 func getScaScansToPreform(currentWorkingDir string, params *AuditParams) (scansToPreform []*xrayutils.ScaScanResult) {
-	recursive := len(currentWorkingDir) > 0
-	for _, requestedDirectory := range getRequestedDirectoriesToScan(currentWorkingDir, params) {
+	requestedDirectories, recursive := getRequestedDirectoriesToScan(currentWorkingDir, params)
+	for _, requestedDirectory := range requestedDirectories {
 		// Detect descriptors and technologies in the requested directory.
 		techToWorkingDirs, err := coreutils.DetectTechnologiesDescriptors(requestedDirectory, recursive, params.Technologies(), getRequestedDescriptors(params), getExcludePattern(params, recursive))
 		if err != nil {
@@ -116,15 +116,15 @@ func getExcludePattern(params *AuditParams, recursive bool) string {
 	return fspatterns.PrepareExcludePathPattern(exclusions, clientutils.WildCardPattern, recursive)
 }
 
-func getRequestedDirectoriesToScan(currentWorkingDir string, params *AuditParams) []string {
+func getRequestedDirectoriesToScan(currentWorkingDir string, params *AuditParams) ([]string, bool) {
 	workingDirs := datastructures.MakeSet[string]()
 	for _, wd := range params.workingDirs {
 		workingDirs.Add(wd)
 	}
-	if workingDirs.Size() == 0 {
-		workingDirs.Add(currentWorkingDir)
+	if len(params.workingDirs) == 0 {
+		return []string{currentWorkingDir}, true
 	}
-	return workingDirs.ToSlice()
+	return workingDirs.ToSlice(), false
 }
 
 // Preform the SCA scan for the given scan information.

--- a/xray/commands/audit/scarunner_test.go
+++ b/xray/commands/audit/scarunner_test.go
@@ -166,6 +166,43 @@ func TestGetExcludePattern(t *testing.T) {
 	}
 }
 
+func TestGetRequestedDirectoriesToScan(t *testing.T) {
+	tests := []struct {
+		name              string
+		cwd               string
+		params            func() *AuditParams
+		expectedRecursive bool
+		expectedDirs      []string
+	}{
+		{
+			name: "Test specific directories",
+			cwd:  "/tmp",
+			params: func() *AuditParams {
+				param := NewAuditParams()
+				param.SetWorkingDirs([]string{"/tmp/dir1", "/tmp/dir2"})
+				return param
+			},
+			expectedRecursive: false,
+			expectedDirs:      []string{"/tmp/dir1", "/tmp/dir2"},
+		},
+		{
+			name:              "Test recursive",
+			cwd:               "/tmp",
+			params:            NewAuditParams,
+			expectedRecursive: true,
+			expectedDirs:      []string{"/tmp"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dirs, recursive := getRequestedDirectoriesToScan(test.cwd, test.params())
+			assert.ElementsMatch(t, test.expectedDirs, dirs)
+			assert.Equal(t, test.expectedRecursive, recursive)
+		})
+	}
+}
+
 func TestGetScaScansToPreform(t *testing.T) {
 
 	dir, cleanUp := createTestDir(t)

--- a/xray/commands/audit/scarunner_test.go
+++ b/xray/commands/audit/scarunner_test.go
@@ -176,21 +176,21 @@ func TestGetRequestedDirectoriesToScan(t *testing.T) {
 	}{
 		{
 			name: "Test specific directories",
-			cwd:  "/tmp",
+			cwd:  "tmp",
 			params: func() *AuditParams {
 				param := NewAuditParams()
-				param.SetWorkingDirs([]string{"/tmp/dir1", "/tmp/dir2"})
+				param.SetWorkingDirs([]string{filepath.Join("tmp", "dir1"), filepath.Join("tmp", "dir2")})
 				return param
 			},
 			expectedRecursive: false,
-			expectedDirs:      []string{"/tmp/dir1", "/tmp/dir2"},
+			expectedDirs:      []string{filepath.Join("tmp", "dir1"), filepath.Join("tmp", "dir2")},
 		},
 		{
 			name:              "Test recursive",
-			cwd:               "/tmp",
+			cwd:               "tmp",
 			params:            NewAuditParams,
 			expectedRecursive: true,
-			expectedDirs:      []string{"/tmp"},
+			expectedDirs:      []string{"tmp"},
 		},
 	}
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

The issue was that we determined if the scan should be recursive based on a wrong variable.
condition was (len on string):
```
len(currentWorkingDir) > 0
```

and fixed to the correct one (len on param list):
```
len(params.workingDirs) == 0
```