### PR TITLE
Improve artifacts links in command summaries

### DIFF
--- a/artifactory/commands/buildinfo/publish.go
+++ b/artifactory/commands/buildinfo/publish.go
@@ -146,7 +146,7 @@ func (bpc *BuildPublishCommand) Run() error {
 		return err
 	}
 
-	if err = recordCommandSummary(buildInfo, buildLink, bpc.serverDetails.Url, bpc.buildConfiguration.GetProject(), majorVersion); err != nil {
+	if err = recordCommandSummary(buildInfo, buildLink, bpc.serverDetails.Url, majorVersion); err != nil {
 		return err
 	}
 
@@ -232,12 +232,12 @@ func (bpc *BuildPublishCommand) getNextBuildNumber(buildName string, servicesMan
 	return strconv.Itoa(latestBuildNumber), nil
 }
 
-func recordCommandSummary(buildInfo *buildinfo.BuildInfo, buildLink, serverUrl, projectKey string, majorVersion int) (err error) {
+func recordCommandSummary(buildInfo *buildinfo.BuildInfo, buildLink, serverUrl string, majorVersion int) (err error) {
 	if !commandsummary.ShouldRecordSummary() {
 		return
 	}
 	buildInfo.BuildUrl = buildLink
-	buildInfoSummary, err := commandsummary.New(commandssummaries.NewBuildInfo(serverUrl, projectKey, majorVersion), "build-info")
+	buildInfoSummary, err := commandsummary.New(commandssummaries.NewBuildInfo(serverUrl, majorVersion), "build-info")
 	if err != nil {
 		return
 	}

--- a/artifactory/commands/commandssummaries/buildinfosummary.go
+++ b/artifactory/commands/commandssummaries/buildinfosummary.go
@@ -16,14 +16,12 @@ const (
 
 type BuildInfoSummary struct {
 	platformUrl  string
-	projectKey   string
 	majorVersion int
 }
 
-func NewBuildInfo(platformUrl, projectKey string, majorVersion int) *BuildInfoSummary {
+func NewBuildInfo(platformUrl string, majorVersion int) *BuildInfoSummary {
 	return &BuildInfoSummary{
 		platformUrl:  platformUrl,
-		projectKey:   projectKey,
 		majorVersion: majorVersion,
 	}
 }
@@ -107,5 +105,5 @@ func (bis *BuildInfoSummary) generateArtifactUrl(artifact buildInfo.Artifact) st
 	if strings.TrimSpace(artifact.OriginalDeploymentRepo) == "" {
 		return ""
 	}
-	return generateArtifactUrl(bis.platformUrl, path.Join(artifact.OriginalDeploymentRepo, artifact.Path), bis.projectKey, bis.majorVersion)
+	return generateArtifactUrl(bis.platformUrl, path.Join(artifact.OriginalDeploymentRepo, artifact.Path), bis.majorVersion)
 }

--- a/artifactory/commands/commandssummaries/buildinfosummary_test.go
+++ b/artifactory/commands/commandssummaries/buildinfosummary_test.go
@@ -24,7 +24,7 @@ func TestBuildInfoTable(t *testing.T) {
 }
 
 func TestBuildInfoModules(t *testing.T) {
-	gh := &BuildInfoSummary{}
+	gh := &BuildInfoSummary{platformUrl: platformUrl, majorVersion: 7}
 	var builds = []*buildinfo.BuildInfo{
 		{
 			Name:     "buildName",

--- a/artifactory/commands/commandssummaries/testdata/modules.md
+++ b/artifactory/commands/commandssummaries/testdata/modules.md
@@ -9,7 +9,7 @@
  <pre>📦 libs-release
 └── 📁 path
     └── 📁 to
-        └── <a href=ui/repos/tree/General/libs-release/path/to/artifact1 target="_blank">artifact1</a>
+        └── <a href=https://myplatform.com/ui/repos/tree/General/libs-release/path/to/artifact1?clearFilter=true target="_blank">artifact1</a>
 
 </pre>
  ####  
@@ -18,6 +18,6 @@
  <pre>📦 generic-local
 └── 📁 path
     └── 📁 to
-        └── <a href=ui/repos/tree/General/generic-local/path/to/artifact2 target="_blank">artifact2</a>
+        └── <a href=https://myplatform.com/ui/repos/tree/General/generic-local/path/to/artifact2?clearFilter=true target="_blank">artifact2</a>
 
 </pre>

--- a/artifactory/commands/commandssummaries/uploadsummary.go
+++ b/artifactory/commands/commandssummaries/uploadsummary.go
@@ -10,7 +10,6 @@ type UploadSummary struct {
 	uploadTree        *utils.FileTree
 	uploadedArtifacts ResultsWrapper
 	platformUrl       string
-	projectKey        string
 	majorVersion      int
 }
 
@@ -24,10 +23,9 @@ type ResultsWrapper struct {
 	Results []UploadResult `json:"results"`
 }
 
-func NewUploadSummary(platformUrl, projectKey string, majorVersion int) *UploadSummary {
+func NewUploadSummary(platformUrl string, majorVersion int) *UploadSummary {
 	return &UploadSummary{
 		platformUrl:  platformUrl,
-		projectKey:   projectKey,
 		majorVersion: majorVersion,
 	}
 }
@@ -63,5 +61,5 @@ func (us *UploadSummary) generateFileTreeMarkdown() string {
 }
 
 func (us *UploadSummary) buildUiUrl(targetPath string) string {
-	return generateArtifactUrl(us.platformUrl, targetPath, us.projectKey, us.majorVersion)
+	return generateArtifactUrl(us.platformUrl, targetPath, us.majorVersion)
 }

--- a/artifactory/commands/commandssummaries/utils.go
+++ b/artifactory/commands/commandssummaries/utils.go
@@ -10,15 +10,10 @@ const (
 	artifactory6UiFormat = "%sartifactory/webapp/#/artifacts/browse/tree/General/%s"
 )
 
-func generateArtifactUrl(rtUrl, pathInRt, project string, majorVersion int) string {
+func generateArtifactUrl(rtUrl, pathInRt string, majorVersion int) string {
 	rtUrl = clientUtils.AddTrailingSlashIfNeeded(rtUrl)
 	if majorVersion == 6 {
 		return fmt.Sprintf(artifactory6UiFormat, rtUrl, pathInRt)
 	}
-	uri := fmt.Sprintf(artifactory7UiFormat, rtUrl, pathInRt)
-	if project != "" {
-		// Project key is added as a second parameter, because the format already has a query parameter.
-		uri += "&projectKey=" + project
-	}
-	return uri
+	return fmt.Sprintf(artifactory7UiFormat, rtUrl, pathInRt)
 }

--- a/artifactory/commands/commandssummaries/utils.go
+++ b/artifactory/commands/commandssummaries/utils.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	artifactory7UiFormat = "%sui/repos/tree/General/%s"
+	artifactory7UiFormat = "%sui/repos/tree/General/%s?clearFilter=true"
 	artifactory6UiFormat = "%sartifactory/webapp/#/artifacts/browse/tree/General/%s"
 )
 
@@ -17,7 +17,8 @@ func generateArtifactUrl(rtUrl, pathInRt, project string, majorVersion int) stri
 	}
 	uri := fmt.Sprintf(artifactory7UiFormat, rtUrl, pathInRt)
 	if project != "" {
-		uri += "?projectKey=" + project
+		// Project key is added as a second parameter, because the format already has a query parameter.
+		uri += "&projectKey=" + project
 	}
 	return uri
 }

--- a/artifactory/commands/commandssummaries/utils_test.go
+++ b/artifactory/commands/commandssummaries/utils_test.go
@@ -18,13 +18,13 @@ func TestGenerateArtifactUrl(t *testing.T) {
 		expected     string
 	}{
 		{"artifactory 7 without project", "", 7, "https://myplatform.com/ui/repos/tree/General/repo/path/file?clearFilter=true"},
-		{"artifactory 7 with project", "proj", 7, "https://myplatform.com/ui/repos/tree/General/repo/path/file?clearFilter=true&projectKey=proj"},
+		{"artifactory 7 with project", "proj", 7, "https://myplatform.com/ui/repos/tree/General/repo/path/file?clearFilter=true"},
 		{"artifactory 6 without project", "", 6, "https://myplatform.com/artifactory/webapp/#/artifacts/browse/tree/General/repo/path/file"},
 	}
 
 	for _, testCase := range cases {
 		t.Run(testCase.testName, func(t *testing.T) {
-			artifactUrl := generateArtifactUrl(platformUrl, fullPath, testCase.projectKey, testCase.majorVersion)
+			artifactUrl := generateArtifactUrl(platformUrl, fullPath, testCase.majorVersion)
 			assert.Equal(t, testCase.expected, artifactUrl)
 		})
 	}

--- a/artifactory/commands/commandssummaries/utils_test.go
+++ b/artifactory/commands/commandssummaries/utils_test.go
@@ -17,8 +17,8 @@ func TestGenerateArtifactUrl(t *testing.T) {
 		majorVersion int
 		expected     string
 	}{
-		{"artifactory 7 without project", "", 7, "https://myplatform.com/ui/repos/tree/General/repo/path/file"},
-		{"artifactory 7 with project", "proj", 7, "https://myplatform.com/ui/repos/tree/General/repo/path/file?projectKey=proj"},
+		{"artifactory 7 without project", "", 7, "https://myplatform.com/ui/repos/tree/General/repo/path/file?clearFilter=true"},
+		{"artifactory 7 with project", "proj", 7, "https://myplatform.com/ui/repos/tree/General/repo/path/file?clearFilter=true&projectKey=proj"},
 		{"artifactory 6 without project", "", 6, "https://myplatform.com/artifactory/webapp/#/artifacts/browse/tree/General/repo/path/file"},
 	}
 

--- a/artifactory/commands/generic/upload.go
+++ b/artifactory/commands/generic/upload.go
@@ -159,7 +159,7 @@ func (uc *UploadCommand) upload() (err error) {
 			successCount = summary.TotalSucceeded
 			failCount = summary.TotalFailed
 
-			if err = recordCommandSummary(servicesManager, summary, serverDetails.Url, uc.buildConfiguration); err != nil {
+			if err = recordCommandSummary(servicesManager, summary, serverDetails.Url); err != nil {
 				return
 			}
 		}
@@ -282,7 +282,7 @@ func createDeleteSpecForSync(deletePattern string, syncDeletesProp string) *spec
 		BuildSpec()
 }
 
-func recordCommandSummary(servicesManager artifactory.ArtifactoryServicesManager, summary *rtServicesUtils.OperationSummary, platformUrl string, buildConfig *build.BuildConfiguration) (err error) {
+func recordCommandSummary(servicesManager artifactory.ArtifactoryServicesManager, summary *rtServicesUtils.OperationSummary, platformUrl string) (err error) {
 	if !commandsummary.ShouldRecordSummary() {
 		return
 	}
@@ -292,12 +292,7 @@ func recordCommandSummary(servicesManager artifactory.ArtifactoryServicesManager
 		return err
 	}
 
-	// Get project key if exists
-	var projectKey string
-	if buildConfig != nil {
-		projectKey = buildConfig.GetProject()
-	}
-	uploadSummary, err := commandsummary.New(commandssummaries.NewUploadSummary(platformUrl, projectKey, majorVersion), "upload")
+	uploadSummary, err := commandsummary.New(commandssummaries.NewUploadSummary(platformUrl, majorVersion), "upload")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Improvements:
1. We clear filter on links to make sure the artifact is not masked and will be shown.
2. Remove the projectKey query param to avoid conflict with repositories that are not part of the project.