### PR TITLE
Transfer - Make high frequency changes atomic

### DIFF
--- a/artifactory/commands/transferfiles/fileserror.go
+++ b/artifactory/commands/transferfiles/fileserror.go
@@ -77,7 +77,7 @@ func (e *errorsRetryPhase) handleErrorsFile(errFilePath string, pcWrapper *produ
 		// Since we're about to handle the transfer retry of the failed files,
 		// we should now decrement the failures counter view.
 		e.progressBar.changeNumberOfFailuresBy(-1 * len(failedFiles.Errors))
-		err = e.stateManager.ChangeTransferFailureCountBy(uint(len(failedFiles.Errors)), false)
+		err = e.stateManager.ChangeTransferFailureCountBy(uint64(len(failedFiles.Errors)), false)
 		if err != nil {
 			return err
 		}

--- a/artifactory/commands/transferfiles/state/runstatus.go
+++ b/artifactory/commands/transferfiles/state/runstatus.go
@@ -40,7 +40,7 @@ type TransferRunStatus struct {
 	WorkingThreads        int    `json:"working_threads,omitempty"`
 	VisitedFolders        uint64 `json:"visited_folders,omitempty"`
 	DelayedFiles          uint64 `json:"delayed_files,omitempty"`
-	TransferFailures      uint   `json:"transfer_failures,omitempty"`
+	TransferFailures      uint64 `json:"transfer_failures,omitempty"`
 	TimeEstimationManager `json:"time_estimation,omitempty"`
 	StaleChunks           []StaleChunks `json:"stale_chunks,omitempty"`
 }

--- a/artifactory/commands/transferfiles/state/statemanager.go
+++ b/artifactory/commands/transferfiles/state/statemanager.go
@@ -136,19 +136,19 @@ func (ts *TransferStateManager) SetRepoFullTransferCompleted() error {
 // Increasing Transferred Diff files (modified files) and SizeByBytes value in suitable repository progress state
 func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase1(chunkTotalFiles, chunkTotalSizeInBytes int64) error {
 	err := ts.TransferState.Action(func(state *TransferState) error {
-		atomicallyAddInt64(&state.CurrentRepo.Phase1Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
-		atomicallyAddInt64(&state.CurrentRepo.Phase1Info.TransferredUnits, chunkTotalFiles, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase1Info.TransferredSizeBytes, chunkTotalSizeInBytes)
+		atomicallyAddInt64(&state.CurrentRepo.Phase1Info.TransferredUnits, chunkTotalFiles)
 		return nil
 	})
 	if err != nil {
 		return err
 	}
 	return ts.TransferRunStatus.action(func(transferRunStatus *TransferRunStatus) error {
-		atomicallyAddInt64(&transferRunStatus.OverallTransfer.TransferredSizeBytes, chunkTotalSizeInBytes, true)
-		atomicallyAddInt64(&transferRunStatus.OverallTransfer.TransferredUnits, chunkTotalFiles, true)
+		atomicallyAddInt64(&transferRunStatus.OverallTransfer.TransferredSizeBytes, chunkTotalSizeInBytes)
+		atomicallyAddInt64(&transferRunStatus.OverallTransfer.TransferredUnits, chunkTotalFiles)
 
 		if transferRunStatus.BuildInfoRepo {
-			atomicallyAddInt64(&transferRunStatus.OverallBiFiles.TransferredUnits, chunkTotalFiles, true)
+			atomicallyAddInt64(&transferRunStatus.OverallBiFiles.TransferredUnits, chunkTotalFiles)
 		}
 		return nil
 	})
@@ -156,16 +156,16 @@ func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase1(chunkTotalFiles
 
 func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase2(chunkTotalFiles, chunkTotalSizeInBytes int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
-		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TransferredUnits, chunkTotalFiles, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TransferredSizeBytes, chunkTotalSizeInBytes)
+		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TransferredUnits, chunkTotalFiles)
 		return nil
 	})
 }
 
 func (ts *TransferStateManager) IncTotalSizeAndFilesPhase2(filesNumber, totalSize int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TotalSizeBytes, totalSize, true)
-		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TotalUnits, filesNumber, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TotalSizeBytes, totalSize)
+		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TotalUnits, filesNumber)
 		return nil
 	})
 }
@@ -175,8 +175,8 @@ func (ts *TransferStateManager) SetTotalSizeAndFilesPhase3(filesNumber, totalSiz
 	return ts.TransferState.Action(func(state *TransferState) error {
 		state.CurrentRepo.Phase3Info.TransferredUnits = 0
 		state.CurrentRepo.Phase3Info.TransferredSizeBytes = 0
-		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TotalSizeBytes, totalSize, true)
-		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TotalUnits, filesNumber, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TotalSizeBytes, totalSize)
+		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TotalUnits, filesNumber)
 		return nil
 	})
 }
@@ -184,8 +184,8 @@ func (ts *TransferStateManager) SetTotalSizeAndFilesPhase3(filesNumber, totalSiz
 // Increase transferred storage and files in phase 3
 func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase3(chunkTotalFiles, chunkTotalSizeInBytes int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
-		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TransferredUnits, chunkTotalFiles, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TransferredSizeBytes, chunkTotalSizeInBytes)
+		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TransferredUnits, chunkTotalFiles)
 		return nil
 	})
 }

--- a/artifactory/commands/transferfiles/state/statemanager.go
+++ b/artifactory/commands/transferfiles/state/statemanager.go
@@ -136,18 +136,19 @@ func (ts *TransferStateManager) SetRepoFullTransferCompleted() error {
 // Increasing Transferred Diff files (modified files) and SizeByBytes value in suitable repository progress state
 func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase1(chunkTotalFiles, chunkTotalSizeInBytes int64) error {
 	err := ts.TransferState.Action(func(state *TransferState) error {
-		state.CurrentRepo.Phase1Info.TransferredSizeBytes += chunkTotalSizeInBytes
-		state.CurrentRepo.Phase1Info.TransferredUnits += chunkTotalFiles
+		AtomicallyAddInt64(&state.CurrentRepo.Phase1Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
+		AtomicallyAddInt64(&state.CurrentRepo.Phase1Info.TransferredUnits, chunkTotalFiles, true)
 		return nil
 	})
 	if err != nil {
 		return err
 	}
 	return ts.TransferRunStatus.action(func(transferRunStatus *TransferRunStatus) error {
-		transferRunStatus.OverallTransfer.TransferredSizeBytes += chunkTotalSizeInBytes
-		transferRunStatus.OverallTransfer.TransferredUnits += chunkTotalFiles
+		AtomicallyAddInt64(&transferRunStatus.OverallTransfer.TransferredSizeBytes, chunkTotalSizeInBytes, true)
+		AtomicallyAddInt64(&transferRunStatus.OverallTransfer.TransferredUnits, chunkTotalFiles, true)
+
 		if transferRunStatus.BuildInfoRepo {
-			transferRunStatus.OverallBiFiles.TransferredUnits += chunkTotalFiles
+			AtomicallyAddInt64(&transferRunStatus.OverallBiFiles.TransferredUnits, chunkTotalFiles, true)
 		}
 		return nil
 	})
@@ -155,16 +156,16 @@ func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase1(chunkTotalFiles
 
 func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase2(chunkTotalFiles, chunkTotalSizeInBytes int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		state.CurrentRepo.Phase2Info.TransferredSizeBytes += chunkTotalSizeInBytes
-		state.CurrentRepo.Phase2Info.TransferredUnits += chunkTotalFiles
+		AtomicallyAddInt64(&state.CurrentRepo.Phase2Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
+		AtomicallyAddInt64(&state.CurrentRepo.Phase2Info.TransferredUnits, chunkTotalFiles, true)
 		return nil
 	})
 }
 
 func (ts *TransferStateManager) IncTotalSizeAndFilesPhase2(filesNumber, totalSize int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		state.CurrentRepo.Phase2Info.TotalSizeBytes += totalSize
-		state.CurrentRepo.Phase2Info.TotalUnits += filesNumber
+		AtomicallyAddInt64(&state.CurrentRepo.Phase2Info.TotalSizeBytes, totalSize, true)
+		AtomicallyAddInt64(&state.CurrentRepo.Phase2Info.TotalUnits, filesNumber, true)
 		return nil
 	})
 }
@@ -172,8 +173,8 @@ func (ts *TransferStateManager) IncTotalSizeAndFilesPhase2(filesNumber, totalSiz
 // Set relevant information of files and storage we need to transfer in phase3
 func (ts *TransferStateManager) SetTotalSizeAndFilesPhase3(filesNumber, totalSize int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		state.CurrentRepo.Phase3Info.TotalSizeBytes = totalSize
-		state.CurrentRepo.Phase3Info.TotalUnits = filesNumber
+		AtomicallyAddInt64(&state.CurrentRepo.Phase3Info.TotalSizeBytes, totalSize, true)
+		AtomicallyAddInt64(&state.CurrentRepo.Phase3Info.TotalUnits, filesNumber, true)
 		return nil
 	})
 }
@@ -181,8 +182,8 @@ func (ts *TransferStateManager) SetTotalSizeAndFilesPhase3(filesNumber, totalSiz
 // Increase transferred storage and files in phase 3
 func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase3(chunkTotalFiles, chunkTotalSizeInBytes int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		state.CurrentRepo.Phase3Info.TransferredSizeBytes += chunkTotalSizeInBytes
-		state.CurrentRepo.Phase3Info.TransferredUnits += chunkTotalFiles
+		AtomicallyAddInt64(&state.CurrentRepo.Phase3Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
+		AtomicallyAddInt64(&state.CurrentRepo.Phase3Info.TransferredUnits, chunkTotalFiles, true)
 		return nil
 	})
 }
@@ -288,29 +289,21 @@ func (ts *TransferStateManager) GetDiffHandlingRange() (start, end time.Time, er
 
 func (ts *TransferStateManager) IncVisitedFolders() error {
 	return ts.action(func(transferRunStatus *TransferRunStatus) error {
-		transferRunStatus.VisitedFolders++
+		AtomicallyAddUint64(&transferRunStatus.VisitedFolders, 1, true)
 		return nil
 	})
 }
 
 func (ts *TransferStateManager) ChangeDelayedFilesCountBy(count uint64, increase bool) error {
 	return ts.TransferRunStatus.action(func(transferRunStatus *TransferRunStatus) error {
-		if increase {
-			transferRunStatus.DelayedFiles += count
-		} else {
-			transferRunStatus.DelayedFiles -= count
-		}
+		AtomicallyAddUint64(&transferRunStatus.DelayedFiles, count, increase)
 		return nil
 	})
 }
 
-func (ts *TransferStateManager) ChangeTransferFailureCountBy(count uint, increase bool) error {
+func (ts *TransferStateManager) ChangeTransferFailureCountBy(count uint64, increase bool) error {
 	return ts.TransferRunStatus.action(func(transferRunStatus *TransferRunStatus) error {
-		if increase {
-			transferRunStatus.TransferFailures += count
-		} else {
-			transferRunStatus.TransferFailures -= count
-		}
+		AtomicallyAddUint64(&transferRunStatus.TransferFailures, count, increase)
 		return nil
 	})
 }

--- a/artifactory/commands/transferfiles/state/statemanager.go
+++ b/artifactory/commands/transferfiles/state/statemanager.go
@@ -136,19 +136,19 @@ func (ts *TransferStateManager) SetRepoFullTransferCompleted() error {
 // Increasing Transferred Diff files (modified files) and SizeByBytes value in suitable repository progress state
 func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase1(chunkTotalFiles, chunkTotalSizeInBytes int64) error {
 	err := ts.TransferState.Action(func(state *TransferState) error {
-		AtomicallyAddInt64(&state.CurrentRepo.Phase1Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
-		AtomicallyAddInt64(&state.CurrentRepo.Phase1Info.TransferredUnits, chunkTotalFiles, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase1Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase1Info.TransferredUnits, chunkTotalFiles, true)
 		return nil
 	})
 	if err != nil {
 		return err
 	}
 	return ts.TransferRunStatus.action(func(transferRunStatus *TransferRunStatus) error {
-		AtomicallyAddInt64(&transferRunStatus.OverallTransfer.TransferredSizeBytes, chunkTotalSizeInBytes, true)
-		AtomicallyAddInt64(&transferRunStatus.OverallTransfer.TransferredUnits, chunkTotalFiles, true)
+		atomicallyAddInt64(&transferRunStatus.OverallTransfer.TransferredSizeBytes, chunkTotalSizeInBytes, true)
+		atomicallyAddInt64(&transferRunStatus.OverallTransfer.TransferredUnits, chunkTotalFiles, true)
 
 		if transferRunStatus.BuildInfoRepo {
-			AtomicallyAddInt64(&transferRunStatus.OverallBiFiles.TransferredUnits, chunkTotalFiles, true)
+			atomicallyAddInt64(&transferRunStatus.OverallBiFiles.TransferredUnits, chunkTotalFiles, true)
 		}
 		return nil
 	})
@@ -156,16 +156,16 @@ func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase1(chunkTotalFiles
 
 func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase2(chunkTotalFiles, chunkTotalSizeInBytes int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		AtomicallyAddInt64(&state.CurrentRepo.Phase2Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
-		AtomicallyAddInt64(&state.CurrentRepo.Phase2Info.TransferredUnits, chunkTotalFiles, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TransferredUnits, chunkTotalFiles, true)
 		return nil
 	})
 }
 
 func (ts *TransferStateManager) IncTotalSizeAndFilesPhase2(filesNumber, totalSize int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		AtomicallyAddInt64(&state.CurrentRepo.Phase2Info.TotalSizeBytes, totalSize, true)
-		AtomicallyAddInt64(&state.CurrentRepo.Phase2Info.TotalUnits, filesNumber, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TotalSizeBytes, totalSize, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase2Info.TotalUnits, filesNumber, true)
 		return nil
 	})
 }
@@ -173,8 +173,8 @@ func (ts *TransferStateManager) IncTotalSizeAndFilesPhase2(filesNumber, totalSiz
 // Set relevant information of files and storage we need to transfer in phase3
 func (ts *TransferStateManager) SetTotalSizeAndFilesPhase3(filesNumber, totalSize int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		AtomicallyAddInt64(&state.CurrentRepo.Phase3Info.TotalSizeBytes, totalSize, true)
-		AtomicallyAddInt64(&state.CurrentRepo.Phase3Info.TotalUnits, filesNumber, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TotalSizeBytes, totalSize, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TotalUnits, filesNumber, true)
 		return nil
 	})
 }
@@ -182,8 +182,8 @@ func (ts *TransferStateManager) SetTotalSizeAndFilesPhase3(filesNumber, totalSiz
 // Increase transferred storage and files in phase 3
 func (ts *TransferStateManager) IncTransferredSizeAndFilesPhase3(chunkTotalFiles, chunkTotalSizeInBytes int64) error {
 	return ts.TransferState.Action(func(state *TransferState) error {
-		AtomicallyAddInt64(&state.CurrentRepo.Phase3Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
-		AtomicallyAddInt64(&state.CurrentRepo.Phase3Info.TransferredUnits, chunkTotalFiles, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TransferredSizeBytes, chunkTotalSizeInBytes, true)
+		atomicallyAddInt64(&state.CurrentRepo.Phase3Info.TransferredUnits, chunkTotalFiles, true)
 		return nil
 	})
 }
@@ -289,21 +289,21 @@ func (ts *TransferStateManager) GetDiffHandlingRange() (start, end time.Time, er
 
 func (ts *TransferStateManager) IncVisitedFolders() error {
 	return ts.action(func(transferRunStatus *TransferRunStatus) error {
-		AtomicallyAddUint64(&transferRunStatus.VisitedFolders, 1, true)
+		atomicallyAddUint64(&transferRunStatus.VisitedFolders, 1, true)
 		return nil
 	})
 }
 
 func (ts *TransferStateManager) ChangeDelayedFilesCountBy(count uint64, increase bool) error {
 	return ts.TransferRunStatus.action(func(transferRunStatus *TransferRunStatus) error {
-		AtomicallyAddUint64(&transferRunStatus.DelayedFiles, count, increase)
+		atomicallyAddUint64(&transferRunStatus.DelayedFiles, count, increase)
 		return nil
 	})
 }
 
 func (ts *TransferStateManager) ChangeTransferFailureCountBy(count uint64, increase bool) error {
 	return ts.TransferRunStatus.action(func(transferRunStatus *TransferRunStatus) error {
-		AtomicallyAddUint64(&transferRunStatus.TransferFailures, count, increase)
+		atomicallyAddUint64(&transferRunStatus.TransferFailures, count, increase)
 		return nil
 	})
 }

--- a/artifactory/commands/transferfiles/state/utils.go
+++ b/artifactory/commands/transferfiles/state/utils.go
@@ -126,13 +126,8 @@ func GetOldTransferDirectoryStructureError() error {
 // Atomically add to an int64 variable.
 // addr     - Pointer to int64 variable
 // delta    - The change to do
-// increase - True to increment, false to decrement
-func atomicallyAddInt64(addr *int64, delta int64, increase bool) {
-	if increase {
-		atomic.AddInt64(addr, delta)
-	} else {
-		atomic.AddInt64(addr, -delta)
-	}
+func atomicallyAddInt64(addr *int64, delta int64) {
+	atomic.AddInt64(addr, delta)
 }
 
 // Atomically add to an uint64 variable.

--- a/artifactory/commands/transferfiles/state/utils.go
+++ b/artifactory/commands/transferfiles/state/utils.go
@@ -127,7 +127,7 @@ func GetOldTransferDirectoryStructureError() error {
 // addr     - Pointer to int64 variable
 // delta    - The change to do
 // increase - True to increment, false to decrement
-func AtomicallyAddInt64(addr *int64, delta int64, increase bool) {
+func atomicallyAddInt64(addr *int64, delta int64, increase bool) {
 	if increase {
 		atomic.AddInt64(addr, delta)
 	} else {
@@ -139,7 +139,7 @@ func AtomicallyAddInt64(addr *int64, delta int64, increase bool) {
 // addr     - Pointer to uint64 variable
 // delta    - The change to do
 // increase - True to increment, false to decrement
-func AtomicallyAddUint64(addr *uint64, delta uint64, increase bool) {
+func atomicallyAddUint64(addr *uint64, delta uint64, increase bool) {
 	if increase {
 		atomic.AddUint64(addr, delta)
 	} else {

--- a/artifactory/commands/transferfiles/state/utils.go
+++ b/artifactory/commands/transferfiles/state/utils.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/jfrog/build-info-go/utils"
@@ -120,4 +121,28 @@ func GetOldTransferDirectoryStructureError() error {
 		return err
 	}
 	return errorutils.CheckErrorf(oldTransferDirectoryStructureErrorFormat, transferDir)
+}
+
+// Atomically add to an int64 variable.
+// addr     - Pointer to int64 variable
+// delta    - The change to do
+// increase - True to increment, false to decrement
+func AtomicallyAddInt64(addr *int64, delta int64, increase bool) {
+	if increase {
+		atomic.AddInt64(addr, delta)
+	} else {
+		atomic.AddInt64(addr, -delta)
+	}
+}
+
+// Atomically add to an uint64 variable.
+// addr     - Pointer to uint64 variable
+// delta    - The change to do
+// increase - True to increment, false to decrement
+func AtomicallyAddUint64(addr *uint64, delta uint64, increase bool) {
+	if increase {
+		atomic.AddUint64(addr, delta)
+	} else {
+		atomic.AddUint64(addr, ^(delta - 1))
+	}
 }

--- a/artifactory/commands/transferfiles/status.go
+++ b/artifactory/commands/transferfiles/status.go
@@ -80,7 +80,7 @@ func addOverallStatus(stateManager *state.TransferStateManager, output *strings.
 	addString(output, "🧵", "Working threads", strconv.Itoa(stateManager.WorkingThreads), 2)
 	addString(output, "⚡", "Transfer speed", stateManager.GetSpeedString(), 2)
 	addString(output, "⌛", "Estimated time remaining", stateManager.GetEstimatedRemainingTimeString(), 1)
-	failureTxt := strconv.FormatUint(uint64(stateManager.TransferFailures), 10)
+	failureTxt := strconv.FormatUint(stateManager.TransferFailures, 10)
 	if stateManager.TransferFailures > 0 {
 		failureTxt += " (" + progressbar.RetryFailureContentNote + ")"
 	}

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -236,7 +236,7 @@ func (tdc *TransferFilesCommand) initStateManager(allSourceLocalRepos, sourceBui
 		if e != nil {
 			return e
 		}
-		tdc.stateManager.TransferFailures = uint(numberInitialErrors)
+		tdc.stateManager.TransferFailures = uint64(numberInitialErrors)
 
 		numberInitialDelays, e := getDelayedFilesCount(allSourceLocalRepos)
 		if e != nil {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Concurrent updates to state variables in certain scenarios can lead to inaccuracies, causing unexpected behaviors. An instance highlighting this concern involves a "negative" value within the "Delayed files" category:

![image](https://github.com/jfrog/jfrog-cli-core/assets/11367982/ed751f87-ece8-4734-916f-338b46d93052)

The objective of this pull request is to improve accuracy by adjusting these values using the native `atomic` package.