### PR TITLE
Adding `--operation` flag for the release bundle promote command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250220084755-22a79e8b77ff
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250221062042-87cb5136765e
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20241121100855-e7a75ceee2bd
 

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
@@ -119,3 +120,5 @@ require (
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20241121100855-e7a75ceee2bd
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.3.3-0.20231223133729-ef57bd08cedc
+
+replace github.com/jfrog/jfrog-client-go => github.com/oshratZairi/jfrog-client-go v0.0.0-20250220085006-01d8636b041b

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,6 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
@@ -115,10 +114,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250126110945-81abbdde452f
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250220084755-22a79e8b77ff
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20241121100855-e7a75ceee2bd
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.3.3-0.20231223133729-ef57bd08cedc
-
-replace github.com/jfrog/jfrog-client-go => github.com/oshratZairi/jfrog-client-go v0.0.0-20250220085006-01d8636b041b

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/jfrog/build-info-go v1.10.9 h1:mdJ+wlLw2ReFsqC7rifJVlRYLEqYk38uXDYAOZ
 github.com/jfrog/build-info-go v1.10.9/go.mod h1:JcISnovFXKx3wWf3p1fcMmlPdt6adxScXvoJN4WXqIE=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-client-go v1.28.1-0.20250220084755-22a79e8b77ff h1:Ay27ZYEgLJXPN/O8a5vx+8FMhrRG60sOnsyGJkKFXoI=
-github.com/jfrog/jfrog-client-go v1.28.1-0.20250220084755-22a79e8b77ff/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20250221062042-87cb5136765e h1:SGKkXdFJtc5Rb32jh5E55SCLrHXtOTvc9YKy6QwWbzY=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20250221062042-87cb5136765e/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,6 @@ github.com/jfrog/build-info-go v1.10.9 h1:mdJ+wlLw2ReFsqC7rifJVlRYLEqYk38uXDYAOZ
 github.com/jfrog/build-info-go v1.10.9/go.mod h1:JcISnovFXKx3wWf3p1fcMmlPdt6adxScXvoJN4WXqIE=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-client-go v1.50.0 h1:t7v/zpLkPomHR6ZjVbPQ1WPQJd9IFKESK9Tt6phZz3k=
-github.com/jfrog/jfrog-client-go v1.50.0/go.mod h1:xHxwKBjPSUBd/FyCWgusfHmSWKUZTkfOZkTmntC2F5Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -170,6 +168,9 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.34.2 h1:pNCwDkzrsv7MS9kpaQvVb1aVLahQXyJ/Tv5oAZMI3i8=
 github.com/onsi/gomega v1.34.2/go.mod h1:v1xfxRgk0KIsG+QOdm7p8UosrOzPYRo60fd3B/1Dukc=
+github.com/oshratZairi/jfrog-client-go v0.0.0-20250216115008-a06b0a541670 h1:3BOq28ewTiOtXoY949NOsBL0HyjEImfmKrwiwh6n7UQ=
+github.com/oshratZairi/jfrog-client-go v0.0.0-20250216115008-a06b0a541670/go.mod h1:xHxwKBjPSUBd/FyCWgusfHmSWKUZTkfOZkTmntC2F5Y=
+github.com/oshratZairi/jfrog-client-go v0.0.0-20250220085006-01d8636b041b/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
@@ -216,6 +217,7 @@ github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8w
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/jfrog/build-info-go v1.10.9 h1:mdJ+wlLw2ReFsqC7rifJVlRYLEqYk38uXDYAOZ
 github.com/jfrog/build-info-go v1.10.9/go.mod h1:JcISnovFXKx3wWf3p1fcMmlPdt6adxScXvoJN4WXqIE=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20250220084755-22a79e8b77ff h1:Ay27ZYEgLJXPN/O8a5vx+8FMhrRG60sOnsyGJkKFXoI=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20250220084755-22a79e8b77ff/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -168,9 +170,6 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.34.2 h1:pNCwDkzrsv7MS9kpaQvVb1aVLahQXyJ/Tv5oAZMI3i8=
 github.com/onsi/gomega v1.34.2/go.mod h1:v1xfxRgk0KIsG+QOdm7p8UosrOzPYRo60fd3B/1Dukc=
-github.com/oshratZairi/jfrog-client-go v0.0.0-20250216115008-a06b0a541670 h1:3BOq28ewTiOtXoY949NOsBL0HyjEImfmKrwiwh6n7UQ=
-github.com/oshratZairi/jfrog-client-go v0.0.0-20250216115008-a06b0a541670/go.mod h1:xHxwKBjPSUBd/FyCWgusfHmSWKUZTkfOZkTmntC2F5Y=
-github.com/oshratZairi/jfrog-client-go v0.0.0-20250220085006-01d8636b041b/go.mod h1:hDoUcW6LZme83YNFbdSRImV+di1x0GP+Nlw7fctkwtE=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
@@ -217,7 +216,6 @@ github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8w
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/lifecycle/common.go
+++ b/lifecycle/common.go
@@ -22,6 +22,18 @@ type releaseBundleCmd struct {
 
 func (rbc *releaseBundleCmd) getPrerequisites() (servicesManager *lifecycle.LifecycleServicesManager,
 	rbDetails services.ReleaseBundleDetails, queryParams services.CommonOptionalQueryParams, err error) {
+	return rbc.initPrerequisites()
+}
+
+func (rbp *ReleaseBundlePromoteCommand) getPromotionPrerequisites() (servicesManager *lifecycle.LifecycleServicesManager,
+	rbDetails services.ReleaseBundleDetails, queryParams services.CommonOptionalQueryParams, err error) {
+	servicesManager, rbDetails, queryParams, err = rbp.initPrerequisites()
+	queryParams.PromotionType = rbp.promotionType
+	return servicesManager, rbDetails, queryParams, err
+}
+
+func (rbc *releaseBundleCmd) initPrerequisites() (servicesManager *lifecycle.LifecycleServicesManager,
+	rbDetails services.ReleaseBundleDetails, queryParams services.CommonOptionalQueryParams, err error) {
 	servicesManager, err = utils.CreateLifecycleServiceManager(rbc.serverDetails, false)
 	if err != nil {
 		return
@@ -34,6 +46,7 @@ func (rbc *releaseBundleCmd) getPrerequisites() (servicesManager *lifecycle.Life
 		ProjectKey: rbc.rbProjectKey,
 		Async:      !rbc.sync,
 	}
+
 	return
 }
 

--- a/lifecycle/common_test.go
+++ b/lifecycle/common_test.go
@@ -1,0 +1,69 @@
+package lifecycle
+
+import (
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/lifecycle/services"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetPrerequisites_Success(t *testing.T) {
+	serverDetails := &config.ServerDetails{}
+	rbCmd := &releaseBundleCmd{
+		serverDetails:        serverDetails,
+		releaseBundleName:    "testRelease",
+		releaseBundleVersion: "1.0.0",
+		sync:                 true,
+		rbProjectKey:         "project1",
+	}
+
+	expectedQueryParams := services.CommonOptionalQueryParams{
+		ProjectKey: rbCmd.rbProjectKey,
+		Async:      false,
+	}
+
+	expectedRbDetails := services.ReleaseBundleDetails{
+		ReleaseBundleName:    rbCmd.releaseBundleName,
+		ReleaseBundleVersion: rbCmd.releaseBundleVersion,
+	}
+
+	servicesManager, rbDetails, queryParams, err := rbCmd.getPrerequisites()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, servicesManager, "Expected servicesManager to be initialized")
+	assert.Equal(t, expectedRbDetails, rbDetails, "ReleaseBundleDetails does not match expected values")
+	assert.Equal(t, expectedQueryParams, queryParams, "QueryParams do not match expected values")
+
+}
+
+func TestGetPromotionPrerequisites_Success(t *testing.T) {
+	serverDetails := &config.ServerDetails{}
+	rbp := &ReleaseBundlePromoteCommand{
+		promotionType: "move",
+		releaseBundleCmd: releaseBundleCmd{
+			serverDetails:        serverDetails,
+			releaseBundleName:    "testRelease",
+			releaseBundleVersion: "1.0.0",
+			sync:                 true,
+			rbProjectKey:         "project1",
+		},
+	}
+
+	expectedQueryParams := services.CommonOptionalQueryParams{
+		ProjectKey:    rbp.rbProjectKey,
+		Async:         false,
+		PromotionType: rbp.promotionType,
+	}
+
+	expectedRbDetails := services.ReleaseBundleDetails{
+		ReleaseBundleName:    rbp.releaseBundleName,
+		ReleaseBundleVersion: rbp.releaseBundleVersion,
+	}
+
+	servicesManager, rbDetails, queryParams, err := rbp.getPromotionPrerequisites()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, servicesManager, "Expected servicesManager to be initialized")
+	assert.Equal(t, expectedRbDetails, rbDetails, "ReleaseBundleDetails do not match expected values") // Replace _ with appropriate variable.
+	assert.Equal(t, expectedQueryParams, queryParams, "QueryParams do not match expected values")
+}

--- a/lifecycle/promote.go
+++ b/lifecycle/promote.go
@@ -14,6 +14,7 @@ type ReleaseBundlePromoteCommand struct {
 	environment          string
 	includeReposPatterns []string
 	excludeReposPatterns []string
+	promotionType        string
 }
 
 func NewReleaseBundlePromoteCommand() *ReleaseBundlePromoteCommand {
@@ -65,6 +66,11 @@ func (rbp *ReleaseBundlePromoteCommand) SetExcludeReposPatterns(excludeReposPatt
 	return rbp
 }
 
+func (rbp *ReleaseBundlePromoteCommand) SetPromotionType(promotionType string) *ReleaseBundlePromoteCommand {
+	rbp.promotionType = promotionType
+	return rbp
+}
+
 func (rbp *ReleaseBundlePromoteCommand) CommandName() string {
 	return "rb_promote"
 }
@@ -78,7 +84,8 @@ func (rbp *ReleaseBundlePromoteCommand) Run() error {
 		return err
 	}
 
-	servicesManager, rbDetails, queryParams, err := rbp.getPrerequisites()
+	servicesManager, rbDetails, queryParams, err := rbp.getPromotionPrerequisites()
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Adding a new flag for release bundle promote (RBP) command named 'operation'.