### PR TITLE
Fix NuGet related tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           dotnet-version: '6.x'
 
-      # Install Mono on Ubuntu to run nuget.exe
+      # Install Mono on Ubuntu to run nuget.exe (due to this issue on Ubuntu 24 that hasn't been fixed yet - https://github.com/NuGet/setup-nuget/issues/168)
       - name: Install Mono on Ubuntu
         if: matrix.os == 'ubuntu'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,17 @@ jobs:
         with:
           dotnet-version: '6.x'
 
-
+      # Install Mono on Ubuntu to run nuget.exe
+      - name: Install Mono on Ubuntu
+        if: matrix.os == 'ubuntu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apt-transport-https dirmngr gnupg ca-certificates
+          sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+          echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
+          
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           dotnet-version: '6.x'
 
+
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main
 


### PR DESCRIPTION
Install Mono on Ubuntu to run nuget.exe, due to this issue on Ubuntu 24 that hasn't been fixed yet - https://github.com/NuGet/setup-nuget/issues/168 : `nuget: 2: mono: not found error on nuget pack command in Ubuntu LTS 24.04.1`