### PR TITLE
Transfer - Attempt to transfer ".jfrog" directory in Docker repositories

### DIFF
--- a/artifactory/commands/transferfiles/localgeneratedfilter.go
+++ b/artifactory/commands/transferfiles/localgeneratedfilter.go
@@ -160,5 +160,8 @@ func (lg *locallyGeneratedFilter) getNonLocallyGeneratedResults(aqlResultItems [
 }
 
 func getPathInRepo(aqlResultItem *utils.ResultItem) string {
+	if aqlResultItem.Path == "." {
+		return aqlResultItem.Name
+	}
 	return aqlResultItem.Path + "/" + aqlResultItem.Name
 }

--- a/artifactory/commands/transferfiles/localgeneratedfilter_test.go
+++ b/artifactory/commands/transferfiles/localgeneratedfilter_test.go
@@ -22,6 +22,7 @@ var filterLocallyGeneratedCases = []struct {
 	{paths: []utils.ResultItem{{Path: "a", Name: "b"}}, returnedPath: []string{"a/b"}},
 	{paths: []utils.ResultItem{{Path: "a", Name: "b"}, {Path: "a/b", Name: "e"}}, returnedPath: []string{"a/b/e"}},
 	{paths: []utils.ResultItem{{Path: "a", Name: "b"}, {Path: "a/b", Name: "e"}}, returnedPath: []string{"a/b", "a/b/e"}},
+	{paths: []utils.ResultItem{{Path: ".", Name: "a"}, {Path: "b", Name: "c"}}, returnedPath: []string{"b/c"}},
 }
 
 func TestFilterLocallyGenerated(t *testing.T) {
@@ -98,4 +99,21 @@ func TestFilterLocallyGeneratedEnabled(t *testing.T) {
 	assert.True(t, NewLocallyGenerated(context.Background(), servicesManager, "8.0.0").IsEnabled())
 	assert.False(t, NewLocallyGenerated(context.Background(), servicesManager, "7.54.5").IsEnabled())
 	assert.False(t, NewLocallyGenerated(context.Background(), servicesManager, "6.0.0").IsEnabled())
+}
+
+var getPathInRepoCases = []struct {
+	aqlResultItem      utils.ResultItem
+	expectedPathInRepo string
+}{
+	{aqlResultItem: utils.ResultItem{Path: ".", Name: "a"}, expectedPathInRepo: "a"},
+	{aqlResultItem: utils.ResultItem{Path: "a", Name: "b"}, expectedPathInRepo: "a/b"},
+}
+
+func TestGetPathInRepo(t *testing.T) {
+	for _, testCase := range getPathInRepoCases {
+		t.Run("", func(t *testing.T) {
+			aqlResultsItem := testCase.aqlResultItem
+			assert.Equal(t, testCase.expectedPathInRepo, getPathInRepo(&aqlResultsItem))
+		})
+	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Certain files, locally generated in Artifactory, shouldn't be transferred.
The `.jfrog` directory, unintentionally included in Docker repository transfers, is triggering errors documented in a CSV file:
```csv
docker-local,.jfrog,,0,false,0,false,FAIL,404,,2023-12-21T16:31:01Z
```

The central cause of the transfer issues stemmed from an incorrect path specification within the locally generated API call. The path `./.jfrog` was inadvertently used, whereas the accurate path should have been solely `.jfrog`. This discrepancy led to the errors encountered.