### PR TITLE
Remove API Key suggestion from config command

### DIFF
--- a/common/commands/config.go
+++ b/common/commands/config.go
@@ -36,7 +36,7 @@ type AuthenticationMethod string
 
 const (
 	AccessToken AuthenticationMethod = "Access Token"
-	BasicAuth   AuthenticationMethod = "Username and Password / API Key"
+	BasicAuth   AuthenticationMethod = "Username and Password / Reference token"
 	MTLS        AuthenticationMethod = "Mutual TLS"
 	WebLogin    AuthenticationMethod = "Web Login"
 )
@@ -375,10 +375,10 @@ func (cc *ConfigCommand) promptAuthMethods() (selectedMethod AuthenticationMetho
 
 	var selected string
 	authMethods := []AuthenticationMethod{
-		BasicAuth,
 		AccessToken,
-		MTLS,
 		WebLogin,
+		BasicAuth,
+		MTLS,
 	}
 	var selectableItems []ioutils.PromptItem
 	for _, curMethod := range authMethods {
@@ -820,7 +820,7 @@ func assertSingleAuthMethod(details *config.ServerDetails) error {
 		details.AccessToken != "" && details.ArtifactoryRefreshToken == "",
 		details.SshKeyPath != ""}
 	if coreutils.SumTrueValues(authMethods) > 1 {
-		return errorutils.CheckErrorf("Only one authentication method is allowed: Username + Password/API key, RSA Token (SSH) or Access Token")
+		return errorutils.CheckErrorf("Only one authentication method is allowed: Username + Password/Reference Token, RSA Token (SSH) or Access Token")
 	}
 	return nil
 }

--- a/utils/ioutils/ioutils.go
+++ b/utils/ioutils/ioutils.go
@@ -40,7 +40,7 @@ func ReadCredentialsFromConsole(details, savedDetails coreutils.Credentials, dis
 }
 
 func ScanJFrogPasswordFromConsole() (string, error) {
-	return ScanPasswordFromConsole("JFrog password or API key: ")
+	return ScanPasswordFromConsole("JFrog password or Reference Token: ")
 }
 
 func ScanPasswordFromConsole(message string) (string, error) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Following the API Key [deprecation process](https://jfrog.com/help/r/jfrog-platform-administration-documentation/jfrog-api-key-deprecation-process), this PR removes the API Key suggestion (wording only) from the config command.
API Key will still be support in the CLI if the JPD supports it (see the link above for more details).