### PR TITLE
Fix memory & time explosion during dependency tree construction for java based projects

### DIFF
--- a/xray/commands/audit/sca/java/deptreemanager.go
+++ b/xray/commands/audit/sca/java/deptreemanager.go
@@ -90,23 +90,6 @@ func getGraphFromDepTree(outputFilePaths string) (depsGraph []*xrayUtils.GraphNo
 	return
 }
 
-func populateDependencyTree(currNode *xrayUtils.GraphNode, currNodeId string, moduleTree *moduleDepTree, uniqueDepsSet *datastructures.Set[string]) {
-	if currNode.NodeHasLoop() {
-		return
-	}
-	for _, childId := range moduleTree.Nodes[currNodeId].Children {
-		childGav := GavPackageTypeIdentifier + childId
-		childNode := &xrayUtils.GraphNode{
-			Id:     childGav,
-			Nodes:  []*xrayUtils.GraphNode{},
-			Parent: currNode,
-		}
-		uniqueDepsSet.Add(childGav)
-		populateDependencyTree(childNode, childId, moduleTree, uniqueDepsSet)
-		currNode.Nodes = append(currNode.Nodes, childNode)
-	}
-}
-
 func parseDepTreeFiles(jsonFilePaths string) ([]*moduleDepTree, error) {
 	outputFilePaths := strings.Split(strings.TrimSpace(jsonFilePaths), "\n")
 	var modules []*moduleDepTree

--- a/xray/commands/audit/sca/java/deptreemanager.go
+++ b/xray/commands/audit/sca/java/deptreemanager.go
@@ -78,7 +78,9 @@ func getGraphFromDepTree(outputFilePaths string) (depsGraph []*xrayUtils.GraphNo
 				childId := GavPackageTypeIdentifier + childName
 				childrenList = append(childrenList, childId)
 			}
-			moduleTreeMap[dependencyId] = childrenList
+			if len(childrenList) > 0 {
+				moduleTreeMap[dependencyId] = childrenList
+			}
 		}
 		moduleTree, moduleUniqueDeps := sca.BuildXrayDependencyTree(moduleTreeMap, GavPackageTypeIdentifier+module.Root)
 		depsGraph = append(depsGraph, moduleTree)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

This PR fixes the bug of memory & time explosion while constructing Gradle/ Maven dependencies tree in big projects
A limitation to the number of impact paths per dependency was set to 10 (per project's module)