### PR TITLE
Fix npm publish with provided tarball

### DIFF
--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -422,6 +422,8 @@ func (npc *NpmPublishCommand) setPackageInfo() error {
 }
 
 func (npc *NpmPublishCommand) readPackageInfoFromTarball(packedFilePath string) (err error) {
+	// Sets the packed file location in the npm publish command
+	npc.packedFilePaths = []string{packedFilePath}
 	log.Debug("Extracting info from npm package:", packedFilePath)
 	tarball, err := os.Open(packedFilePath)
 	if err != nil {
@@ -449,9 +451,7 @@ func (npc *NpmPublishCommand) readPackageInfoFromTarball(packedFilePath string) 
 			if err != nil {
 				return errorutils.CheckError(err)
 			}
-
 			npc.packageInfo, err = biutils.ReadPackageInfo(packageJson, npc.npmVersion)
-			npc.packedFilePaths = []string{packedFilePath}
 			return err
 		}
 	}

--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -418,12 +418,12 @@ func (npc *NpmPublishCommand) setPackageInfo() error {
 	}
 	log.Debug("The provided path is not a directory, we assume this is a compressed npm package")
 	npc.tarballProvided = true
+	// Sets the location of the provided tarball
+	npc.packedFilePaths = []string{npc.publishPath}
 	return npc.readPackageInfoFromTarball(npc.publishPath)
 }
 
 func (npc *NpmPublishCommand) readPackageInfoFromTarball(packedFilePath string) (err error) {
-	// Sets the packed file location in the npm publish command
-	npc.packedFilePaths = []string{packedFilePath}
 	log.Debug("Extracting info from npm package:", packedFilePath)
 	tarball, err := os.Open(packedFilePath)
 	if err != nil {

--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -422,7 +422,7 @@ func (npc *NpmPublishCommand) setPackageInfo() error {
 }
 
 func (npc *NpmPublishCommand) readPackageInfoFromTarball(packedFilePath string) (err error) {
-	log.Debug("Extracting info from npm package:", npc.packedFilePaths)
+	log.Debug("Extracting info from npm package:", packedFilePath)
 	tarball, err := os.Open(packedFilePath)
 	if err != nil {
 		return errorutils.CheckError(err)
@@ -451,6 +451,7 @@ func (npc *NpmPublishCommand) readPackageInfoFromTarball(packedFilePath string) 
 			}
 
 			npc.packageInfo, err = biutils.ReadPackageInfo(packageJson, npc.npmVersion)
+			npc.packedFilePaths = []string{packedFilePath}
 			return err
 		}
 	}

--- a/artifactory/commands/npm/publish_test.go
+++ b/artifactory/commands/npm/publish_test.go
@@ -9,17 +9,26 @@ import (
 
 func TestReadPackageInfoFromTarball(t *testing.T) {
 	npmPublish := NewNpmPublishCommand()
-	npmPublish.packedFilePaths = append(npmPublish.packedFilePaths, filepath.Join("..", "testdata", "npm", "npm-example-0.0.3.tgz"))
-	npmPublish.packedFilePaths = append(npmPublish.packedFilePaths, filepath.Join("..", "testdata", "npm", "npm-example-0.0.4.tgz"))
 
-	err := npmPublish.readPackageInfoFromTarball(npmPublish.packedFilePaths[0])
-	assert.NoError(t, err)
-	assert.Equal(t, "npm-example", npmPublish.packageInfo.Name)
-	assert.Equal(t, "0.0.3", npmPublish.packageInfo.Version)
-
-	err = npmPublish.readPackageInfoFromTarball(npmPublish.packedFilePaths[1])
-	assert.NoError(t, err)
-	assert.Equal(t, "npm-example", npmPublish.packageInfo.Name)
-	assert.Equal(t, "0.0.4", npmPublish.packageInfo.Version)
-
+	var testCases = []struct {
+		filePath       string
+		packageName    string
+		packageVersion string
+	}{
+		{
+			filePath:       filepath.Join("..", "testdata", "npm", "npm-example-0.0.3.tgz"),
+			packageName:    "npm-example",
+			packageVersion: "0.0.3",
+		}, {
+			filePath:       filepath.Join("..", "testdata", "npm", "npm-example-0.0.4.tgz"),
+			packageName:    "npm-example",
+			packageVersion: "0.0.4",
+		},
+	}
+	for _, test := range testCases {
+		err := npmPublish.readPackageInfoFromTarball(test.filePath)
+		assert.NoError(t, err)
+		assert.Equal(t, test.packageName, npmPublish.packageInfo.Name)
+		assert.Equal(t, test.packageVersion, npmPublish.packageInfo.Version)
+	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

# Fix npm pack when reading a pre packed npm package
When reading for an already packed npm package, there was a missing file path that wasn't set because of the changes to handle workspaces.
This PR should fix it by setting the file path.