### PR TITLE
Fix npm pack command with prePack script

### DIFF
--- a/artifactory/utils/npm/pack.go
+++ b/artifactory/utils/npm/pack.go
@@ -27,7 +27,20 @@ func createPackCmdConfig(executablePath string, splitFlags []string) *npmutils.N
 	}
 }
 
+// Extracts packed file names from npm pack command output
+// The output can differ when a prePack script exists,
+// This function will filter the output and search for the .tgz files.
 func getPackageFileNameFromOutput(output string) []string {
-	output = strings.TrimSpace(output)
-	return strings.Split(output, "\n")
+	// Split the output into lines
+	lines := strings.Split(output, "\n")
+	// Filter the lines to only include those that end with .tgz
+	var packagesFileNames []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		// If the line ends with .tgz, add it to the tgzFiles slice
+		if strings.HasSuffix(line, ".tgz") {
+			packagesFileNames = append(packagesFileNames, line)
+		}
+	}
+	return packagesFileNames
 }

--- a/artifactory/utils/npm/pack.go
+++ b/artifactory/utils/npm/pack.go
@@ -1,11 +1,17 @@
 package npm
 
 import (
+	"fmt"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"strings"
 
 	gofrogcmd "github.com/jfrog/gofrog/io"
 	npmutils "github.com/jfrog/jfrog-cli-core/v2/utils/npm"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+)
+
+const (
+	npmPackedTarballSuffix = ".tgz"
 )
 
 func Pack(npmFlags []string, executablePath string) ([]string, error) {
@@ -14,7 +20,7 @@ func Pack(npmFlags []string, executablePath string) ([]string, error) {
 	if err != nil {
 		return []string{}, errorutils.CheckError(err)
 	}
-	return getPackageFileNameFromOutput(output), nil
+	return getPackageFileNameFromOutput(output)
 }
 
 func createPackCmdConfig(executablePath string, splitFlags []string) *npmutils.NpmConfig {
@@ -29,18 +35,25 @@ func createPackCmdConfig(executablePath string, splitFlags []string) *npmutils.N
 
 // Extracts packed file names from npm pack command output
 // The output can differ when a prePack script exists,
-// This function will filter the output and search for the .tgz files.
-func getPackageFileNameFromOutput(output string) []string {
-	// Split the output into lines
+// This function will filter the output and search for the .tgz files
+// To avoid misidentifying files, we will verify file exists
+func getPackageFileNameFromOutput(output string) (packedTgzFiles []string, err error) {
 	lines := strings.Split(output, "\n")
-	// Filter the lines to only include those that end with .tgz
-	var packagesFileNames []string
+	var packedFileNamesFromOutput []string
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
-		// If the line ends with .tgz, add it to the tgzFiles slice
-		if strings.HasSuffix(line, ".tgz") {
-			packagesFileNames = append(packagesFileNames, line)
+		if strings.HasSuffix(line, npmPackedTarballSuffix) {
+			packedFileNamesFromOutput = append(packedFileNamesFromOutput, line)
 		}
 	}
-	return packagesFileNames
+	for _, file := range packedFileNamesFromOutput {
+		exists, err := fileutils.IsFileExists(file, true)
+		if err != nil {
+			return nil, fmt.Errorf("error occurred while checking packed npm tarball exists: %w", err)
+		}
+		if exists {
+			packedTgzFiles = append(packedTgzFiles, file)
+		}
+	}
+	return
 }

--- a/tests/testdata/npm-workspaces/package.json
+++ b/tests/testdata/npm-workspaces/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepack": "echo 'prepack script executed'"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

modified the `getPackageFileNameFromOutput` function to extract .tgz files from the output, which as we saw, can be different when pre pack scripts exists or any other parameters which can effect the output of the npm pack command