### PR TITLE
Test Cli outputs of cmd with errors

### DIFF
--- a/utils/tests/test_cli.go
+++ b/utils/tests/test_cli.go
@@ -60,8 +60,10 @@ func RunCmdWithOutputs(t *testing.T, executeCmd func() error) (output string, er
 	newStdout, stdWriter, cleanUp := redirectOutToPipe(t)
 	defer cleanUp()
 
+	errCh := make(chan error, 1)
+
 	go func() {
-		err = executeCmd()
+		errCh <- executeCmd()
 		// Closing the temp stdout in order to be able to read it's content.
 		assert.NoError(t, stdWriter.Close())
 	}()
@@ -70,6 +72,9 @@ func RunCmdWithOutputs(t *testing.T, executeCmd func() error) (output string, er
 	assert.NoError(t, e)
 	output = string(content)
 	log.Debug(output)
+
+	err = <-errCh
+
 	return
 }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

Add option to run test CLI with command that return error as well