### PR TITLE
Transfer - Phase 3 progress wrongly adds transferred files

### DIFF
--- a/artifactory/commands/transferfiles/state/statemanager.go
+++ b/artifactory/commands/transferfiles/state/statemanager.go
@@ -172,6 +172,8 @@ func (ts *TransferStateManager) IncTotalSizeAndFilesPhase2(filesNumber, totalSiz
 // Set relevant information of files and storage we need to transfer in phase3
 func (ts *TransferStateManager) SetTotalSizeAndFilesPhase3(filesNumber, totalSize int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
+		state.CurrentRepo.Phase3Info.TransferredUnits = 0
+		state.CurrentRepo.Phase3Info.TransferredSizeBytes = 0
 		state.CurrentRepo.Phase3Info.TotalSizeBytes = totalSize
 		state.CurrentRepo.Phase3Info.TotalUnits = filesNumber
 		return nil


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

There's an issue that needs fixing: 

![image](https://github.com/jfrog/jfrog-cli-core/assets/11367982/04960c39-cc52-437a-bd67-2e3b42bb6953)

**Steps to reproduce**
Execute `jf rt transfer-files` twice. The second run will show incorrect progress in Phase 3.

**The root cause**
Phase 3 doesn't retain information, yet it fetches the count of transferred files from the prior run.