### PR TITLE
Join error on GetRepoConfigByPrefix

### DIFF
--- a/common/project/projectconfig.go
+++ b/common/project/projectconfig.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -128,11 +129,11 @@ func GetProjectConfFilePath(projectType ProjectType) (confFilePath string, exist
 func GetRepoConfigByPrefix(configFilePath, prefix string, vConfig *viper.Viper) (repoConfig *RepositoryConfig, err error) {
 	defer func() {
 		if err != nil {
-			err = fmt.Errorf("%s\nPlease run 'jf %s-config' with your %s repository information",
+			err = errors.Join(err, fmt.Errorf("%s\nPlease run 'jf %s-config' with your %s repository information",
 				err.Error(),
 				vConfig.GetString("type"),
 				prefix,
-			)
+			))
 		}
 	}()
 	if !vConfig.IsSet(prefix) {

--- a/common/project/projectconfig.go
+++ b/common/project/projectconfig.go
@@ -129,11 +129,7 @@ func GetProjectConfFilePath(projectType ProjectType) (confFilePath string, exist
 func GetRepoConfigByPrefix(configFilePath, prefix string, vConfig *viper.Viper) (repoConfig *RepositoryConfig, err error) {
 	defer func() {
 		if err != nil {
-			err = errors.Join(err, fmt.Errorf("%s\nPlease run 'jf %s-config' with your %s repository information",
-				err.Error(),
-				vConfig.GetString("type"),
-				prefix,
-			))
+			err = errors.Join(err, fmt.Errorf("please run 'jf %s-config' with your %s repository information", vConfig.GetString("type"), prefix))
 		}
 	}()
 	if !vConfig.IsSet(prefix) {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

When refactoring the code to another location `GetRepoConfigByPrefix` was changed and did not join the errors by mistake.
https://github.com/jfrog/jfrog-cli-core/commit/8e451d1cd6d5a7703f4851f1b840ab386ab97106#diff-374058d0b4f3d0f1fc734af2925a8e92e53a4f18e4372f5f7b34cf3864f5c6fcL129
return the join for the errors.