### PR TITLE
Fix "unknown/unknown" module id for docker attestations

### DIFF
--- a/artifactory/utils/container/manifest.go
+++ b/artifactory/utils/container/manifest.go
@@ -39,13 +39,20 @@ type FatManifest struct {
 }
 
 type ManifestDetails struct {
-	Digest   string   `json:"digest"`
-	Platform Platform `json:"platform"`
+	Digest      string      `json:"digest"`
+	Platform    Platform    `json:"platform"`
+	Annotations Annotations `json:"annotations"`
 }
 
 type Platform struct {
 	Architecture string `json:"architecture"`
 	Os           string `json:"os"`
+}
+
+// Annotations for attestation manifests.
+type Annotations struct {
+	ReferenceDigest string `json:"vnd.docker.reference.digest"`
+	ReferenceType   string `json:"vnd.docker.reference.type"`
 }
 
 // Return all the search patterns in which manifest can be found.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Docker attestations do not have a specified platform, so we cannot construct the module ID based on it.
This fix creates a dedicated module for Docker attestations.