### PR TITLE
Transfer - Generate a thread dump before a graceful stop

### DIFF
--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -516,6 +516,10 @@ func (tdc *TransferFilesCommand) handleStop(srcUpService *srcUserPluginService) 
 			// The stopSignal channel is closed
 			return
 		}
+		// Before interrupting the process, do a thread dump
+		if err := doThreadDump(); err != nil {
+			log.Error(err)
+		}
 		tdc.cancelFunc()
 		if newPhase != nil {
 			newPhase.StopGracefully()
@@ -808,4 +812,15 @@ func parseErrorsFromLogFiles(logPaths []string) (allErrors FilesErrors, err erro
 
 func assertSupportedTransferDirStructure() error {
 	return state.VerifyTransferRunStatusVersion()
+}
+
+func doThreadDump() error {
+	log.Info("Starting thread dumping...")
+	threadDump, err := coreutils.NewProfiler().ThreadDump()
+	if err != nil {
+		return err
+	}
+	log.Info(threadDump)
+	log.Info("Thread dump ended successfully")
+	return nil
 }

--- a/artifactory/utils/weblogin.go
+++ b/artifactory/utils/weblogin.go
@@ -32,7 +32,7 @@ func DoWebLogin(serverDetails *config.ServerDetails) (token auth.CommonTokenPara
 				"Make sure the details you entered are correct and that Artifactory meets the version requirement."))
 		return
 	}
-	log.Info("After logging in via your web browser, please enter the code if prompted: "+uuidStr[len(uuidStr)-4:])
+	log.Info("After logging in via your web browser, please enter the code if prompted: " + uuidStr[len(uuidStr)-4:])
 	if err = browser.OpenURL(clientUtils.AddTrailingSlashIfNeeded(serverDetails.Url) + "ui/login?jfClientSession=" + uuidStr + "&jfClientName=JFrog-CLI&jfClientCode=1"); err != nil {
 		return
 	}

--- a/utils/coreutils/profiler.go
+++ b/utils/coreutils/profiler.go
@@ -1,0 +1,86 @@
+package coreutils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"time"
+
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+)
+
+const (
+	defaultInterval    = time.Second
+	defaultRepetitions = 3
+)
+
+type Profiler struct {
+	interval    time.Duration
+	repetitions uint
+}
+
+type ProfilerOption func(*Profiler)
+
+func NewProfiler(opts ...ProfilerOption) *Profiler {
+	profiler := &Profiler{
+		interval:    defaultInterval,
+		repetitions: defaultRepetitions,
+	}
+	for _, opt := range opts {
+		opt(profiler)
+	}
+	return profiler
+}
+
+func WithInterval(interval time.Duration) ProfilerOption {
+	return func(p *Profiler) {
+		p.interval = interval
+	}
+}
+
+func WithRepetitions(repetitions uint) ProfilerOption {
+	return func(p *Profiler) {
+		p.repetitions = repetitions
+	}
+}
+
+func (p *Profiler) ThreadDump() (output string, err error) {
+	var outputFilePath string
+	if outputFilePath, err = p.threadDumpToFile(); err != nil {
+		return
+	}
+	defer func() {
+		err = errors.Join(err, os.Remove(outputFilePath))
+	}()
+	return p.convertFileToString(outputFilePath)
+}
+
+func (p *Profiler) threadDumpToFile() (outputFilePath string, err error) {
+	outputFile, err := fileutils.CreateTempFile()
+	if err != nil {
+		return
+	}
+	defer func() {
+		err = errors.Join(err, outputFile.Close())
+	}()
+
+	for i := 0; i < int(p.repetitions); i++ {
+		fmt.Fprintf(outputFile, "========== Thread dump #%d ==========\n", i)
+		prof := pprof.Lookup("goroutine")
+		if err = prof.WriteTo(outputFile, 1); err != nil {
+			return
+		}
+		time.Sleep(p.interval)
+	}
+	return outputFile.Name(), nil
+}
+
+func (p *Profiler) convertFileToString(outputFilePath string) (output string, err error) {
+	var outputBytes []byte
+	if outputBytes, err = os.ReadFile(outputFilePath); err != nil {
+		return
+	}
+	output = string(outputBytes)
+	return
+}

--- a/utils/coreutils/profiler_test.go
+++ b/utils/coreutils/profiler_test.go
@@ -1,0 +1,57 @@
+package coreutils
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThreadDump(t *testing.T) {
+	// Create default profiler
+	profiler := NewProfiler()
+
+	// Start a thread that sleeps
+	go func() {
+		dummyZzzz()
+	}()
+
+	// Run thread dump
+	output, err := profiler.ThreadDump()
+	assert.NoError(t, err)
+
+	// Check results
+	assert.Contains(t, output, "Thread dump #0")
+	assert.Contains(t, output, "Thread dump #1")
+	assert.Contains(t, output, "Thread dump #2")
+	assert.Contains(t, output, "dummyZzzz")
+}
+
+func TestThreadInterval(t *testing.T) {
+	// Create profiler with 10 repetitions and 10ms intervals
+	var expectedRepetitions uint = 10
+	var expectedInterval = 10 * time.Millisecond
+	profiler := NewProfiler(WithInterval(expectedInterval), WithRepetitions(expectedRepetitions))
+
+	// Check that the required values are set
+	assert.Equal(t, profiler.interval, expectedInterval)
+	assert.Equal(t, profiler.repetitions, expectedRepetitions)
+
+	// start measure the time
+	start := time.Now()
+
+	// Run thread dump
+	output, err := profiler.ThreadDump()
+	assert.NoError(t, err)
+
+	// Ensure duration less than 1 second
+	assert.WithinDuration(t, start, time.Now(), time.Second)
+
+	// Ensure 10 repetitions
+	assert.Contains(t, output, "Thread dump #"+strconv.FormatUint(uint64(expectedRepetitions)-1, 10))
+}
+
+func dummyZzzz() {
+	time.Sleep(2 * time.Second)
+}

--- a/utils/coreutils/profiler_test.go
+++ b/utils/coreutils/profiler_test.go
@@ -52,6 +52,7 @@ func TestThreadInterval(t *testing.T) {
 	assert.Contains(t, output, "Thread dump #"+strconv.FormatUint(uint64(expectedRepetitions)-1, 10))
 }
 
+// In the thread dump test, we look for this function name in the output to ensure that functions executed in goroutines are recorded.
 func dummyZzzz() {
 	time.Sleep(2 * time.Second)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Example output:
```
2023/12/14 18:12:57 [Info] ========== Running 'Full Transfer Phase' for repo 'docker-local-big2'... ==========
2023/12/14 18:13:17 [Info] Starting thread dumping...
2023/12/14 18:13:20 [Info] ========== Thread dump #0 ==========
goroutine profile: total 60
16 @ 0x103c7ce 0x104c2e5 0x191013d 0x106cce1
#       0x191013c       github.com/vbauerster/mpb/v7.(*Bar).serve+0x17c /Users/yahavi/go/pkg/mod/github.com/vbauerster/mpb/v7@v7.5.3/bar.go:347

8 @ 0x103c7ce 0x1069e25 0x1954ede 0x1941790 0x16de2a2 0x106cce1
#       0x1069e24       time.Sleep+0x124                                                                                                                                        /usr/local/Cellar/go/1.21.5/libexec/src/runtime/time.go:195
#       0x1954edd       github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.uploadChunkWhenPossible+0x3d                                                      /Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/t
ransferfiles/utils.go:238
#       0x194178f       github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles.(*fullTransferPhase).transferFolder.uploadChunkWhenPossibleHandler.func3+0x12f    /Users/yahavi/code/cli/jfrog-cli-core/artifactory/commands/t
ransferfiles/utils.go:412
#       0x16de2a1       github.com/jfrog/gofrog/parallel.(*runner).addThread.func1+0x141                                                                                        /Users/yahavi/code/cli/gofrog/parallel/runner.go:244

4 @ 0x103c7ce 0x100952d 0x1009132 0x12f9eb9 0x12fabbc 0x12f951f 0x106cce1
#       0x12f9eb8       net/http.(*persistConn).addTLS+0x338    /usr/local/Cellar/go/1.21.5/libexec/src/net/http/transport.go:1561
#       0x12fabbb       net/http.(*Transport).dialConn+0x99b    /usr/local/Cellar/go/1.21.5/libexec/src/net/http/transport.go:1635
#       0x12f951e       net/http.(*Transport).dialConnFor+0x9e  /usr/local/Cellar/go/1.21.5/libexec/src/net/http/transport.go:1467

4 @ 0x103c7ce 0x1035bf7 0x1066e25 0x10d8587 0x10d987a 0x10d9868 0x12045a5 0x1210ce5 0x125ebbb 0x10fbf38 0x125ed9e 0x125c370 0x12605b1 0x12605b2 0x1260639 0x12652cb 0x1263133 0x12fa14d 0x12fa14e 0x106cce1
#       0x1066e24       internal/poll.runtime_pollWait+0x84             /usr/local/Cellar/go/1.21.5/libexec/src/runtime/netpoll.go:343
#       0x10d8586       internal/poll.(*pollDesc).wait+0x26             /usr/local/Cellar/go/1.21.5/libexec/src/internal/poll/fd_poll_runtime.go:84
#       0x10d9879       internal/poll.(*pollDesc).waitRead+0x279        /usr/local/Cellar/go/1.21.5/libexec/src/internal/poll/fd_poll_runtime.go:89
#       0x10d9867       internal/poll.(*FD).Read+0x267                  /usr/local/Cellar/go/1.21.5/libexec/src/internal/poll/fd_unix.go:164
#       0x12045a4       net.(*netFD).Read+0x24                          /usr/local/Cellar/go/1.21.5/libexec/src/net/fd_posix.go:55
#       0x1210ce4       net.(*conn).Read+0x44                           /usr/local/Cellar/go/1.21.5/libexec/src/net/net.go:179
#       0x125ebba       crypto/tls.(*atLeastReader).Read+0x3a           /usr/local/Cellar/go/1.21.5/libexec/src/crypto/tls/conn.go:805
#       0x10fbf37       bytes.(*Buffer).ReadFrom+0x97                   /usr/local/Cellar/go/1.21.5/libexec/src/bytes/buffer.go:211
#       0x125ed9d       crypto/tls.(*Conn).readFromUntil+0xdd           /usr/local/Cellar/go/1.21.5/libexec/src/crypto/tls/conn.go:827
#       0x125c36f       crypto/tls.(*Conn).readRecordOrCCS+0x24f        /usr/local/Cellar/go/1.21.5/libexec/src/crypto/tls/conn.go:625
#       0x12605b0       crypto/tls.(*Conn).readRecord+0x50              /usr/local/Cellar/go/1.21.5/libexec/src/crypto/tls/conn.go:587
#       0x12605b1       crypto/tls.(*Conn).readHandshakeBytes+0x51      /usr/local/Cellar/go/1.21.5/libexec/src/crypto/tls/conn.go:1074
#       0x1260638       crypto/tls.(*Conn).readHandshake+0x38           /usr/local/Cellar/go/1.21.5/libexec/src/crypto/tls/conn.go:1085
#       0x12652ca       crypto/tls.(*Conn).clientHandshake+0x28a        /usr/local/Cellar/go/1.21.5/libexec/src/crypto/tls/handshake_client.go:223
#       0x1263132       crypto/tls.(*Conn).handshakeContext+0x3d2       /usr/local/Cellar/go/1.21.5/libexec/src/crypto/tls/conn.go:1552
#       0x12fa14c       crypto/tls.(*Conn).HandshakeContext+0x6c        /usr/local/Cellar/go/1.21.5/libexec/src/crypto/tls/conn.go:1492
#       0x12fa14d       net/http.(*persistConn).addTLS.func2+0x6d       /usr/local/Cellar/go/1.21.5/libexec/src/net/http/transport.go:1555

...
```