### PR TITLE
Reduced the min npm version for supporting scoped auth

### DIFF
--- a/artifactory/commands/npm/npmcommand.go
+++ b/artifactory/commands/npm/npmcommand.go
@@ -4,6 +4,11 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
 	"github.com/jfrog/build-info-go/build"
 	biUtils "github.com/jfrog/build-info-go/build/utils"
 	"github.com/jfrog/gofrog/version"
@@ -18,10 +23,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/spf13/viper"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
 )
 
 const (
@@ -31,7 +32,7 @@ const (
 
 	// Scoped authentication env var that sets the _auth or _authToken npm config variables.
 	npmConfigAuthEnv                  = "npm_config_%s:%s"
-	npmVersionSupportingScopedAuthEnv = "9.3.1"
+	npmVersionSupportingScopedAuthEnv = "9.2.0"
 	// Legacy un-scoped auth env vars doesn't support access tokens (with _authToken suffix).
 	npmLegacyConfigAuthEnv = "npm_config__auth"
 )


### PR DESCRIPTION
Reduced the minimum npm version for supporting scoped auth, from 9.3.1 to 9.2.0.
This resolves an issue, where when running `jf npm install` with npm 9.2.0, JFrog CLI doesn't authenticate with the JFrog Platform.