### PR TITLE
Make the CheckExtendedSummaryEntitled API public

### DIFF
--- a/artifactory/utils/commandsummary/commandsummary.go
+++ b/artifactory/utils/commandsummary/commandsummary.go
@@ -5,13 +5,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
-	"github.com/jfrog/jfrog-client-go/utils/errorutils"
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
-	"github.com/jfrog/jfrog-client-go/utils/log"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-client-go/http/httpclient"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 // To create a new command summary, the user must implement this interface.
@@ -270,6 +275,43 @@ func UnmarshalFromFilePath(dataFile string, target any) (err error) {
 		return errorutils.CheckError(err)
 	}
 	return
+}
+
+func CheckExtendedSummaryEntitled(serverUrl string) (bool, error) {
+	// Parse and validate the URL
+	parsedUrl, err := url.Parse(serverUrl)
+	if err != nil || !parsedUrl.IsAbs() {
+		return false, fmt.Errorf("invalid server URL: %s", serverUrl)
+	}
+
+	// Construct the full URL
+	fullUrl := fmt.Sprintf("%sui/api/v1/system/auth/screen/footer", parsedUrl.String())
+
+	client, err := httpclient.ClientBuilder().SetRetries(3).Build()
+	if err != nil {
+		return false, errorutils.CheckError(err)
+	}
+
+	resp, body, _, err := client.SendGet(fullUrl, false, httputils.HttpClientDetails{}, "")
+	if err != nil {
+		fmt.Println("Error making HTTP request:", err)
+		return false, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Println("Non-OK HTTP status:", resp.StatusCode)
+		return false, nil
+	}
+
+	var result struct {
+		PlatformId string `json:"platformId"`
+	}
+
+	if err := json.Unmarshal(body, &result); err != nil {
+		return false, errorutils.CheckError(err)
+	}
+	entitled := strings.Contains(strings.ToLower(result.PlatformId), "enterprise")
+	return entitled, nil
 }
 
 // Converts the given data into a byte array.

--- a/artifactory/utils/commandsummary/markdownConfig.go
+++ b/artifactory/utils/commandsummary/markdownConfig.go
@@ -3,13 +3,14 @@ package commandsummary
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
 	"github.com/jfrog/jfrog-client-go/http/httpclient"
 	clientUtils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
-	"net/http"
-	"net/url"
-	"strings"
 )
 
 // Static struct to hold the Markdown configuration values
@@ -62,7 +63,7 @@ func (mg *MarkdownConfig) SetScanResultsMapping(resultsMap map[string]ScanResult
 
 // Initializes the command summary values that effect Markdown generation
 func InitMarkdownGenerationValues(serverUrl string, platformMajorVersion int) (err error) {
-	entitled, err := checkExtendedSummaryEntitled(serverUrl)
+	entitled, err := CheckExtendedSummaryEntitled(serverUrl)
 	if err != nil {
 		return
 	}
@@ -72,7 +73,7 @@ func InitMarkdownGenerationValues(serverUrl string, platformMajorVersion int) (e
 	return
 }
 
-func checkExtendedSummaryEntitled(serverUrl string) (bool, error) {
+func CheckExtendedSummaryEntitled(serverUrl string) (bool, error) {
 	// Parse and validate the URL
 	parsedUrl, err := url.Parse(serverUrl)
 	if err != nil || !parsedUrl.IsAbs() {


### PR DESCRIPTION
Make the `CheckExtendedSummaryEntitled` API public, so that it can be used by the `jfrog-cli-security` module.