### PR TITLE
Command Summary - Separate Module Table View from Artifacts Tree

### DIFF
--- a/artifactory/utils/commandsummary/buildinfosummary.go
+++ b/artifactory/utils/commandsummary/buildinfosummary.go
@@ -102,7 +102,7 @@ func (bis *BuildInfoSummary) buildInfoModules(builds []*buildInfo.BuildInfo) str
 
 func (bis *BuildInfoSummary) generateModulesMarkdown(modules ...buildInfo.Module) string {
 	var modulesMarkdown strings.Builder
-	// Modules could help nested modules inside of them
+	// Modules could include nested modules inside of them
 	// Group the modules by their root module ID
 	// If a module has no root, it is considered as a root module itself.
 	groupedModuleMap := groupModules(modules)
@@ -336,12 +336,14 @@ func extractDockerImageTag(modules []buildInfo.Module) string {
 	return ""
 }
 
-func filterModules(modules ...buildInfo.Module) (supportedModules []buildInfo.Module) {
+// Filter out unsupported modules, return empty list if no supported modules found.
+func filterModules(modules ...buildInfo.Module) []buildInfo.Module {
+	supportedModules := make([]buildInfo.Module, 0, len(modules))
 	for _, module := range modules {
 		if !isSupportedModule(&module) {
 			continue
 		}
 		supportedModules = append(supportedModules, module)
 	}
-	return
+	return supportedModules
 }

--- a/artifactory/utils/commandsummary/buildinfosummary.go
+++ b/artifactory/utils/commandsummary/buildinfosummary.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	basicSummaryUpgradeNotice = "<a href=\"%s\">🐸 Enable the linkage to Artifactory</a>\n\n"
-	modulesTitle              = "📦 Artifacts published to Artifactory by this workflow"
+	modulesTitle              = "📦 Modules published to Artifactory by this workflow"
 	minTableColumnLength      = 400
 	markdownSpaceFiller       = "&nbsp;"
 	NonScannedResult          = "non-scanned"
@@ -67,16 +67,20 @@ func (bis *BuildInfoSummary) GenerateMarkdownFromFiles(dataFilePaths []string) (
 	return WrapCollapsableMarkdown(bis.GetSummaryTitle(), finalMarkdown, 3), nil
 }
 
+// Create a table with published builds and possible scan results.
 func (bis *BuildInfoSummary) buildInfoTable(builds []*buildInfo.BuildInfo) string {
 	var tableBuilder strings.Builder
 	tableBuilder.WriteString(getBuildInfoTableHeader())
 	for _, build := range builds {
-		appendBuildRow(&tableBuilder, build)
+		appendBuildInfoRow(&tableBuilder, build)
 	}
 	tableBuilder.WriteString("\n\n")
 	return tableBuilder.String()
 }
 
+// Generates a view for published modules within the build.
+// Modules are displayed as tables if they are scannable via CLI command,
+// otherwise, they are shown as an artifact tree.
 func (bis *BuildInfoSummary) buildInfoModules(builds []*buildInfo.BuildInfo) string {
 	var markdownBuilder strings.Builder
 	markdownBuilder.WriteString("\n\n<h3>Published Modules</h3>\n\n")
@@ -268,7 +272,7 @@ func appendSpacesToTableColumn(str string) string {
 	return str
 }
 
-func appendBuildRow(tableBuilder *strings.Builder, build *buildInfo.BuildInfo) {
+func appendBuildInfoRow(tableBuilder *strings.Builder, build *buildInfo.BuildInfo) {
 	buildName := build.Name + " " + build.Number
 	buildScanResult := getScanResults(buildName)
 	if StaticMarkdownConfig.IsExtendedSummary() {

--- a/artifactory/utils/commandsummary/buildinfosummary.go
+++ b/artifactory/utils/commandsummary/buildinfosummary.go
@@ -45,12 +45,13 @@ func (bis *BuildInfoSummary) GetSummaryTitle() string {
 	return "🛠️️ Published JFrog Build Info"
 }
 
-func (bis *BuildInfoSummary) GenerateMarkdownFromFiles(dataFilePaths []string) (string, error) {
+func (bis *BuildInfoSummary) GenerateMarkdownFromFiles(dataFilePaths []string) (finalMarkdown string, err error) {
+	// Aggregate all the build info files into a slice
 	var builds []*buildInfo.BuildInfo
 	for _, filePath := range dataFilePaths {
 		var publishBuildInfo buildInfo.BuildInfo
-		if err := UnmarshalFromFilePath(filePath, &publishBuildInfo); err != nil {
-			return "", err
+		if err = UnmarshalFromFilePath(filePath, &publishBuildInfo); err != nil {
+			return
 		}
 		builds = append(builds, &publishBuildInfo)
 	}
@@ -63,7 +64,8 @@ func (bis *BuildInfoSummary) GenerateMarkdownFromFiles(dataFilePaths []string) (
 	if publishedModulesMarkdown != "" {
 		publishedModulesMarkdown = WrapCollapsableMarkdown(modulesTitle, publishedModulesMarkdown, 2)
 	}
-	finalMarkdown := buildInfoTableMarkdown + publishedModulesMarkdown
+	finalMarkdown = buildInfoTableMarkdown + publishedModulesMarkdown
+
 	return WrapCollapsableMarkdown(bis.GetSummaryTitle(), finalMarkdown, 3), nil
 }
 

--- a/artifactory/utils/commandsummary/buildinfosummary.go
+++ b/artifactory/utils/commandsummary/buildinfosummary.go
@@ -56,7 +56,7 @@ func (bis *BuildInfoSummary) GenerateMarkdownFromFiles(dataFilePaths []string) (
 		builds = append(builds, &publishBuildInfo)
 	}
 	if len(builds) == 0 {
-		return "", nil
+		return
 	}
 
 	buildInfoTableMarkdown := bis.buildInfoTable(builds)

--- a/artifactory/utils/commandsummary/buildinfosummary_test.go
+++ b/artifactory/utils/commandsummary/buildinfosummary_test.go
@@ -520,7 +520,7 @@ func testMarkdownOutput(t *testing.T, expected, actual string) {
 	// the string is not formatted, leading to an unequal comparison.
 	// Ensure to test small units of Markdown for better unit testing
 	// and to facilitate testing.
-	maxCompareLength := 5000
+	maxCompareLength := 950
 	if len(expected) > maxCompareLength || len(actual) > maxCompareLength {
 		t.Fatalf("Markdown output is too long to compare, limit the length to %d chars", maxCompareLength)
 	}

--- a/artifactory/utils/commandsummary/buildinfosummary_test.go
+++ b/artifactory/utils/commandsummary/buildinfosummary_test.go
@@ -17,6 +17,7 @@ const (
 	dockerImageModule     = "docker-image-module.md"
 	genericModule         = "generic-module.md"
 	mavenModule           = "maven-module.md"
+	mavenNestedModule     = "maven-nested-module.md"
 	dockerMultiArchModule = "multiarch-docker-image.md"
 )
 
@@ -119,6 +120,72 @@ func TestBuildInfoModulesMaven(t *testing.T) {
 		StaticMarkdownConfig.setExtendedSummary(false)
 		res := buildInfoSummary.buildInfoModules(builds)
 		testMarkdownOutput(t, getTestDataFile(t, mavenModule), res)
+	})
+}
+
+func TestBuildInfoModulesMavenWithSubModules(t *testing.T) {
+	buildInfoSummary, cleanUp := prepareBuildInfoTest()
+	defer func() {
+		cleanUp()
+	}()
+	var builds = []*buildinfo.BuildInfo{
+		{
+			Name:     "buildName",
+			Number:   "123",
+			Started:  "2024-05-05T12:47:20.803+0300",
+			BuildUrl: "http://myJFrogPlatform/builds/buildName/123",
+			Modules: []buildinfo.Module{
+				{
+					Id:   "maven",
+					Type: buildinfo.Maven,
+					Artifacts: []buildinfo.Artifact{{
+						Name:                   "artifact1",
+						Path:                   "path/to/artifact1",
+						OriginalDeploymentRepo: "libs-release",
+					}},
+					Dependencies: []buildinfo.Dependency{{
+						Id: "dep1",
+					}},
+				},
+				{
+					Id:     "submodule1",
+					Parent: "maven",
+					Type:   buildinfo.Maven,
+					Artifacts: []buildinfo.Artifact{{
+						Name:                   "artifact2",
+						Path:                   "path/to/artifact2",
+						OriginalDeploymentRepo: "libs-release",
+					}},
+					Dependencies: []buildinfo.Dependency{{
+						Id: "dep2",
+					}},
+				},
+				{
+					Id:     "submodule2",
+					Parent: "maven",
+					Type:   buildinfo.Maven,
+					Artifacts: []buildinfo.Artifact{{
+						Name:                   "artifact3",
+						Path:                   "path/to/artifact3",
+						OriginalDeploymentRepo: "libs-release",
+					}},
+					Dependencies: []buildinfo.Dependency{{
+						Id: "dep3",
+					}},
+				},
+			},
+		},
+	}
+
+	t.Run("Extended Summary", func(t *testing.T) {
+		StaticMarkdownConfig.setExtendedSummary(true)
+		res := buildInfoSummary.buildInfoModules(builds)
+		testMarkdownOutput(t, getTestDataFile(t, mavenNestedModule), res)
+	})
+	t.Run("Basic Summary", func(t *testing.T) {
+		StaticMarkdownConfig.setExtendedSummary(false)
+		res := buildInfoSummary.buildInfoModules(builds)
+		testMarkdownOutput(t, getTestDataFile(t, mavenNestedModule), res)
 	})
 }
 

--- a/artifactory/utils/commandsummary/markdownConfig.go
+++ b/artifactory/utils/commandsummary/markdownConfig.go
@@ -67,6 +67,7 @@ func InitMarkdownGenerationValues(serverUrl string, platformMajorVersion int) (e
 		return
 	}
 	StaticMarkdownConfig.setExtendedSummary(entitled)
+	StaticMarkdownConfig.setExtendedSummary(false)
 	StaticMarkdownConfig.setPlatformMajorVersion(platformMajorVersion)
 	StaticMarkdownConfig.setPlatformUrl(serverUrl)
 	return

--- a/artifactory/utils/commandsummary/markdownConfig.go
+++ b/artifactory/utils/commandsummary/markdownConfig.go
@@ -67,7 +67,6 @@ func InitMarkdownGenerationValues(serverUrl string, platformMajorVersion int) (e
 		return
 	}
 	StaticMarkdownConfig.setExtendedSummary(entitled)
-	StaticMarkdownConfig.setExtendedSummary(false)
 	StaticMarkdownConfig.setPlatformMajorVersion(platformMajorVersion)
 	StaticMarkdownConfig.setPlatformUrl(serverUrl)
 	return

--- a/artifactory/utils/testdata/command_summaries/basic/generic-module.md
+++ b/artifactory/utils/testdata/command_summaries/basic/generic-module.md
@@ -6,8 +6,14 @@
 
 **generic**
 
+<a href="https://jfrog.com/help/r/jfrog-and-github-integration-guide/jfrog-and-github-integration-features-matrix">🐸 Enable the linkage to Artifactory</a>
 
 
-| Artifacts | Security Violations | Security Issues |
-| :------------ | :--------------------- | :------------------ |
-| <a href="https://jfrog.com/help/r/jfrog-and-github-integration-guide/jfrog-and-github-integration-features-matrix">🐸 Enable the linkage to Artifactory</a><br><br><pre>📦 generic-local<br>└── 📁 path<br>    └── 📁 to<br>        └── 📄 artifact2<br><br></pre> | Not scanned | Not scanned |
+
+<pre>📦 generic-local
+└── 📁 path
+    └── 📁 to
+        └── 📄 artifact2
+
+</pre>
+

--- a/artifactory/utils/testdata/command_summaries/basic/maven-module.md
+++ b/artifactory/utils/testdata/command_summaries/basic/maven-module.md
@@ -6,8 +6,14 @@
 
 **maven**
 
+<a href="https://jfrog.com/help/r/jfrog-and-github-integration-guide/jfrog-and-github-integration-features-matrix">🐸 Enable the linkage to Artifactory</a>
 
 
-| Artifacts | Security Violations | Security Issues |
-| :------------ | :--------------------- | :------------------ |
-| <a href="https://jfrog.com/help/r/jfrog-and-github-integration-guide/jfrog-and-github-integration-features-matrix">🐸 Enable the linkage to Artifactory</a><br><br><pre>📦 libs-release<br>└── 📁 path<br>    └── 📁 to<br>        └── 📄 artifact1<br><br></pre> | Not scanned | Not scanned |
+
+<pre>📦 libs-release
+└── 📁 path
+    └── 📁 to
+        └── 📄 artifact1
+
+</pre>
+

--- a/artifactory/utils/testdata/command_summaries/basic/maven-nested-module.md
+++ b/artifactory/utils/testdata/command_summaries/basic/maven-nested-module.md
@@ -1,0 +1,30 @@
+
+
+<h3>Published Modules</h3>
+
+
+
+**maven**
+
+<a href="https://jfrog.com/help/r/jfrog-and-github-integration-guide/jfrog-and-github-integration-features-matrix">🐸 Enable the linkage to Artifactory</a>
+
+
+
+<pre><details><summary>submodule1</summary>
+📦 libs-release
+└── 📁 path
+    └── 📁 to
+        └── 📄 artifact2
+
+</details></pre>
+
+
+
+<pre><details><summary>submodule2</summary>
+📦 libs-release
+└── 📁 path
+    └── 📁 to
+        └── 📄 artifact3
+
+</details></pre>
+

--- a/artifactory/utils/testdata/command_summaries/extended/generic-module.md
+++ b/artifactory/utils/testdata/command_summaries/extended/generic-module.md
@@ -8,6 +8,10 @@
 
 
 
-| Artifacts | Security Violations | Security Issues |
-| :------------ | :--------------------- | :------------------ |
-| <pre>📦 generic-local<br>└── 📁 path<br>    └── 📁 to<br>        └── <a href='https://myplatform.com/ui/repos/tree/General/generic-local/path/to/artifact2?clearFilter=true' target="_blank">artifact2</a><br><br></pre> | Not scanned | Not scanned |
+<pre>📦 generic-local
+└── 📁 path
+    └── 📁 to
+        └── <a href='https://myplatform.com/ui/repos/tree/General/generic-local/path/to/artifact2?clearFilter=true' target="_blank">artifact2</a>
+
+</pre>
+

--- a/artifactory/utils/testdata/command_summaries/extended/maven-module.md
+++ b/artifactory/utils/testdata/command_summaries/extended/maven-module.md
@@ -8,6 +8,10 @@
 
 
 
-| Artifacts | Security Violations | Security Issues |
-| :------------ | :--------------------- | :------------------ |
-| <pre>📦 libs-release<br>└── 📁 path<br>    └── 📁 to<br>        └── <a href='https://myplatform.com/ui/repos/tree/General/libs-release/path/to/artifact1?clearFilter=true' target="_blank">artifact1</a><br><br></pre> | Not scanned | Not scanned |
+<pre>📦 libs-release
+└── 📁 path
+    └── 📁 to
+        └── <a href='https://myplatform.com/ui/repos/tree/General/libs-release/path/to/artifact1?clearFilter=true' target="_blank">artifact1</a>
+
+</pre>
+

--- a/artifactory/utils/testdata/command_summaries/extended/maven-nested-module.md
+++ b/artifactory/utils/testdata/command_summaries/extended/maven-nested-module.md
@@ -1,0 +1,28 @@
+
+
+<h3>Published Modules</h3>
+
+
+
+**maven**
+
+
+
+<pre><details><summary>submodule1</summary>
+📦 libs-release
+└── 📁 path
+    └── 📁 to
+        └── <a href='https://myplatform.com/ui/repos/tree/General/libs-release/path/to/artifact2?clearFilter=true' target="_blank">artifact2</a>
+
+</details></pre>
+
+
+
+<pre><details><summary>submodule2</summary>
+📦 libs-release
+└── 📁 path
+    └── 📁 to
+        └── <a href='https://myplatform.com/ui/repos/tree/General/libs-release/path/to/artifact3?clearFilter=true' target="_blank">artifact3</a>
+
+</details></pre>
+


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

### Summary:

This PR separates the logic for generating markdown related to modules.

### Details:

The module display is now divided into two subsections:

Modules with scan results (currently, this applies only to Docker images).
Modules without scan results (e.g., an npm module that is packaged into a tar file and then deleted, which we currently cannot scan easily with a JF command).
Introduced refactoring to improve code maintainability for the future.

Made minor adjustments to titles and UI elements for a better user experience.

### Before - Npm modules is displayed on a table
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/f1ae6acc-e67d-4921-bccf-11850570d399">


### After - Generic module is displayed without table:
<img width="935" alt="image" src="https://github.com/user-attachments/assets/90ec2628-5132-42d6-860a-b4e75136a0f2">


##