### PR TITLE
Fix docker build summery broken link (missing org)

### DIFF
--- a/artifactory/utils/commandsummary/buildinfosummary.go
+++ b/artifactory/utils/commandsummary/buildinfosummary.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils/container"
 	"github.com/jfrog/jfrog-client-go/utils/log"
+	"net/url"
 	"path"
 	"strings"
 )
@@ -249,16 +250,16 @@ func isSupportedModule(module *buildInfo.Module) bool {
 }
 
 func createDockerMultiArchTitle(module *buildInfo.Module) string {
-	parentImageName := strings.Split(module.Parent, ":")[0]
-	var sha256 string
-	for _, artifact := range module.Artifacts {
-		if artifact.Name == container.ManifestJsonFile {
-			sha256 = artifact.Sha256
-			break
-		}
-	}
 	if StaticMarkdownConfig.IsExtendedSummary() {
-		dockerModuleLink := fmt.Sprintf(artifactoryDockerPackagesUiFormat, strings.TrimSuffix(StaticMarkdownConfig.GetPlatformUrl(), "/"), "%2F%2F"+parentImageName, sha256)
+		parentImageName := strings.Split(module.Parent, ":")[0]
+		var sha256 string
+		for _, artifact := range module.Artifacts {
+			if artifact.Name == container.ManifestJsonFile {
+				sha256 = artifact.Sha256
+				break
+			}
+		}
+		dockerModuleLink := fmt.Sprintf(artifactoryDockerPackagesUiFormat, strings.TrimSuffix(StaticMarkdownConfig.GetPlatformUrl(), "/"), "%2F%2F"+url.PathEscape(parentImageName), sha256)
 		return fmt.Sprintf("%s <a href=%s>(🐸 View)</a>", module.Id, dockerModuleLink)
 	}
 	return module.Id

--- a/artifactory/utils/container/buildinfo.go
+++ b/artifactory/utils/container/buildinfo.go
@@ -362,6 +362,10 @@ func (builder *buildInfoBuilder) createMultiPlatformBuildInfo(fatManifest *FatMa
 		Properties: imageProperties,
 		Artifacts:  []buildinfo.Artifact{getFatManifestArtifact(searchResultFatManifest)},
 	}}}
+	imageLongNameWithoutRepo, err := builder.image.GetImageLongNameWithoutRepoWithTag()
+	if err != nil {
+		return nil, err
+	}
 	// Create all image arch modules
 	for _, manifest := range fatManifest.Manifests {
 		image := candidateImages[manifest.Digest]
@@ -378,7 +382,7 @@ func (builder *buildInfoBuilder) createMultiPlatformBuildInfo(fatManifest *FatMa
 			Id:        getModuleIdByManifest(manifest, baseModuleId),
 			Type:      buildinfo.Docker,
 			Artifacts: artifacts,
-			Parent:    baseModuleId,
+			Parent:    imageLongNameWithoutRepo,
 		})
 	}
 	return buildInfo, setBuildProperties(builder.buildName, builder.buildNumber, builder.project, builder.imageLayers, builder.serviceManager)

--- a/artifactory/utils/container/image.go
+++ b/artifactory/utils/container/image.go
@@ -86,6 +86,21 @@ func (image *Image) GetImageShortNameWithTag() (string, error) {
 	return imageName, nil
 }
 
+// GetImageLongNameWithoutRepoWithTag removes the registry hostname and repository name, returning the organization and image name with the tag.
+// e.g., "docker-local/myorg/hello-world:latest" -> "myorg/hello-world:latest"
+// e.g., "docker-local/hello-world:latest" -> "hello-world:latest"
+func (image *Image) GetImageLongNameWithoutRepoWithTag() (string, error) {
+	imageName, err := image.GetImageLongNameWithTag()
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(imageName, "/")
+	if len(parts) > 1 {
+		return strings.Join(parts[1:], "/"), nil
+	}
+	return parts[0], nil
+}
+
 // Get image tag name of an image.
 // e.g.: https://my-registry/docker-local/hello-world:latest. -> latest
 func (image *Image) GetImageTag() (string, error) {

--- a/artifactory/utils/container/image.go
+++ b/artifactory/utils/container/image.go
@@ -90,15 +90,15 @@ func (image *Image) GetImageShortNameWithTag() (string, error) {
 // e.g., "docker-local/myorg/hello-world:latest" -> "myorg/hello-world:latest"
 // e.g., "docker-local/hello-world:latest" -> "hello-world:latest"
 func (image *Image) GetImageLongNameWithoutRepoWithTag() (string, error) {
-	imageName, err := image.GetImageLongNameWithTag()
+	longName, err := image.GetImageLongNameWithTag()
 	if err != nil {
 		return "", err
 	}
-	parts := strings.Split(imageName, "/")
+	parts := strings.Split(longName, "/")
 	if len(parts) > 1 {
 		return strings.Join(parts[1:], "/"), nil
 	}
-	return parts[0], nil
+	return longName, nil
 }
 
 // Get image tag name of an image.

--- a/artifactory/utils/container/image_test.go
+++ b/artifactory/utils/container/image_test.go
@@ -82,6 +82,28 @@ func TestGetImageLongNameWithTag(t *testing.T) {
 	_, err := NewImage("domain").GetImageLongNameWithTag()
 	assert.Error(t, err)
 }
+
+func TestGetImageLongNameWithoutRepoWithTag(t *testing.T) {
+	var imageTags = []struct {
+		in       string
+		expected string
+	}{
+		{"domain:8080/repo-name/hello-world:latest", "hello-world:latest"},
+		{"domain/repo-name/hello-world:latest", "hello-world:latest"},
+		{"domain/repo-name/org-name/hello-world:latest", "org-name/hello-world:latest"},
+		{"domain/repo-name/org-name/hello-world", "org-name/hello-world:latest"},
+	}
+
+	for _, v := range imageTags {
+		result, err := NewImage(v.in).GetImageLongNameWithoutRepoWithTag()
+		assert.NoError(t, err)
+		assert.Equal(t, v.expected, result)
+	}
+	// Validate failure upon missing image name
+	_, err := NewImage("domain").GetImageLongNameWithoutRepoWithTag()
+	assert.Error(t, err)
+}
+
 func TestGetImageShortNameWithTag(t *testing.T) {
 	var imageTags = []struct {
 		in       string


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Fix the missing org part on the docker build summary (view) link.
![image](https://github.com/user-attachments/assets/06e7b3ab-e3ac-459b-b0c3-bedcc94ae6fa)

The current link points to `<ArtifactoryURL>/ui/packages/docker:%2F%2F<image-name>/sha256__AAA`
While it should point to `<ArtifactoryURL>/ui/packages/docker:%2F%2F<org-name>%2F<image-name>/sha256__AAA` when org name is part of the docker image name.