### PR TITLE
Update web login prompts

### DIFF
--- a/artifactory/utils/weblogin.go
+++ b/artifactory/utils/weblogin.go
@@ -28,8 +28,8 @@ func DoWebLogin(serverDetails *config.ServerDetails) (token auth.CommonTokenPara
 	}
 	if err = accessManager.SendLoginAuthenticationRequest(uuidStr); err != nil {
 		err = errors.Join(err,
-			errorutils.CheckErrorf("The 'Web Login' functionality is only supported for Artifactory version 7.64.0 and above. "+
-				"Make sure the details you entered are correct and that Artifactory meets the version requirement."))
+			errorutils.CheckErrorf("it looks like the Web Login is unavailable. This could be because your JFrog Artifactory version is less than 7.64.0. "+
+				"You can use the \"jf c add\" command to authenticate with the JFrog Platform"))
 		return
 	}
 	log.Info("After logging in via your web browser, please enter the code if prompted: " + uuidStr[len(uuidStr)-4:])

--- a/artifactory/utils/weblogin.go
+++ b/artifactory/utils/weblogin.go
@@ -28,8 +28,8 @@ func DoWebLogin(serverDetails *config.ServerDetails) (token auth.CommonTokenPara
 	}
 	if err = accessManager.SendLoginAuthenticationRequest(uuidStr); err != nil {
 		err = errors.Join(err,
-			errorutils.CheckErrorf("it looks like the Web Login is unavailable. This could be because your JFrog Artifactory version is less than 7.64.0. "+
-				"You can use the \"jf c add\" command to authenticate with the JFrog Platform"))
+			errorutils.CheckErrorf("Oops! it looks like the web login option is unavailable right now. This could be because your JFrog Artifactory version is less than 7.64.0. \n"+
+				"Don't worry! You can use the \"jf c add\" command to authenticate with the JFrog Platform using other methods"))
 		return
 	}
 	log.Info("After logging in via your web browser, please enter the code if prompted: " + uuidStr[len(uuidStr)-4:])

--- a/common/commands/config.go
+++ b/common/commands/config.go
@@ -322,7 +322,11 @@ func (cc *ConfigCommand) getConfigurationFromUser() (err error) {
 	}
 
 	if cc.details.Url == "" {
-		ioutils.ScanFromConsole("JFrog Platform URL", &cc.details.Url, cc.defaultDetails.Url)
+		urlPrompt := "JFrog Platform URL"
+		if cc.useWebLogin {
+			urlPrompt = "Enter your " + urlPrompt
+		}
+		ioutils.ScanFromConsole(urlPrompt, &cc.details.Url, cc.defaultDetails.Url)
 	}
 
 	if fileutils.IsSshUrl(cc.details.Url) || fileutils.IsSshUrl(cc.details.ArtifactoryUrl) {
@@ -462,7 +466,7 @@ func (cc *ConfigCommand) readClientCertInfoFromConsole() {
 }
 
 func (cc *ConfigCommand) checkClientCertForReverseProxy() {
-	if cc.details.ClientCertPath != "" && cc.details.ClientCertKeyPath != "" {
+	if cc.details.ClientCertPath != "" && cc.details.ClientCertKeyPath != "" || cc.useWebLogin {
 		return
 	}
 	if coreutils.AskYesNo("Is the Artifactory reverse proxy configured to accept a client certificate?", false) {

--- a/general/login/login.go
+++ b/general/login/login.go
@@ -42,7 +42,7 @@ func newConfLogin() error {
 
 func promptPlatformUrl() (string, error) {
 	var platformUrl string
-	ioutils.ScanFromConsole("JFrog Platform URL", &platformUrl, "")
+	ioutils.ScanFromConsole("Enter your JFrog Platform URL", &platformUrl, "")
 	if platformUrl == "" {
 		return "", errorutils.CheckErrorf("providing JFrog Platform URL is mandatory")
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Revise the web login commands errors (`jf login` & `jf c add` with Web Login) to advise executing `jf c add` if the Artifactory version is below 7.64.0. 
![image](https://github.com/jfrog/jfrog-cli-core/assets/11367982/a22dadc7-0dd6-4abb-8762-b0af516ab585)
