### PR TITLE
Transfer - The runProducerConsumers method might terminate prematurely

### DIFF
--- a/artifactory/commands/transferfiles/manager.go
+++ b/artifactory/commands/transferfiles/manager.go
@@ -238,6 +238,10 @@ func runProducerConsumers(pcWrapper *producerConsumerWrapper) (executionErr erro
 	// Run() is a blocking method, so once all chunk builders are idle, the tasks queue closes and Run() stops running.
 	pcWrapper.chunkBuilderProducerConsumer.Run()
 	if pcWrapper.chunkUploaderProducerConsumer.IsStarted() {
+		// There might be a moment when the chunk uploader has no upload tasks.
+		// This circumstance might lead to setting the finish notification before completing all file uploads.
+		// To address this, we reset the finish notification to ensure no remaining upload tasks after the next finish notification.
+		pcWrapper.chunkUploaderProducerConsumer.ResetFinishNotification()
 		// Wait till notified that the uploader finished its tasks, and it will not receive new tasks from the builder.
 		<-pcWrapper.chunkUploaderProducerConsumer.GetFinishedNotification()
 	}

--- a/artifactory/commands/transferfiles/manager.go
+++ b/artifactory/commands/transferfiles/manager.go
@@ -241,9 +241,10 @@ func runProducerConsumers(pcWrapper *producerConsumerWrapper) (executionErr erro
 		// There might be a moment when the chunk uploader has no upload tasks.
 		// This circumstance might lead to setting the finish notification before completing all file uploads.
 		// To address this, we reset the finish notification to ensure no remaining upload tasks after the next finish notification.
-		pcWrapper.chunkUploaderProducerConsumer.ResetFinishNotification()
+		pcWrapper.chunkUploaderProducerConsumer.ResetFinishNotificationIfActive()
 		// Wait till notified that the uploader finished its tasks, and it will not receive new tasks from the builder.
 		<-pcWrapper.chunkUploaderProducerConsumer.GetFinishedNotification()
+		log.Debug("Chunk uploaded producer consumer has completed all tasks. All files relevant to this phase have all been uploaded.")
 	}
 	// Close the tasks queue with Done().
 	pcWrapper.chunkUploaderProducerConsumer.Done()

--- a/artifactory/commands/transferfiles/manager_test.go
+++ b/artifactory/commands/transferfiles/manager_test.go
@@ -14,7 +14,7 @@ func TestRunProducerConsumers(t *testing.T) {
 	// Add 10 tasks for the chunkBuilderProducerConsumer. Each task provides a task to the chunkUploaderProducerConsumer.
 	for i := 0; i < 10; i++ {
 		_, err := producerConsumerWrapper.chunkBuilderProducerConsumer.AddTask(func(int) error {
-			time.Sleep(time.Millisecond)
+			time.Sleep(time.Millisecond * 100)
 			_, err := producerConsumerWrapper.chunkUploaderProducerConsumer.AddTask(
 				func(int) error {
 					time.Sleep(time.Millisecond)

--- a/artifactory/commands/transferfiles/manager_test.go
+++ b/artifactory/commands/transferfiles/manager_test.go
@@ -1,0 +1,37 @@
+package transferfiles
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunProducerConsumers(t *testing.T) {
+	// Create the producer-consumers
+	producerConsumerWrapper := newProducerConsumerWrapper()
+
+	// Add 10 tasks for the chunkBuilderProducerConsumer. Each task provides a task to the chunkUploaderProducerConsumer.
+	for i := 0; i < 10; i++ {
+		_, err := producerConsumerWrapper.chunkBuilderProducerConsumer.AddTask(func(int) error {
+			time.Sleep(time.Millisecond)
+			_, err := producerConsumerWrapper.chunkUploaderProducerConsumer.AddTask(
+				func(int) error {
+					time.Sleep(time.Millisecond)
+					return nil
+				},
+			)
+			assert.NoError(t, err)
+			return nil
+		})
+		assert.NoError(t, err)
+	}
+
+	// Run the producer-consumers
+	err := runProducerConsumers(&producerConsumerWrapper)
+	assert.NoError(t, err)
+
+	// Assert no active treads left in the producer-consumers
+	assert.Zero(t, producerConsumerWrapper.chunkBuilderProducerConsumer.ActiveThreads())
+	assert.Zero(t, producerConsumerWrapper.chunkUploaderProducerConsumer.ActiveThreads())
+}

--- a/go.mod
+++ b/go.mod
@@ -103,4 +103,4 @@ require (
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20231220102935-c8776c613ad8
 
-replace github.com/jfrog/gofrog => github.com/yahavi/gofrog v1.2.1-0.20231223070252-e0b1ba98592f
+replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.3.3-0.20231223133729-ef57bd08cedc

--- a/go.mod
+++ b/go.mod
@@ -103,4 +103,4 @@ require (
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20231220102935-c8776c613ad8
 
-replace github.com/jfrog/gofrog => github.com/yahavi/gofrog v1.2.1-0.20231222163403-25275913704c
+replace github.com/jfrog/gofrog => github.com/yahavi/gofrog v1.2.1-0.20231223070252-e0b1ba98592f

--- a/go.mod
+++ b/go.mod
@@ -103,4 +103,4 @@ require (
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20231220102935-c8776c613ad8
 
-// replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.3.2-0.20231130091721-6d742be8bc7a
+replace github.com/jfrog/gofrog => github.com/yahavi/gofrog v1.2.1-0.20231222163403-25275913704c

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,6 @@ github.com/jedib0t/go-pretty/v6 v6.4.0 h1:YlI/2zYDrweA4MThiYMKtGRfT+2qZOO65ulej8
 github.com/jedib0t/go-pretty/v6 v6.4.0/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/jfrog/build-info-go v1.9.18 h1:0RKeZtNWZjONX5j94aIPQSKMi1whP2evmGQymYF+5mA=
 github.com/jfrog/build-info-go v1.9.18/go.mod h1:/5VZXH2Ud0IK3cOFwPykjwPOaEcHhzzbjnRiou+YKpM=
-github.com/jfrog/gofrog v1.3.2 h1:TktKP+PdZdxjkYZxWWIq4DkTGSYtr9Slsy+egZpEhUY=
-github.com/jfrog/gofrog v1.3.2/go.mod h1:AQo5Fq0G9nDEF6icH7MYQK0iohR4HuEAXl8jaxRuT6Q=
 github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYLipdsOFMY=
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-client-go v1.35.3 h1:Kf4mErh1tlbHzKz3941+d9vpEsPM2clgdOaYOKfNQGI=
@@ -215,6 +213,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
+github.com/yahavi/gofrog v1.2.1-0.20231222163403-25275913704c h1:fO9byq1NztYLMyB8B26aa2MfxvUdNdWUO9Yu6SAzdRI=
+github.com/yahavi/gofrog v1.2.1-0.20231222163403-25275913704c/go.mod h1:AQo5Fq0G9nDEF6icH7MYQK0iohR4HuEAXl8jaxRuT6Q=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
-github.com/yahavi/gofrog v1.2.1-0.20231222163403-25275913704c h1:fO9byq1NztYLMyB8B26aa2MfxvUdNdWUO9Yu6SAzdRI=
-github.com/yahavi/gofrog v1.2.1-0.20231222163403-25275913704c/go.mod h1:AQo5Fq0G9nDEF6icH7MYQK0iohR4HuEAXl8jaxRuT6Q=
+github.com/yahavi/gofrog v1.2.1-0.20231223070252-e0b1ba98592f h1:BpQH2P4BQdHG1BGPpxguZrbQxYpWh0dvJTUpZHbYFH4=
+github.com/yahavi/gofrog v1.2.1-0.20231223070252-e0b1ba98592f/go.mod h1:AQo5Fq0G9nDEF6icH7MYQK0iohR4HuEAXl8jaxRuT6Q=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/jedib0t/go-pretty/v6 v6.4.0 h1:YlI/2zYDrweA4MThiYMKtGRfT+2qZOO65ulej8
 github.com/jedib0t/go-pretty/v6 v6.4.0/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/jfrog/build-info-go v1.9.18 h1:0RKeZtNWZjONX5j94aIPQSKMi1whP2evmGQymYF+5mA=
 github.com/jfrog/build-info-go v1.9.18/go.mod h1:/5VZXH2Ud0IK3cOFwPykjwPOaEcHhzzbjnRiou+YKpM=
+github.com/jfrog/gofrog v1.3.3-0.20231223133729-ef57bd08cedc h1:aKVJSydPVBhJkEncWM9Vc66lM2slRDG/4ILXERKewJ0=
+github.com/jfrog/gofrog v1.3.3-0.20231223133729-ef57bd08cedc/go.mod h1:AQo5Fq0G9nDEF6icH7MYQK0iohR4HuEAXl8jaxRuT6Q=
 github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYLipdsOFMY=
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-client-go v1.35.3 h1:Kf4mErh1tlbHzKz3941+d9vpEsPM2clgdOaYOKfNQGI=
@@ -213,8 +215,6 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
-github.com/yahavi/gofrog v1.2.1-0.20231223070252-e0b1ba98592f h1:BpQH2P4BQdHG1BGPpxguZrbQxYpWh0dvJTUpZHbYFH4=
-github.com/yahavi/gofrog v1.2.1-0.20231223070252-e0b1ba98592f/go.mod h1:AQo5Fq0G9nDEF6icH7MYQK0iohR4HuEAXl8jaxRuT6Q=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Depends on https://github.com/jfrog/gofrog/pull/42.
Tests: https://github.com/jfrog/jfrog-cli/pull/2384.
At times, the chunk uploader might have no upload tasks, resulting in setting the finish notification before all file uploads are completed. This could cause the runProducerConsumers to exit prematurely without finishing the uploading jobs.

When tasks are present in the queue without a polling task manager, it may lead to an increase in curProcessedUploadChunks without a corresponding decrease. This situation can escalate, especially when there are enough future upload tasks, potentially causing a deadlock by increasing curProcessedUploadChunks to the maximum number of allowed worker threads.

To resolve this, we reset the finish notification to ensure no remaining upload tasks after the subsequent finish notification.