### PR TITLE
Mvn - avoid parsing build info when it has not been collected

### DIFF
--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -265,9 +265,10 @@ func (mc *MvnCommand) updateBuildInfoArtifactsWithDeploymentRepo(vConfig *viper.
 	if err != nil {
 		return errorutils.CheckErrorf("failed to read build info file: %s", err.Error())
 	}
-	// There are some scenarios where the build info details were set but no content was generated,
-	// such as running a `jf mvn <command>` from the jfrog-cli-setup GitHub Action,
-	// which automatically fills the build info details, but the command itself doesn't always generate any content.
+	// In some scenarios, the build info details are set but no content is generated.
+	// For example, running a `jf mvn <command>` from the jfrog-cli-setup GitHub Action
+	// automatically fills the build info details, but the command itself may not generate any content.
+	// Examples include `mvn -v`, `mvn test`, etc.
 	if len(content) == 0 {
 		return nil
 	}

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -153,13 +153,15 @@ func (mc *MvnCommand) Run() error {
 		return err
 	}
 
-	isCollectedBuildInfo, err := mc.configuration.IsCollectBuildInfo()
-	if err != nil {
-		return err
-	}
-	if isCollectedBuildInfo {
-		if err = mc.updateBuildInfoArtifactsWithDeploymentRepo(vConfig, mvnParams.GetBuildInfoFilePath()); err != nil {
+	if mc.configuration != nil {
+		isCollectedBuildInfo, err := mc.configuration.IsCollectBuildInfo()
+		if err != nil {
 			return err
+		}
+		if isCollectedBuildInfo {
+			if err = mc.updateBuildInfoArtifactsWithDeploymentRepo(vConfig, mvnParams.GetBuildInfoFilePath()); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -266,7 +266,7 @@ func (mc *MvnCommand) updateBuildInfoArtifactsWithDeploymentRepo(vConfig *viper.
 		return errorutils.CheckErrorf("failed to read build info file: %s", err.Error())
 	}
 	// In some scenarios, the build info details are set but no content is generated.
-	// For example, running a `jf mvn <command>` from the jfrog-cli-setup GitHub Action
+	// For example, running a `jf mvn <command>` from the Setup JFrog Cli GitHub Action
 	// automatically fills the build info details, but the command itself may not generate any content.
 	// Examples include `mvn -v`, `mvn test`, etc.
 	if len(content) == 0 {

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -158,7 +158,7 @@ func (mc *MvnCommand) Run() error {
 		return err
 	}
 	if isCollectedBuildInfo {
-		if err = mc.updateBuildInfoArtifactsWithDeploymentRepo(vConfig, mc.buildArtifactsDetailsFile); err != nil {
+		if err = mc.updateBuildInfoArtifactsWithDeploymentRepo(vConfig, mvnParams.GetBuildInfoFilePath()); err != nil {
 			return err
 		}
 	}

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -153,8 +153,14 @@ func (mc *MvnCommand) Run() error {
 		return err
 	}
 
-	if err = mc.updateBuildInfoArtifactsWithDeploymentRepo(vConfig, mvnParams.GetBuildInfoFilePath()); err != nil {
+	isCollectedBuildInfo, err := mc.configuration.IsCollectBuildInfo()
+	if err != nil {
 		return err
+	}
+	if isCollectedBuildInfo {
+		if err = mc.updateBuildInfoArtifactsWithDeploymentRepo(vConfig, mc.buildArtifactsDetailsFile); err != nil {
+			return err
+		}
 	}
 
 	if mc.buildArtifactsDetailsFile == "" {
@@ -256,6 +262,9 @@ func (mc *MvnCommand) updateBuildInfoArtifactsWithDeploymentRepo(vConfig *viper.
 	content, err := os.ReadFile(buildInfoFilePath)
 	if err != nil {
 		return errorutils.CheckErrorf("failed to read build info file: %s", err.Error())
+	}
+	if len(content) == 0 {
+		return nil
 	}
 	buildInfo := new(entities.BuildInfo)
 	if err = json.Unmarshal(content, &buildInfo); err != nil {

--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -265,6 +265,9 @@ func (mc *MvnCommand) updateBuildInfoArtifactsWithDeploymentRepo(vConfig *viper.
 	if err != nil {
 		return errorutils.CheckErrorf("failed to read build info file: %s", err.Error())
 	}
+	// There are some scenarios where the build info details were set but no content was generated,
+	// such as running a `jf mvn <command>` from the jfrog-cli-setup GitHub Action,
+	// which automatically fills the build info details, but the command itself doesn't always generate any content.
 	if len(content) == 0 {
 		return nil
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
