### PR TITLE
Fix poetry failing test

### DIFF
--- a/utils/python/utils.go
+++ b/utils/python/utils.go
@@ -81,7 +81,20 @@ func ConfigPoetryRepo(url, username, password, configRepoName string) error {
 	if err != nil {
 		return errorutils.CheckError(err)
 	}
-	return addRepoToPyprojectFile(filepath.Join(currentDir, pyproject), configRepoName, url)
+	if err = addRepoToPyprojectFile(filepath.Join(currentDir, pyproject), configRepoName, url); err != nil {
+		return err
+	}
+	return poetryUpdate(err)
+}
+
+func poetryUpdate(err error) error {
+	log.Info("Running Poetry update")
+	cmd := io.NewCommand("poetry", "update", []string{"--verbose"})
+	err = gofrogcmd.RunCmd(cmd)
+	if err != nil {
+		return errorutils.CheckErrorf("Poetry config command failed with: %s", err.Error())
+	}
+	return nil
 }
 
 func runPoetryConfigCommand(args []string, maskArgs bool) error {
@@ -113,11 +126,5 @@ func addRepoToPyprojectFile(filepath, poetryRepoName, repoUrl string) error {
 		return errorutils.CheckErrorf("Failed to add tool.poetry.source to pyproject.toml: %s", err.Error())
 	}
 	log.Info(fmt.Sprintf("Added tool.poetry.source name:%q url:%q", poetryRepoName, repoUrl))
-	log.Info("Running Poetry update")
-	cmd := io.NewCommand("poetry", "update", []string{})
-	err = gofrogcmd.RunCmd(cmd)
-	if err != nil {
-		return errorutils.CheckErrorf("Poetry config command failed with: %s", err.Error())
-	}
 	return err
 }

--- a/utils/python/utils.go
+++ b/utils/python/utils.go
@@ -84,17 +84,17 @@ func ConfigPoetryRepo(url, username, password, configRepoName string) error {
 	if err = addRepoToPyprojectFile(filepath.Join(currentDir, pyproject), configRepoName, url); err != nil {
 		return err
 	}
-	return poetryUpdate(err)
+	return poetryUpdate()
 }
 
-func poetryUpdate(err error) error {
+func poetryUpdate() (err error) {
 	log.Info("Running Poetry update")
 	cmd := io.NewCommand("poetry", "update", []string{"--verbose"})
 	err = gofrogcmd.RunCmd(cmd)
 	if err != nil {
 		return errorutils.CheckErrorf("Poetry config command failed with: %s", err.Error())
 	}
-	return nil
+	return
 }
 
 func runPoetryConfigCommand(args []string, maskArgs bool) error {

--- a/utils/python/utils.go
+++ b/utils/python/utils.go
@@ -89,7 +89,7 @@ func ConfigPoetryRepo(url, username, password, configRepoName string) error {
 
 func poetryUpdate() (err error) {
 	log.Info("Running Poetry update")
-	cmd := io.NewCommand("poetry", "update", []string{"--verbose"})
+	cmd := io.NewCommand("poetry", "update", []string{})
 	err = gofrogcmd.RunCmd(cmd)
 	if err != nil {
 		return errorutils.CheckErrorf("Poetry config command failed with: %s", err.Error())


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

the test `TestAddRepoToPyprojectFile` was failing due error to resolve dependencies.

the problem is that the test should not have tried to run poetry update command as it attempts to resolve dependencies from a non-existing artifactory repo.

Fix:
Split functionality of `addRepoToPyprojectFile` and `poetry update` to a different function
