### PR TITLE
download-jars.sh downloads to the wrong path

### DIFF
--- a/buildscripts/download-jars.sh
+++ b/buildscripts/download-jars.sh
@@ -11,5 +11,5 @@ GRADLE_DEP_TREE_VERSION="3.0.1"
 # Changing this version also requires a change in mavenDepTreeVersion within xray/commands/audit/sca/java/mvn.go.
 MAVEN_DEP_TREE_VERSION="1.0.2"
 
-curl -fL https://releases.jfrog.io/artifactory/oss-release-local/com/jfrog/gradle-dep-tree/${GRADLE_DEP_TREE_VERSION}/gradle-dep-tree-${GRADLE_DEP_TREE_VERSION}.jar -o xray/commands/audit/sca/java/gradle-dep-tree.jar
-curl -fL https://releases.jfrog.io/artifactory/oss-release-local/com/jfrog/maven-dep-tree/${MAVEN_DEP_TREE_VERSION}/maven-dep-tree-${MAVEN_DEP_TREE_VERSION}.jar -o xray/commands/audit/sca/java/maven-dep-tree.jar
+curl -fL https://releases.jfrog.io/artifactory/oss-release-local/com/jfrog/gradle-dep-tree/${GRADLE_DEP_TREE_VERSION}/gradle-dep-tree-${GRADLE_DEP_TREE_VERSION}.jar -o xray/commands/audit/sca/java/resources/gradle-dep-tree.jar
+curl -fL https://releases.jfrog.io/artifactory/oss-release-local/com/jfrog/maven-dep-tree/${MAVEN_DEP_TREE_VERSION}/maven-dep-tree-${MAVEN_DEP_TREE_VERSION}.jar -o xray/commands/audit/sca/java/resources/maven-dep-tree.jar


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Download gradle-dep-tree.jar and maven-dep-tree.jar to `xray/commands/audit/sca/java/resources/` instead of just `xray/commands/audit/sca/java/`. Right now, this problem doesn't seem to have an impact as the jars under `xray/commands/audit/sca/java/resources/` look accurate.