### PR TITLE
 Update go.mod and go.sum with latest version of jfrog-client-go

### DIFF
--- a/artifactory/commands/transferfiles/transfer_test.go
+++ b/artifactory/commands/transferfiles/transfer_test.go
@@ -333,7 +333,7 @@ func TestGetAllLocalRepositories(t *testing.T) {
 			assert.NoError(t, err)
 			_, err = w.Write(bytes)
 			assert.NoError(t, err)
-		case "/api/repositories?type=local&packageType=":
+		case "/api/repositories?type=local":
 			// Response for GetWithFilter
 			w.WriteHeader(http.StatusOK)
 			response := &[]services.RepositoryDetails{{Key: "repo-1"}, {Key: "repo-2"}}
@@ -341,7 +341,7 @@ func TestGetAllLocalRepositories(t *testing.T) {
 			assert.NoError(t, err)
 			_, err = w.Write(bytes)
 			assert.NoError(t, err)
-		case "/api/repositories?type=federated&packageType=":
+		case "/api/repositories?type=federated":
 			// Response for GetWithFilter
 			w.WriteHeader(http.StatusOK)
 			// We add a build info repository to the response to cover cases whereby a federated build-info repository is returned

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240811142930-ab9715567376
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240827071113-de462dc3df22
 
 // replace github.com/jfrog/build-info-go => github.com/asafambar/build-info-go v1.8.9-0.20240819133117-c3f52700927d
 

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/jfrog/build-info-go v1.9.34 h1:bPnW58VpclbpBe/x8XEu/2BIviEOoJrJ5PkRRc
 github.com/jfrog/build-info-go v1.9.34/go.mod h1:6mdtqjREK76bHNODXakqKR/+ksJ9dvfLS7H57BZtnLY=
 github.com/jfrog/gofrog v1.7.5 h1:dFgtEDefJdlq9cqTRoe09RLxS5Bxbe1Ev5+E6SmZHcg=
 github.com/jfrog/gofrog v1.7.5/go.mod h1:jyGiCgiqSSR7k86hcUSu67XVvmvkkgWTmPsH25wI298=
-github.com/jfrog/jfrog-client-go v1.45.0 h1:CX+xlMdcvnG509PExwqJ17hzwVtFfkpeCyeKmDKKRNY=
-github.com/jfrog/jfrog-client-go v1.45.0/go.mod h1:f5Jfv+RGKVr4smOp4a4pxyBKdlpLG7R894kx2XW+w8c=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20240827071113-de462dc3df22 h1:+4D+R4PTZHzMjLJ5C50U/omYgMIz3aLLUwUCi+REJiU=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20240827071113-de462dc3df22/go.mod h1:f5Jfv+RGKVr4smOp4a4pxyBKdlpLG7R894kx2XW+w8c=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
This PR updates the JFrog CLI Code to use the latest development branch.
Prior to this pull request (PR), the JFrog CLI client was generating `/api/repositories?type=federated&packageType=`. We can see that the packageType is empty. The new code inside JFrog client Go generates it better like this: `/API/repositories?type=federated`. 

Following tests were modified as the URI for query parameters was changed and resulted in more accurate results