### PR TITLE
Curation - Recognize 403 or 500 errors from the tree builder

### DIFF
--- a/utils/java/mvn.go
+++ b/utils/java/mvn.go
@@ -255,7 +255,10 @@ func (mdt *MavenDepTreeManager) CreateTempDirWithSettingsXmlIfNeeded() (tempDirP
 // In case mvn tree fails on 403 or 500 it can be related to packages blocked by curation.
 // For this use case to succeed, pass through should be enabled in the curated repos
 func (mdt *MavenDepTreeManager) suspectCurationBlockedError(cmdOutput string) (msgToUser string) {
-	if mdt.isCurationCmd && (strings.Contains(cmdOutput, "status code: 403") || strings.Contains(cmdOutput, "status code: 500")) {
+	if !mdt.isCurationCmd {
+		return
+	}
+	if strings.Contains(cmdOutput, "status code: 403") || strings.Contains(cmdOutput, "status code: 500") {
 		msgToUser = "Failed to get dependencies tree for maven project, Please verify pass-through enabled on the curated repos"
 	}
 	return msgToUser

--- a/utils/java/mvn.go
+++ b/utils/java/mvn.go
@@ -170,10 +170,15 @@ func (mdt *MavenDepTreeManager) RunMvnCmd(goals []string) (cmdOutput []byte, err
 	//#nosec G204
 	cmdOutput, err = exec.Command("mvn", goals...).CombinedOutput()
 	if err != nil {
+		stringOutput := string(cmdOutput)
 		if len(cmdOutput) > 0 {
-			log.Info(string(cmdOutput))
+			log.Info(stringOutput)
 		}
-		err = fmt.Errorf("failed running command 'mvn %s': %s", strings.Join(goals, " "), err.Error())
+		if msg := mdt.suspectCurationBlockedError(stringOutput); msg != "" {
+			err = fmt.Errorf("failed running command 'mvn %s\n\n%s", strings.Join(goals, " "), msg)
+		} else {
+			err = fmt.Errorf("failed running command 'mvn %s': %s", strings.Join(goals, " "), err.Error())
+		}
 	}
 	return
 }
@@ -245,4 +250,13 @@ func (mdt *MavenDepTreeManager) CreateTempDirWithSettingsXmlIfNeeded() (tempDirP
 		clearMavenDepTreeRun = nil
 	}
 	return
+}
+
+// In case mvn tree fails on 403 or 500 it can be related to packages blocked by curation.
+// For this use case to succeed, pass through should be enabled in the curated repos
+func (mdt *MavenDepTreeManager) suspectCurationBlockedError(cmdOutput string) (msgToUser string) {
+	if mdt.isCurationCmd && (strings.Contains(cmdOutput, "status code: 403") || strings.Contains(cmdOutput, "status code: 500")) {
+		msgToUser = "Failed to get dependencies tree for maven project, Please verify pass-through enabled on the curated repos"
+	}
+	return msgToUser
 }

--- a/utils/java/mvn_test.go
+++ b/utils/java/mvn_test.go
@@ -344,3 +344,43 @@ func TestRemoveMavenConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.FileExists(t, mavenConfigPath)
 }
+
+func TestMavenDepTreeManager_suspectCurationBlockedError(t *testing.T) {
+	tests := []struct {
+		name          string
+		wantMsgToUser string
+		input         string
+	}{
+		{
+			name:          "failed on 403",
+			wantMsgToUser: "Please verify pass-through enabled on the curated repos",
+			input: "ERROR] Failed to execute goal on project my-app: Could not resolve dependencies for project com.mycompany.app:my-app:jar:1.0-SNAPSHOT: Failed to " +
+				"collect dependencies at junit:junit:jar:3.8.1: Failed to read artifact descriptor for junit:junit:jar:3.8.1: " +
+				"The following artifacts could not be resolved: junit:junit:pom:3.8.1 (absent): Could not transfer artifact junit:junit:pom:3.8.1 " +
+				"from/to artifactory (http://test:8046/artifactory/api/curation/audit/maven-remote): status code: 403, reason phrase: Forbidden (403)",
+		},
+		{
+			name:          "failed on 500",
+			wantMsgToUser: "Please verify pass-through enabled on the curated repos",
+			input: "[ERROR] Failed to execute goal on project my-app: Could not resolve dependencies for project com.mycompany.app:my-app:jar:1.0-SNAPSHOT: " +
+				"Failed to collect dependencies at junit:junit:jar:3.8.1: Failed to read artifact descriptor for junit:junit:jar:3.8.1: The following artifacts" +
+				" could not be resolved: junit:junit:pom:3.8.1 (absent): Could not transfer artifact junit:junit:pom:3.8.1 from/to artifactory" +
+				" (http://test:8046/artifactory/api/curation/audit/virtual-to-smart): status code: 500, reason phrase: Internal Server Error (500)",
+		},
+		{
+			name:          "not 403 or 500",
+			wantMsgToUser: "",
+			input: "ERROR] Failed to execute goal on project my-app: Could not resolve dependencies for project com.mycompany.app:my-app:jar:1.0-SNAPSHOT: Failed to " +
+				"collect dependencies at junit:junit:jar:3.8.1: Failed to read artifact descriptor for junit:junit:jar:3.8.1: " +
+				"The following artifacts could not be resolved: junit:junit:pom:3.8.1 (absent): Could not transfer artifact junit:junit:pom:3.8.1 " +
+				"from/to artifactory (http://test:8046/artifactory/api/curation/audit/maven-remote): status code: 400, reason phrase: Forbidden (400)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mdt := &MavenDepTreeManager{}
+			msg := mdt.suspectCurationBlockedError(tt.input)
+			assert.Contains(t, tt.wantMsgToUser, msg)
+		})
+	}
+}


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [X] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [X] This pull request is on the dev branch.
- [X] I used gofmt for formatting the code before submitting the pull request.
-----
