### PR TITLE
Fix panic in build-scan without arguments

### DIFF
--- a/plugins/common/config.go
+++ b/plugins/common/config.go
@@ -14,10 +14,9 @@ import (
 // Any empty configuration could be later overridden by environment variables if set.
 func CreateBuildConfiguration(c *components.Context) *build.BuildConfiguration {
 	buildConfiguration := new(build.BuildConfiguration)
-	buildNameArg, buildNumberArg := c.Arguments[0], c.Arguments[1]
-	if buildNameArg == "" || buildNumberArg == "" {
-		buildNameArg = ""
-		buildNumberArg = ""
+	var buildNameArg, buildNumberArg string
+	if len(c.Arguments) > 1 && c.Arguments[0] != "" && c.Arguments[1] != "" {
+		buildNameArg, buildNumberArg = c.Arguments[0], c.Arguments[1]
 	}
 	buildConfiguration.SetBuildName(buildNameArg).SetBuildNumber(buildNumberArg).SetProject(c.GetStringFlagValue("project")).SetModule(c.GetStringFlagValue("module"))
 	return buildConfiguration


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Resolve https://github.com/jfrog/jfrog-cli/issues/2424

The build name and build-number arguments can be supplied via environment variables. `buildConfiguration.GetBuildName()` and `buildConfiguration.GetBuildNumber()` are handling these cases.
Hence, it also makes sense not to include any arguments in this command.
