### PR TITLE
Artifactory Release Lifecycle Management - Modify release bundle promotion properties

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/RobiNino/jfrog-client-go v0.0.0-20240201120059-8ed7b43c770f
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240201133918-82ad9eb51c3f
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20231220102935-c8776c613ad8
 

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240122123649-74f725715bbe
+replace github.com/jfrog/jfrog-client-go => github.com/RobiNino/jfrog-client-go v0.0.0-20240201120059-8ed7b43c770f
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20231220102935-c8776c613ad8
 

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
-github.com/RobiNino/jfrog-client-go v0.0.0-20240201120059-8ed7b43c770f h1:M/xVZfo0OGLljA9WhtS2b+plvMJPuK2Qr/4lSggPacs=
-github.com/RobiNino/jfrog-client-go v0.0.0-20240201120059-8ed7b43c770f/go.mod h1:y1WF6eiZ7V2DortiwjpMEicEH6NIJH+hOXI5QI2W3NU=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -88,6 +86,8 @@ github.com/jfrog/build-info-go v1.9.21 h1:bcD0SEC2lEilhjE+aDB3xlvA8zsr4Kw/bFzvr9
 github.com/jfrog/build-info-go v1.9.21/go.mod h1:Vxv6zmx4e1NWsx40OHaDWCCYDeYAq2yXzpJ4nsDChbE=
 github.com/jfrog/gofrog v1.5.1 h1:2AXL8hHu1jJFMIoCqTp2OyRUfEqEp4nC7J8fwn6KtwE=
 github.com/jfrog/gofrog v1.5.1/go.mod h1:SZ1EPJUruxrVGndOzHd+LTiwWYKMlHqhKD+eu+v5Hqg=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20240201133918-82ad9eb51c3f h1:mbWuP+LpyOKJI7FLFdauGG0SEQQ6KcoA4CwOAgsiYg8=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20240201133918-82ad9eb51c3f/go.mod h1:y1WF6eiZ7V2DortiwjpMEicEH6NIJH+hOXI5QI2W3NU=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
+github.com/RobiNino/jfrog-client-go v0.0.0-20240201120059-8ed7b43c770f h1:M/xVZfo0OGLljA9WhtS2b+plvMJPuK2Qr/4lSggPacs=
+github.com/RobiNino/jfrog-client-go v0.0.0-20240201120059-8ed7b43c770f/go.mod h1:y1WF6eiZ7V2DortiwjpMEicEH6NIJH+hOXI5QI2W3NU=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -86,8 +88,6 @@ github.com/jfrog/build-info-go v1.9.21 h1:bcD0SEC2lEilhjE+aDB3xlvA8zsr4Kw/bFzvr9
 github.com/jfrog/build-info-go v1.9.21/go.mod h1:Vxv6zmx4e1NWsx40OHaDWCCYDeYAq2yXzpJ4nsDChbE=
 github.com/jfrog/gofrog v1.5.1 h1:2AXL8hHu1jJFMIoCqTp2OyRUfEqEp4nC7J8fwn6KtwE=
 github.com/jfrog/gofrog v1.5.1/go.mod h1:SZ1EPJUruxrVGndOzHd+LTiwWYKMlHqhKD+eu+v5Hqg=
-github.com/jfrog/jfrog-client-go v1.36.0 h1:iODLDjYSlK7rLH8/lEmAFHwYsboeBfaqxXybz6waraE=
-github.com/jfrog/jfrog-client-go v1.36.0/go.mod h1:y1WF6eiZ7V2DortiwjpMEicEH6NIJH+hOXI5QI2W3NU=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=

--- a/lifecycle/common.go
+++ b/lifecycle/common.go
@@ -19,7 +19,8 @@ type releaseBundleCmd struct {
 	rbProjectKey         string
 }
 
-func (rbc *releaseBundleCmd) getPrerequisites() (servicesManager *lifecycle.LifecycleServicesManager, rbDetails services.ReleaseBundleDetails, params services.CreateOrPromoteReleaseBundleParams, err error) {
+func (rbc *releaseBundleCmd) getPrerequisites() (servicesManager *lifecycle.LifecycleServicesManager,
+	rbDetails services.ReleaseBundleDetails, queryParams services.CommonOptionalQueryParams, err error) {
 	servicesManager, err = utils.CreateLifecycleServiceManager(rbc.serverDetails, false)
 	if err != nil {
 		return
@@ -28,12 +29,9 @@ func (rbc *releaseBundleCmd) getPrerequisites() (servicesManager *lifecycle.Life
 		ReleaseBundleName:    rbc.releaseBundleName,
 		ReleaseBundleVersion: rbc.releaseBundleVersion,
 	}
-	params = services.CreateOrPromoteReleaseBundleParams{
-		ReleaseBundleQueryParams: services.ReleaseBundleQueryParams{
-			ProjectKey: rbc.rbProjectKey,
-			Async:      !rbc.sync,
-		},
-		SigningKeyName: rbc.signingKeyName,
+	queryParams = services.CommonOptionalQueryParams{
+		ProjectKey: rbc.rbProjectKey,
+		Async:      !rbc.sync,
 	}
 	return
 }

--- a/lifecycle/createcommon.go
+++ b/lifecycle/createcommon.go
@@ -67,13 +67,13 @@ func (rbc *ReleaseBundleCreateCommand) Run() error {
 		return err
 	}
 
-	servicesManager, rbDetails, params, err := rbc.getPrerequisites()
+	servicesManager, rbDetails, queryParams, err := rbc.getPrerequisites()
 	if err != nil {
 		return err
 	}
 
 	if rbc.buildsSpecPath != "" {
-		return rbc.createFromBuilds(servicesManager, rbDetails, params)
+		return rbc.createFromBuilds(servicesManager, rbDetails, queryParams)
 	}
-	return rbc.createFromReleaseBundles(servicesManager, rbDetails, params)
+	return rbc.createFromReleaseBundles(servicesManager, rbDetails, queryParams)
 }

--- a/lifecycle/createfrombuilds.go
+++ b/lifecycle/createfrombuilds.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (rbc *ReleaseBundleCreateCommand) createFromBuilds(servicesManager *lifecycle.LifecycleServicesManager,
-	rbDetails services.ReleaseBundleDetails, params services.CreateOrPromoteReleaseBundleParams) error {
+	rbDetails services.ReleaseBundleDetails, queryParams services.CommonOptionalQueryParams) error {
 
 	builds := CreateFromBuildsSpec{}
 	content, err := fileutils.ReadFile(rbc.buildsSpecPath)
@@ -31,7 +31,7 @@ func (rbc *ReleaseBundleCreateCommand) createFromBuilds(servicesManager *lifecyc
 	if err != nil {
 		return err
 	}
-	return servicesManager.CreateReleaseBundleFromBuilds(rbDetails, params, buildsSource)
+	return servicesManager.CreateReleaseBundleFromBuilds(rbDetails, queryParams, rbc.signingKeyName, buildsSource)
 }
 
 func (rbc *ReleaseBundleCreateCommand) convertToBuildsSource(builds CreateFromBuildsSpec) (services.CreateFromBuildsSource, error) {

--- a/lifecycle/createfrombundles.go
+++ b/lifecycle/createfrombundles.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (rbc *ReleaseBundleCreateCommand) createFromReleaseBundles(servicesManager *lifecycle.LifecycleServicesManager,
-	rbDetails services.ReleaseBundleDetails, params services.CreateOrPromoteReleaseBundleParams) error {
+	rbDetails services.ReleaseBundleDetails, queryParams services.CommonOptionalQueryParams) error {
 
 	bundles := CreateFromReleaseBundlesSpec{}
 	content, err := fileutils.ReadFile(rbc.releaseBundlesSpecPath)
@@ -25,7 +25,7 @@ func (rbc *ReleaseBundleCreateCommand) createFromReleaseBundles(servicesManager 
 	}
 
 	releaseBundlesSource := rbc.convertToReleaseBundlesSource(bundles)
-	return servicesManager.CreateReleaseBundleFromBundles(rbDetails, params, releaseBundlesSource)
+	return servicesManager.CreateReleaseBundleFromBundles(rbDetails, queryParams, rbc.signingKeyName, releaseBundlesSource)
 }
 
 func (rbc *ReleaseBundleCreateCommand) convertToReleaseBundlesSource(bundles CreateFromReleaseBundlesSpec) services.CreateFromReleaseBundlesSource {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Depends on https://github.com/jfrog/jfrog-client-go/pull/893

Breaking changes:
- Changed signature of creation and promotion commands.
- Removed the `overwrite_existing_artifacts` promotion option that has been decommissioned as of 7.75.0 (both from UI and API).

Improvement:
- Support for include/exclude repositories in release bundle promotion.