### PR TITLE
Revert commit "Fix root module name handling in build info collection"

### DIFF
--- a/artifactory/commands/golang/go.go
+++ b/artifactory/commands/golang/go.go
@@ -197,13 +197,9 @@ func (gc *GoCommand) run() (err error) {
 		if errorutils.CheckError(err) != nil {
 			return
 		}
-		var moduleName string
-		moduleName, err = gc.buildConfiguration.ResolveBaseModuleName()
-		if err != nil {
-			return
+		if gc.buildConfiguration.GetModule() != "" {
+			goModule.SetName(gc.buildConfiguration.GetModule())
 		}
-		goModule.SetName(moduleName)
-
 		err = errorutils.CheckError(goModule.CalcDependencies())
 	}
 

--- a/artifactory/commands/golang/gopublish.go
+++ b/artifactory/commands/golang/gopublish.go
@@ -128,11 +128,9 @@ func (gpc *GoPublishCommand) Run() error {
 		if err != nil {
 			return errorutils.CheckError(err)
 		}
-		moduleName, err := gpc.buildConfiguration.ResolveBaseModuleName()
-		if err != nil {
-			return err
+		if gpc.buildConfiguration.GetModule() != "" {
+			goModule.SetName(gpc.buildConfiguration.GetModule())
 		}
-		goModule.SetName(moduleName)
 		err = goModule.AddArtifacts(artifacts...)
 		if err != nil {
 			return errorutils.CheckError(err)

--- a/artifactory/commands/npm/npmcommand.go
+++ b/artifactory/commands/npm/npmcommand.go
@@ -353,11 +353,9 @@ func (nc *NpmCommand) prepareBuildInfoModule() error {
 		return errorutils.CheckError(err)
 	}
 	nc.buildInfoModule.SetCollectBuildInfo(nc.collectBuildInfo)
-	moduleName, err := nc.buildConfiguration.ResolveBaseModuleName()
-	if err != nil {
-		return err
+	if nc.buildConfiguration.GetModule() != "" {
+		nc.buildInfoModule.SetName(nc.buildConfiguration.GetModule())
 	}
-	nc.buildInfoModule.SetName(moduleName)
 	return nil
 }
 

--- a/artifactory/commands/npm/publish.go
+++ b/artifactory/commands/npm/publish.go
@@ -204,13 +204,9 @@ func (npc *NpmPublishCommand) Run() (err error) {
 	if err != nil {
 		return errorutils.CheckError(err)
 	}
-
-	moduleName, err := npc.buildConfiguration.ResolveBaseModuleName()
-	if err != nil {
-		return
+	if npc.buildConfiguration.GetModule() != "" {
+		npmModule.SetName(npc.buildConfiguration.GetModule())
 	}
-	npmModule.SetName(moduleName)
-
 	buildArtifacts, err := specutils.ConvertArtifactsDetailsToBuildInfoArtifacts(npc.artifactsDetailsReader)
 	if err != nil {
 		return err

--- a/artifactory/commands/python/poetry.go
+++ b/artifactory/commands/python/poetry.go
@@ -75,11 +75,9 @@ func (pc *PoetryCommand) install(buildConfiguration *buildUtils.BuildConfigurati
 	if err != nil {
 		return
 	}
-	moduleName, err := buildConfiguration.ResolveBaseModuleName()
-	if err != nil {
-		return
+	if buildConfiguration.GetModule() != "" {
+		pythonModule.SetName(buildConfiguration.GetModule())
 	}
-	pythonModule.SetName(moduleName)
 	var localDependenciesPath string
 	localDependenciesPath, err = config.GetJfrogDependenciesPath()
 	if err != nil {

--- a/artifactory/commands/python/python.go
+++ b/artifactory/commands/python/python.go
@@ -58,12 +58,9 @@ func (pc *PythonCommand) Run() (err error) {
 		if err != nil {
 			return
 		}
-		var moduleName string
-		moduleName, err = buildConfiguration.ResolveBaseModuleName()
-		if err != nil {
-			return
+		if buildConfiguration.GetModule() != "" {
+			pythonModule.SetName(buildConfiguration.GetModule())
 		}
-		pythonModule.SetName(moduleName)
 		var localDependenciesPath string
 		localDependenciesPath, err = config.GetJfrogDependenciesPath()
 		if err != nil {

--- a/common/build/buildutils.go
+++ b/common/build/buildutils.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -460,18 +459,6 @@ func (bc *BuildConfiguration) IsCollectBuildInfo() (bool, error) {
 
 func (bc *BuildConfiguration) IsLoadedFromConfigFile() bool {
 	return bc.loadedFromConfigFile
-}
-
-// ResolveBaseModuleName returns the module name to publish build info.
-// If the module name is not specified, it falls back to the current working directory name.
-// If the working directory cannot be retrieved, it defaults to "module".
-// Module name is mandatory to publish build info.
-func (bc *BuildConfiguration) ResolveBaseModuleName() (string, error) {
-	if bc.module != "" {
-		return bc.module, nil
-	}
-	wd, err := os.Getwd()
-	return path.Base(wd), errorutils.CheckError(err)
 }
 
 func PopulateBuildArtifactsAsPartials(buildArtifacts []buildInfo.Artifact, buildConfiguration *BuildConfiguration, moduleType buildInfo.ModuleType) error {

--- a/common/build/buildutils_test.go
+++ b/common/build/buildutils_test.go
@@ -3,7 +3,6 @@ package build
 import (
 	biutils "github.com/jfrog/build-info-go/utils"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -245,38 +244,4 @@ func TestIsLoadedFromConfigFile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, buildName, buildNameFile)
 	assert.Equal(t, buildNumber, artclientutils.LatestBuildNumberKey)
-}
-
-func TestBuildConfiguration_ResolveModuleName(t *testing.T) {
-	testCases := []struct {
-		name   string
-		module string
-	}{
-		{
-			name:   "Module is set",
-			module: "custom-module",
-		},
-		{
-			name:   "Module not set, fallback to base directory name",
-			module: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Setup
-			bc := BuildConfiguration{module: tc.module}
-			// Execute
-			result, err := bc.ResolveBaseModuleName()
-			assert.NoError(t, err)
-			// Assert
-			if tc.module == "" {
-				wd, err := os.Getwd()
-				assert.NoError(t, err)
-				assert.Equal(t, path.Base(wd), result)
-			} else {
-				assert.Equal(t, tc.module, result)
-			}
-		})
-	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Revert the commit that was introduced via #1201, because it breaks the default module name for a few package managers.
