### PR TITLE
Job Summary - Handle Docker Multi-Module Sections Separately

### DIFF
--- a/artifactory/commands/commandssummaries/buildinfosummary.go
+++ b/artifactory/commands/commandssummaries/buildinfosummary.go
@@ -6,7 +6,6 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils/container"
 	"github.com/jfrog/jfrog-cli-core/v2/commandsummary"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 	"path"
 	"strings"
 	"time"
@@ -186,9 +185,8 @@ func createDockerMultiArchTitle(module *buildInfo.Module, platformUrl string) st
 	var sha256 string
 	for _, artifact := range module.Artifacts {
 		if artifact.Name == container.ManifestJsonFile {
-			log.Info("Manifest file found with SHA256:", artifact.Sha256)
-			// Extract the sha256 from the artifact's sha256 field, The format is sha256:<sha256>
-			sha256 = strings.Split(artifact.Sha256, ":")[1]
+			sha256 = artifact.Sha256
+			break
 		}
 	}
 	// Create a link to the Docker package in Artifactory UI

--- a/artifactory/commands/commandssummaries/buildinfosummary.go
+++ b/artifactory/commands/commandssummaries/buildinfosummary.go
@@ -92,14 +92,14 @@ func (bis *BuildInfoSummary) generateModulesMarkdown(modules ...buildInfo.Module
 				// Skip the parent module if there are multiple modules, as it will be displayed as a header
 				continue
 			}
-			modulesMarkdown.WriteString(bis.generateModuleArtifactsTree(module, isMultiModule))
+			modulesMarkdown.WriteString(bis.generateModuleArtifactsTree(&module, isMultiModule))
 		}
 		modulesMarkdown.WriteString("</pre>\n")
 	}
 	return modulesMarkdown.String()
 }
 
-func (bis *BuildInfoSummary) generateModuleArtifactsTree(module buildInfo.Module, shouldCollapseArtifactsTree bool) string {
+func (bis *BuildInfoSummary) generateModuleArtifactsTree(module *buildInfo.Module, shouldCollapseArtifactsTree bool) string {
 	artifactsTree := bis.createArtifactsTree(module)
 	if shouldCollapseArtifactsTree {
 		return bis.generateModuleCollapsibleSection(module, artifactsTree)
@@ -107,16 +107,16 @@ func (bis *BuildInfoSummary) generateModuleArtifactsTree(module buildInfo.Module
 	return artifactsTree
 }
 
-func (bis *BuildInfoSummary) generateModuleCollapsibleSection(module buildInfo.Module, sectionContent string) string {
+func (bis *BuildInfoSummary) generateModuleCollapsibleSection(module *buildInfo.Module, sectionContent string) string {
 	switch module.Type {
 	case buildInfo.Docker:
-		return createCollapsibleSection(createDockerMultiArchTitle(&module, bis.platformUrl), sectionContent)
+		return createCollapsibleSection(createDockerMultiArchTitle(module, bis.platformUrl), sectionContent)
 	default:
 		return createCollapsibleSection(module.Id, sectionContent)
 	}
 }
 
-func (bis *BuildInfoSummary) createArtifactsTree(module buildInfo.Module) string {
+func (bis *BuildInfoSummary) createArtifactsTree(module *buildInfo.Module) string {
 	artifactsTree := utils.NewFileTree()
 	for _, artifact := range module.Artifacts {
 		artifactUrlInArtifactory := bis.generateArtifactUrl(artifact)
@@ -141,7 +141,7 @@ func (bis *BuildInfoSummary) generateArtifactUrl(artifact buildInfo.Artifact) st
 func groupModulesByParent(modules []buildInfo.Module) map[string][]buildInfo.Module {
 	parentToModulesMap := make(map[string][]buildInfo.Module, len(modules))
 	for _, module := range modules {
-		if len(module.Artifacts) == 0 || !isSupportedModule(module) {
+		if len(module.Artifacts) == 0 || !isSupportedModule(&module) {
 			continue
 		}
 
@@ -155,7 +155,7 @@ func groupModulesByParent(modules []buildInfo.Module) map[string][]buildInfo.Mod
 	return parentToModulesMap
 }
 
-func isSupportedModule(module buildInfo.Module) bool {
+func isSupportedModule(module *buildInfo.Module) bool {
 	switch module.Type {
 	case buildInfo.Maven, buildInfo.Npm, buildInfo.Go, buildInfo.Generic, buildInfo.Terraform:
 		return true

--- a/artifactory/commands/commandssummaries/buildinfosummary.go
+++ b/artifactory/commands/commandssummaries/buildinfosummary.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils/container"
 	"github.com/jfrog/jfrog-cli-core/v2/commandsummary"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 	"path"
 	"strings"
 	"time"
@@ -185,6 +186,7 @@ func createDockerMultiArchTitle(module *buildInfo.Module, platformUrl string) st
 	var sha256 string
 	for _, artifact := range module.Artifacts {
 		if artifact.Name == container.ManifestJsonFile {
+			log.Info("Manifest file found with SHA256:", artifact.Sha256)
 			// Extract the sha256 from the artifact's sha256 field, The format is sha256:<sha256>
 			sha256 = strings.Split(artifact.Sha256, ":")[1]
 		}

--- a/artifactory/commands/commandssummaries/buildinfosummary.go
+++ b/artifactory/commands/commandssummaries/buildinfosummary.go
@@ -111,10 +111,10 @@ func (bis *BuildInfoSummary) generateModuleCollapsibleSection(module buildInfo.M
 	switch module.Type {
 	case buildInfo.Docker:
 		// Extract the parent image name from the module ID (e.g. my-image:1.0 -> my-image)
-		parentImageName := strings.Split(module.Id, ":")[0]
+		parentImageName := strings.Split(module.Parent, ":")[0]
 		// Create a link to the Docker package in Artifactory UI
 		dockerModuleLink := fmt.Sprintf(artifactoryDockerPackagesUiFormat, strings.TrimSuffix(bis.platformUrl, "/"), "%2F%2F"+parentImageName, module.Sha256)
-		dockerTitleWithLink := fmt.Sprintf("%s <a href=%s>(View 🐸)</a>", module.Id, dockerModuleLink)
+		dockerTitleWithLink := fmt.Sprintf("%s <a href=%s>(🐸 View)</a>", module.Id, dockerModuleLink)
 		return createCollapsibleSection(dockerTitleWithLink, sectionContent)
 	default:
 		return createCollapsibleSection(module.Id, sectionContent)

--- a/artifactory/commands/commandssummaries/buildinfosummary.go
+++ b/artifactory/commands/commandssummaries/buildinfosummary.go
@@ -92,22 +92,22 @@ func (bis *BuildInfoSummary) generateModulesMarkdown(modules ...buildInfo.Module
 				// Skip the parent module if there are multiple modules, as it will be displayed as a header
 				continue
 			}
-			modulesMarkdown.WriteString(bis.generateModuleMarkdown(module, isMultiModule))
+			modulesMarkdown.WriteString(bis.generateModuleArtifactsTree(module, isMultiModule))
 		}
 		modulesMarkdown.WriteString("</pre>\n")
 	}
 	return modulesMarkdown.String()
 }
 
-func (bis *BuildInfoSummary) generateModuleMarkdown(module buildInfo.Module, shouldCollapse bool) string {
+func (bis *BuildInfoSummary) generateModuleArtifactsTree(module buildInfo.Module, shouldCollapseArtifactsTree bool) string {
 	artifactsTree := bis.createArtifactsTree(module)
-	if shouldCollapse {
+	if shouldCollapseArtifactsTree {
 		return bis.generateModuleCollapsibleSection(module, artifactsTree)
 	}
 	return artifactsTree
 }
 
-func (bis *BuildInfoSummary) generateModuleCollapsibleSection(module buildInfo.Module, artifactsTree string) string {
+func (bis *BuildInfoSummary) generateModuleCollapsibleSection(module buildInfo.Module, sectionContent string) string {
 	switch module.Type {
 	case buildInfo.Docker:
 		// Extract the parent image name from the module ID (e.g. my-image:1.0 -> my-image)
@@ -115,9 +115,9 @@ func (bis *BuildInfoSummary) generateModuleCollapsibleSection(module buildInfo.M
 		// Create a link to the Docker package in Artifactory UI
 		dockerModuleLink := fmt.Sprintf(artifactoryDockerPackagesUiFormat, strings.TrimSuffix(bis.platformUrl, "/"), "%2F%2F"+parentImageName, module.Sha256)
 		dockerTitleWithLink := fmt.Sprintf("%s <a href=%s>(View 🐸)</a>", module.Id, dockerModuleLink)
-		return createCollapsibleSection(dockerTitleWithLink, artifactsTree)
+		return createCollapsibleSection(dockerTitleWithLink, sectionContent)
 	default:
-		return createCollapsibleSection(module.Id, artifactsTree)
+		return createCollapsibleSection(module.Id, sectionContent)
 	}
 }
 

--- a/artifactory/commands/commandssummaries/buildinfosummary_test.go
+++ b/artifactory/commands/commandssummaries/buildinfosummary_test.go
@@ -125,6 +125,9 @@ func TestBuildInfoModulesWithGrouping(t *testing.T) {
 			Started: "2024-08-12T11:11:50.198+0300",
 			Modules: []buildinfo.Module{
 				{
+					Checksum: buildinfo.Checksum{
+						Sha256: "2217c766cddcd2d24994caaf7713db556a0fa8de108a946ebe5b0369f784a59a",
+					},
 					Properties: map[string]string{
 						"docker.image.tag": "ecosysjfrog.jfrog.io/docker-local/multiarch-image:1",
 					},
@@ -148,6 +151,9 @@ func TestBuildInfoModulesWithGrouping(t *testing.T) {
 					Type:   "docker",
 					Parent: "multiarch-image:1",
 					Id:     "linux/amd64/multiarch-image:1",
+					Checksum: buildinfo.Checksum{
+						Sha256: "aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e",
+					},
 					Artifacts: []buildinfo.Artifact{
 						{
 							Checksum: buildinfo.Checksum{
@@ -165,6 +171,9 @@ func TestBuildInfoModulesWithGrouping(t *testing.T) {
 					Type:   "docker",
 					Parent: "multiarch-image:1",
 					Id:     "linux/arm64/multiarch-image:1",
+					Checksum: buildinfo.Checksum{
+						Sha256: "1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93",
+					},
 					Artifacts: []buildinfo.Artifact{
 						{
 							Checksum: buildinfo.Checksum{
@@ -182,6 +191,9 @@ func TestBuildInfoModulesWithGrouping(t *testing.T) {
 					Type:   "docker",
 					Parent: "multiarch-image:1",
 					Id:     "linux/arm/multiarch-image:1",
+					Checksum: buildinfo.Checksum{
+						Sha256: "33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c",
+					},
 					Artifacts: []buildinfo.Artifact{
 						{
 							Checksum: buildinfo.Checksum{
@@ -207,8 +219,31 @@ func TestBuildInfoModulesWithGrouping(t *testing.T) {
 				},
 				{
 					Type:   "docker",
+					Parent: "multiarch-image:1",
+					Id:     "attestations/multiarch-image:1",
+					Checksum: buildinfo.Checksum{
+						Sha256: "33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c",
+					},
+					Artifacts: []buildinfo.Artifact{
+						{
+							Checksum: buildinfo.Checksum{
+								Sha1:   "63d3ac90f9cd322b76543d7bf96eeb92417faf41",
+								Sha256: "33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c",
+								Md5:    "99bbb1e1035aea4d9150e4348f24e107",
+							},
+							Name:                   "sha256:67a5a1efd2df970568a17c1178ec5df786bbf627274f285c6dbce71fae9ebe57",
+							Path:                   "multiarch-image/sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338/sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c",
+							OriginalDeploymentRepo: "docker-local",
+						},
+					},
+				},
+				{
+					Type:   "docker",
 					Parent: "image:2",
 					Id:     "image:2",
+					Checksum: buildinfo.Checksum{
+						Sha256: "aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e",
+					},
 					Artifacts: []buildinfo.Artifact{
 						{
 							Checksum: buildinfo.Checksum{

--- a/artifactory/commands/commandssummaries/buildinfosummary_test.go
+++ b/artifactory/commands/commandssummaries/buildinfosummary_test.go
@@ -125,9 +125,6 @@ func TestBuildInfoModulesWithGrouping(t *testing.T) {
 			Started: "2024-08-12T11:11:50.198+0300",
 			Modules: []buildinfo.Module{
 				{
-					Checksum: buildinfo.Checksum{
-						Sha256: "2217c766cddcd2d24994caaf7713db556a0fa8de108a946ebe5b0369f784a59a",
-					},
 					Properties: map[string]string{
 						"docker.image.tag": "ecosysjfrog.jfrog.io/docker-local/multiarch-image:1",
 					},
@@ -151,10 +148,17 @@ func TestBuildInfoModulesWithGrouping(t *testing.T) {
 					Type:   "docker",
 					Parent: "multiarch-image:1",
 					Id:     "linux/amd64/multiarch-image:1",
-					Checksum: buildinfo.Checksum{
-						Sha256: "aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e",
-					},
 					Artifacts: []buildinfo.Artifact{
+						{
+							Checksum: buildinfo.Checksum{
+								Sha1:   "32c1416f8430fbbabd82cb014c5e09c5fe702404",
+								Sha256: "sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21",
+								Md5:    "f568bfb1c9576a1f06235ebe0389d2d8",
+							},
+							Name:                   "manifest.json",
+							Path:                   "multiarch-image/sha256__552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21",
+							OriginalDeploymentRepo: "docker-local",
+						},
 						{
 							Checksum: buildinfo.Checksum{
 								Sha1:   "32c1416f8430fbbabd82cb014c5e09c5fe702404",
@@ -171,10 +175,17 @@ func TestBuildInfoModulesWithGrouping(t *testing.T) {
 					Type:   "docker",
 					Parent: "multiarch-image:1",
 					Id:     "linux/arm64/multiarch-image:1",
-					Checksum: buildinfo.Checksum{
-						Sha256: "1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93",
-					},
 					Artifacts: []buildinfo.Artifact{
+						{
+							Checksum: buildinfo.Checksum{
+								Sha1:   "32c1416f8430fbbabd82cb014c5e09c5fe702404",
+								Sha256: "sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92",
+								Md5:    "f568bfb1c9576a1f06235ebe0389d2d8",
+							},
+							Name:                   "manifest.json",
+							Path:                   "multiarch-image/sha256__bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92",
+							OriginalDeploymentRepo: "docker-local",
+						},
 						{
 							Checksum: buildinfo.Checksum{
 								Sha1:   "82b6d4ae1f673c609469a0a84170390ecdff5a38",
@@ -191,10 +202,17 @@ func TestBuildInfoModulesWithGrouping(t *testing.T) {
 					Type:   "docker",
 					Parent: "multiarch-image:1",
 					Id:     "linux/arm/multiarch-image:1",
-					Checksum: buildinfo.Checksum{
-						Sha256: "33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c",
-					},
 					Artifacts: []buildinfo.Artifact{
+						{
+							Checksum: buildinfo.Checksum{
+								Sha1:   "32c1416f8430fbbabd82cb014c5e09c5fe702404",
+								Sha256: "sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338",
+								Md5:    "f568bfb1c9576a1f06235ebe0389d2d8",
+							},
+							Name:                   "manifest.json",
+							Path:                   "multiarch-image/sha256__686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338",
+							OriginalDeploymentRepo: "docker-local",
+						},
 						{
 							Checksum: buildinfo.Checksum{
 								Sha1:   "63d3ac90f9cd322b76543d7bf96eeb92417faf41",

--- a/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
+++ b/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
@@ -1,21 +1,25 @@
 #### multiarch-image:1
-<pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e>(🐸 View)</a></summary>
-📦 docker-local
-└── 📁 multiarch-image
-    └── 📁 sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21
-        └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e?clearFilter=true target="_blank">sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e</a>
 
-</details><details><summary>linux/arm64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93>(🐸 View)</a></summary>
+<pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21>(🐸 View)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
-    └── 📁 sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92
-        └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93?clearFilter=true target="_blank">sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93</a>
+    ├── 📁 sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21
+    │   └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e?clearFilter=true target="_blank">sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e</a>
+    └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256__552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21?clearFilter=true target="_blank">sha256__552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21</a>
 
-</details><details><summary>linux/arm/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c>(🐸 View)</a></summary>
+</details><details><summary>linux/arm64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92>(🐸 View)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
-    └── 📁 sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338
-        ├── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338/sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c?clearFilter=true target="_blank">sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c</a>
-        └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338/sha256__5480d2ca1740c20ce17652e01ed2265cdc914458acd41256a2b1ccff28f2762c?clearFilter=true target="_blank">sha256__5480d2ca1740c20ce17652e01ed2265cdc914458acd41256a2b1ccff28f2762c</a>
+    ├── 📁 sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92
+    │   └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93?clearFilter=true target="_blank">sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93</a>
+    └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256__bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92?clearFilter=true target="_blank">sha256__bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92</a>
+
+</details><details><summary>linux/arm/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338>(🐸 View)</a></summary>
+📦 docker-local
+└── 📁 multiarch-image
+    ├── 📁 sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338
+    │   ├── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338/sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c?clearFilter=true target="_blank">sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c</a>
+    │   └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338/sha256__5480d2ca1740c20ce17652e01ed2265cdc914458acd41256a2b1ccff28f2762c?clearFilter=true target="_blank">sha256__5480d2ca1740c20ce17652e01ed2265cdc914458acd41256a2b1ccff28f2762c</a>
+    └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256__686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338?clearFilter=true target="_blank">sha256__686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338</a>
 
 </details></pre>

--- a/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
+++ b/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
@@ -1,5 +1,4 @@
 #### multiarch-image:1
-
 <pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Flinux/amd64/multiarch-image/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e>(View 🐸)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image

--- a/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
+++ b/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
@@ -1,19 +1,19 @@
 #### multiarch-image:1
-<pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21>(🐸 View)</a></summary>
+<pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21>(🐸 View)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
     ├── 📁 sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21
     │   └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e?clearFilter=true target="_blank">sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e</a>
     └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256__552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21?clearFilter=true target="_blank">sha256__552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21</a>
 
-</details><details><summary>linux/arm64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92>(🐸 View)</a></summary>
+</details><details><summary>linux/arm64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92>(🐸 View)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
     ├── 📁 sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92
     │   └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93?clearFilter=true target="_blank">sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93</a>
     └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256__bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92?clearFilter=true target="_blank">sha256__bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92</a>
 
-</details><details><summary>linux/arm/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338>(🐸 View)</a></summary>
+</details><details><summary>linux/arm/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338>(🐸 View)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
     ├── 📁 sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338

--- a/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
+++ b/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
@@ -1,5 +1,4 @@
 #### multiarch-image:1
-
 <pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e>(🐸 View)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image

--- a/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
+++ b/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
@@ -1,17 +1,18 @@
 #### multiarch-image:1
-<pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Flinux/amd64/multiarch-image/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e>(View 🐸)</a></summary>
+
+<pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e>(🐸 View)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
     └── 📁 sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21
         └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e?clearFilter=true target="_blank">sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e</a>
 
-</details><details><summary>linux/arm64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Flinux/arm64/multiarch-image/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93>(View 🐸)</a></summary>
+</details><details><summary>linux/arm64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93>(🐸 View)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
     └── 📁 sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92
         └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93?clearFilter=true target="_blank">sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93</a>
 
-</details><details><summary>linux/arm/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Flinux/arm/multiarch-image/sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c>(View 🐸)</a></summary>
+</details><details><summary>linux/arm/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c>(🐸 View)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
     └── 📁 sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338

--- a/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
+++ b/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
@@ -1,5 +1,4 @@
 #### multiarch-image:1
-
 <pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Fmultiarch-image/sha256__552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21>(🐸 View)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image

--- a/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
+++ b/artifactory/commands/commandssummaries/testdata/multiarch-image1.md
@@ -1,17 +1,18 @@
 #### multiarch-image:1
-<pre><details><summary>linux/amd64/multiarch-image:1</summary>
+
+<pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Flinux/amd64/multiarch-image/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e>(View 🐸)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
     └── 📁 sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21
         └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e?clearFilter=true target="_blank">sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e</a>
 
-</details><details><summary>linux/arm64/multiarch-image:1</summary>
+</details><details><summary>linux/arm64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Flinux/arm64/multiarch-image/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93>(View 🐸)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
     └── 📁 sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92
         └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93?clearFilter=true target="_blank">sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93</a>
 
-</details><details><summary>linux/arm/multiarch-image:1</summary>
+</details><details><summary>linux/arm/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Flinux/arm/multiarch-image/sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c>(View 🐸)</a></summary>
 📦 docker-local
 └── 📁 multiarch-image
     └── 📁 sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338

--- a/artifactory/commands/commandssummaries/utils.go
+++ b/artifactory/commands/commandssummaries/utils.go
@@ -8,6 +8,8 @@ import (
 const (
 	artifactory7UiFormat = "%sui/repos/tree/General/%s?clearFilter=true"
 	artifactory6UiFormat = "%sartifactory/webapp/#/artifacts/browse/tree/General/%s"
+
+	artifactoryDockerPackagesUiFormat = "%s/ui/packages/docker:%s/sha256__%s"
 )
 
 func generateArtifactUrl(rtUrl, pathInRt string, majorVersion int) string {

--- a/artifactory/utils/container/buildinfo.go
+++ b/artifactory/utils/container/buildinfo.go
@@ -27,7 +27,8 @@ const (
 	markerLayerSuffix          string      = ".marker"
 	attestationManifestRefType string      = "attestation-manifest"
 	unknownPlatformPlaceholder string      = "unknown"
-	attestationsModuleIdPrefix string      = "attestations"
+
+	AttestationsModuleIdPrefix string = "attestations"
 )
 
 // Docker image build info builder.
@@ -385,7 +386,7 @@ func (builder *buildInfoBuilder) createMultiPlatformBuildInfo(fatManifest *FatMa
 // Construct the manifest's module ID by its type (attestation) or its platform.
 func getModuleIdByManifest(manifest ManifestDetails, baseModuleId string) string {
 	if manifest.Annotations.ReferenceType == attestationManifestRefType {
-		return path.Join(attestationsModuleIdPrefix, baseModuleId)
+		return path.Join(AttestationsModuleIdPrefix, baseModuleId)
 	}
 	if manifest.Platform.Os != unknownPlatformPlaceholder && manifest.Platform.Architecture != unknownPlatformPlaceholder {
 		return path.Join(manifest.Platform.Os, manifest.Platform.Architecture, baseModuleId)

--- a/artifactory/utils/container/buildinfo.go
+++ b/artifactory/utils/container/buildinfo.go
@@ -132,7 +132,7 @@ func getManifestArtifact(manifest *utils.ResultItem) (artifact buildinfo.Artifac
 	return buildinfo.Artifact{
 		Name:                   ManifestJsonFile,
 		Type:                   "json",
-		Checksum:               buildinfo.Checksum{Sha1: manifest.Actual_Sha1, Md5: manifest.Actual_Md5},
+		Checksum:               buildinfo.Checksum{Sha1: manifest.Actual_Sha1, Md5: manifest.Actual_Md5, Sha256: manifest.Sha256},
 		Path:                   path.Join(manifest.Path, manifest.Name),
 		OriginalDeploymentRepo: manifest.Repo,
 	}
@@ -143,7 +143,7 @@ func getFatManifestArtifact(fatManifest *utils.ResultItem) (artifact buildinfo.A
 	return buildinfo.Artifact{
 		Name:                   "list.manifest.json",
 		Type:                   "json",
-		Checksum:               buildinfo.Checksum{Sha1: fatManifest.Actual_Sha1, Md5: fatManifest.Actual_Md5},
+		Checksum:               buildinfo.Checksum{Sha1: fatManifest.Actual_Sha1, Md5: fatManifest.Actual_Md5, Sha256: fatManifest.Sha256},
 		Path:                   path.Join(fatManifest.Path, fatManifest.Name),
 		OriginalDeploymentRepo: fatManifest.Repo,
 	}
@@ -154,7 +154,7 @@ func getManifestDependency(searchResults *utils.ResultItem) (dependency buildinf
 	return buildinfo.Dependency{
 		Id:       ManifestJsonFile,
 		Type:     "json",
-		Checksum: buildinfo.Checksum{Sha1: searchResults.Actual_Sha1, Md5: searchResults.Actual_Md5},
+		Checksum: buildinfo.Checksum{Sha1: searchResults.Actual_Sha1, Md5: searchResults.Actual_Md5, Sha256: searchResults.Sha256},
 	}
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
- Ignore Docker attestation modules in the summary.
- Add a link to the Docker package in Artifactory in the multi-arch collapsible view.

#### multiarch-image:1
<pre><details><summary>linux/amd64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Flinux/amd64/multiarch-image/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e>(View 🐸)</a></summary>
📦 docker-local
└── 📁 multiarch-image
    └── 📁 sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21
        └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:552ccb2628970ef526f13151a0269258589fc8b5701519a9c255c4dd224b9a21/sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e?clearFilter=true target="_blank">sha256__aee9d258e62f0666e3286acca21be37d2e39f69f8dde74454b9f3cd8ef437e4e</a>

</details><details><summary>linux/arm64/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Flinux/arm64/multiarch-image/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93>(View 🐸)</a></summary>
📦 docker-local
└── 📁 multiarch-image
    └── 📁 sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92
        └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:bee6dc0408dfd20c01e12e644d8bc1d60ff100a8c180d6c7e85d374c13ae4f92/sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93?clearFilter=true target="_blank">sha256__1f17f9d95f85ba55773db30ac8e6fae894831be87f5c28f2b58d17f04ef65e93</a>

</details><details><summary>linux/arm/multiarch-image:1 <a href=https://myplatform.com/ui/packages/docker:%2F%2Flinux/arm/multiarch-image/sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c>(View 🐸)</a></summary>
📦 docker-local
└── 📁 multiarch-image
    └── 📁 sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338
        ├── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338/sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c?clearFilter=true target="_blank">sha256__33b5b5485e88e63d3630e5dcb008f98f102b0f980a9daa31bd976efdec7a8e4c</a>
        └── <a href=https://myplatform.com/ui/repos/tree/General/docker-local/multiarch-image/sha256:686085b9972e0f7a432b934574e3dca27b4fa0a3d10d0ae7099010160db6d338/sha256__5480d2ca1740c20ce17652e01ed2265cdc914458acd41256a2b1ccff28f2762c?clearFilter=true target="_blank">sha256__5480d2ca1740c20ce17652e01ed2265cdc914458acd41256a2b1ccff28f2762c</a>

</details></pre>
