### PR TITLE
embedded plugin context - don't set flags if not exists

### DIFF
--- a/plugins/components/commandcomp.go
+++ b/plugins/components/commandcomp.go
@@ -3,6 +3,8 @@ package components
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/jfrog/gofrog/datastructures"
 )
 
 type Argument struct {
@@ -51,6 +53,7 @@ type ActionFunc func(c *Context) error
 type Context struct {
 	Arguments        []string
 	CommandName      string
+	existingFlags    *datastructures.Set[string]
 	stringFlags      map[string]string
 	boolFlags        map[string]bool
 	PrintCommandHelp func(commandName string) error
@@ -75,11 +78,7 @@ func (c *Context) GetBoolFlagValue(flagName string) bool {
 }
 
 func (c *Context) IsFlagSet(flagName string) bool {
-	if _, exist := c.stringFlags[flagName]; exist {
-		return true
-	}
-	_, exist := c.boolFlags[flagName]
-	return exist
+	return c.existingFlags.Exists(flagName)
 }
 
 type Flag interface {

--- a/plugins/components/commandcomp.go
+++ b/plugins/components/commandcomp.go
@@ -3,8 +3,6 @@ package components
 import (
 	"fmt"
 	"strconv"
-
-	"github.com/jfrog/gofrog/datastructures"
 )
 
 type Argument struct {
@@ -53,7 +51,6 @@ type ActionFunc func(c *Context) error
 type Context struct {
 	Arguments        []string
 	CommandName      string
-	existingFlags    *datastructures.Set[string]
 	stringFlags      map[string]string
 	boolFlags        map[string]bool
 	PrintCommandHelp func(commandName string) error
@@ -78,7 +75,11 @@ func (c *Context) GetBoolFlagValue(flagName string) bool {
 }
 
 func (c *Context) IsFlagSet(flagName string) bool {
-	return c.existingFlags.Exists(flagName)
+	if _, exist := c.stringFlags[flagName]; exist {
+		return true
+	}
+	_, exist := c.boolFlags[flagName]
+	return exist
 }
 
 type Flag interface {

--- a/plugins/components/conversionlayer.go
+++ b/plugins/components/conversionlayer.go
@@ -426,6 +426,7 @@ func getValueForStringFlag(f StringFlag, baseContext *cli.Context) (finalValue s
 		return
 	}
 	if f.DefaultValue != "" {
+		// Empty but has a default value defined.
 		finalValue = f.DefaultValue
 		return
 	}

--- a/plugins/components/conversionlayer.go
+++ b/plugins/components/conversionlayer.go
@@ -408,11 +408,9 @@ func fillFlagMaps(c *Context, baseContext *cli.Context, originalFlags []Flag) er
 		}
 
 		if boolFlag, ok := flag.(BoolFlag); ok {
-			if baseContext.IsSet(boolFlag.Name) {
-				finalValue, skip := getValueForBoolFlag(boolFlag, baseContext)
-				if !skip {
-					c.boolFlags[boolFlag.Name] = finalValue
-				}
+			finalValue, skip := getValueForBoolFlag(boolFlag, baseContext)
+			if !skip {
+				c.boolFlags[boolFlag.Name] = finalValue
 			}
 		}
 	}

--- a/plugins/components/conversionlayer.go
+++ b/plugins/components/conversionlayer.go
@@ -397,6 +397,10 @@ func fillFlagMaps(c *Context, baseContext *cli.Context, originalFlags []Flag) er
 	// Loop over all plugin's known flags.
 	for _, flag := range originalFlags {
 		if stringFlag, ok := flag.(StringFlag); ok {
+			if !baseContext.IsSet(stringFlag.Name) {
+				// Flag not set, continue.
+				continue
+			}
 			finalValue, err := getValueForStringFlag(stringFlag, baseContext.String(stringFlag.Name))
 			if err != nil {
 				return err
@@ -406,7 +410,9 @@ func fillFlagMaps(c *Context, baseContext *cli.Context, originalFlags []Flag) er
 		}
 
 		if boolFlag, ok := flag.(BoolFlag); ok {
-			c.boolFlags[boolFlag.Name] = getValueForBoolFlag(boolFlag, baseContext)
+			if baseContext.IsSet(boolFlag.Name) {
+				c.boolFlags[boolFlag.Name] = getValueForBoolFlag(boolFlag, baseContext)
+			}
 		}
 	}
 	return nil

--- a/plugins/components/conversionlayer.go
+++ b/plugins/components/conversionlayer.go
@@ -412,22 +412,20 @@ func fillFlagMaps(c *Context, baseContext *cli.Context, originalFlags []Flag) er
 	return nil
 }
 
-func getValueForStringFlag(f StringFlag, baseContext *cli.Context) (finalValue string, err error) {
+func getValueForStringFlag(f StringFlag, baseContext *cli.Context) (string, error) {
 	value := baseContext.String(f.Name)
 	if value != "" {
-		finalValue = value
-		return
+		return value, nil
 	}
 	if f.DefaultValue != "" {
 		// Empty but has a default value defined.
-		finalValue = f.DefaultValue
-		return
+		return f.DefaultValue, nil
 	}
 	if f.Mandatory {
 		// Empty but mandatory.
-		err = errors.New("Mandatory flag '" + f.Name + "' is missing")
+		return "", errors.New("Mandatory flag '" + f.Name + "' is missing")
 	}
-	return
+	return "", nil
 }
 
 func getValueForBoolFlag(f BoolFlag, baseContext *cli.Context) bool {

--- a/plugins/components/conversionlayer.go
+++ b/plugins/components/conversionlayer.go
@@ -391,7 +391,6 @@ func getPrintCommandHelpFunc(c *cli.Context) func(commandName string) error {
 }
 
 func fillFlagMaps(c *Context, baseContext *cli.Context, originalFlags []Flag) error {
-	c.existingFlags = datastructures.MakeSet[string]()
 	c.stringFlags = make(map[string]string)
 	c.boolFlags = make(map[string]bool)
 
@@ -403,17 +402,11 @@ func fillFlagMaps(c *Context, baseContext *cli.Context, originalFlags []Flag) er
 				return err
 			}
 			if finalValue != "" || baseContext.IsSet(stringFlag.Name) {
-				c.existingFlags.Add(stringFlag.Name)
+				c.stringFlags[stringFlag.Name] = finalValue
 			}
-			c.stringFlags[stringFlag.Name] = finalValue
-			continue
 		}
 		if boolFlag, ok := flag.(BoolFlag); ok {
-			finalValue := getValueForBoolFlag(boolFlag, baseContext)
-			if finalValue || baseContext.IsSet(boolFlag.Name) {
-				c.existingFlags.Add(boolFlag.Name)
-			}
-			c.boolFlags[boolFlag.Name] = finalValue
+			c.boolFlags[boolFlag.Name] = getValueForBoolFlag(boolFlag, baseContext)
 		}
 	}
 	return nil

--- a/plugins/components/conversionlayer.go
+++ b/plugins/components/conversionlayer.go
@@ -425,12 +425,11 @@ func getValueForStringFlag(f StringFlag, baseContext *cli.Context) (finalValue s
 		finalValue = value
 		return
 	}
-	skip = !baseContext.IsSet(f.Name)
 	if f.DefaultValue != "" {
-		skip = false
 		finalValue = f.DefaultValue
 		return
 	}
+	skip = !baseContext.IsSet(f.Name)
 	// Empty but mandatory.
 	if f.Mandatory {
 		err = errors.New("Mandatory flag '" + f.Name + "' is missing")
@@ -439,12 +438,11 @@ func getValueForStringFlag(f StringFlag, baseContext *cli.Context) (finalValue s
 }
 
 func getValueForBoolFlag(f BoolFlag, baseContext *cli.Context) (finalValue, skip bool) {
-	skip = !baseContext.IsSet(f.Name)
 	if f.DefaultValue {
-		skip = false
 		finalValue = baseContext.BoolT(f.Name)
 		return
 	}
+	skip = !baseContext.IsSet(f.Name)
 	finalValue = baseContext.Bool(f.Name)
 	return
 }

--- a/plugins/components/conversionlayer_test.go
+++ b/plugins/components/conversionlayer_test.go
@@ -290,7 +290,7 @@ func TestGetValueForStringFlag(t *testing.T) {
 	// Received, verify default is ignored.
 	expected := "value"
 	baseContext := &cli.Context{}
-	baseContext.Set(f.Name, expected)
+	assert.NoError(t,baseContext.Set(f.Name, expected))
 	finalValue, skip, err = getValueForStringFlag(f, baseContext)
 	assert.NoError(t, err)
 	assert.False(t, skip)

--- a/plugins/components/conversionlayer_test.go
+++ b/plugins/components/conversionlayer_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
 )
 
 func TestCreateCommandUsages(t *testing.T) {
@@ -269,24 +270,29 @@ func TestGetValueForStringFlag(t *testing.T) {
 	f := NewStringFlag("string-flag", "This is how you use it.")
 
 	// Not received, no default or mandatory.
-	finalValue, err := getValueForStringFlag(f, "")
+	finalValue, skip, err := getValueForStringFlag(f, &cli.Context{})
 	assert.NoError(t, err)
+	assert.True(t, skip)
 	assert.Empty(t, finalValue)
 
 	// Not received, no default but mandatory.
 	f.Mandatory = true
-	_, err = getValueForStringFlag(f, "")
+	_, _, err = getValueForStringFlag(f, &cli.Context{})
 	assert.Error(t, err)
 
 	// Not received, verify default is taken.
 	f.DefaultValue = "default"
-	finalValue, err = getValueForStringFlag(f, "")
+	finalValue, skip, err = getValueForStringFlag(f, &cli.Context{})
 	assert.NoError(t, err)
+	assert.False(t, skip)
 	assert.Equal(t, finalValue, f.DefaultValue)
 
 	// Received, verify default is ignored.
 	expected := "value"
-	finalValue, err = getValueForStringFlag(f, expected)
+	baseContext := &cli.Context{}
+	baseContext.Set(f.Name, expected)
+	finalValue, skip, err = getValueForStringFlag(f, baseContext)
 	assert.NoError(t, err)
+	assert.False(t, skip)
 	assert.Equal(t, finalValue, expected)
 }

--- a/plugins/components/conversionlayer_test.go
+++ b/plugins/components/conversionlayer_test.go
@@ -273,30 +273,27 @@ func TestGetValueForStringFlag(t *testing.T) {
 	baseContext := cli.NewContext(nil, flagSet, nil)
 
 	// Not received, no default or mandatory.
-	finalValue, skip, err := getValueForStringFlag(f, baseContext)
+	finalValue, err := getValueForStringFlag(f, baseContext)
 	assert.NoError(t, err)
-	assert.True(t, skip)
 	assert.Empty(t, finalValue)
 
 	// Not received, no default but mandatory.
 	f.Mandatory = true
-	_, _, err = getValueForStringFlag(f, baseContext)
+	_, err = getValueForStringFlag(f, baseContext)
 	assert.Error(t, err)
 
 	// Not received, verify default is taken.
 	f.DefaultValue = "default"
-	finalValue, skip, err = getValueForStringFlag(f, baseContext)
+	finalValue, err = getValueForStringFlag(f, baseContext)
 	assert.NoError(t, err)
-	assert.False(t, skip)
 	assert.Equal(t, finalValue, f.DefaultValue)
 
 	// Received, verify default is ignored.
 	expected := "value"
 	flagSet.Var(DummyFlagValue{Value: expected}, f.Name, f.HelpValue)
-	assert.NoError(t,baseContext.Set(f.Name, expected))
-	finalValue, skip, err = getValueForStringFlag(f, baseContext)
+	assert.NoError(t, baseContext.Set(f.Name, expected))
+	finalValue, err = getValueForStringFlag(f, baseContext)
 	assert.NoError(t, err)
-	assert.False(t, skip)
 	assert.Equal(t, finalValue, expected)
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

For embedded plugins, when using its `context` flags where reported as set when they are not.
Fixing: `(c *Context) IsFlagSet(flagName string) bool` 