### PR TITLE
JFROG_CLI_REQUEST_TIMEOUT variable with the request timeout

### DIFF
--- a/artifactory/utils/utils.go
+++ b/artifactory/utils/utils.go
@@ -92,7 +92,11 @@ func GetEncryptedPasswordFromArtifactory(artifactoryAuth auth.ServiceDetails, in
 }
 
 func CreateServiceManager(serverDetails *config.ServerDetails, httpRetries, httpRetryWaitMilliSecs int, isDryRun bool) (artifactory.ArtifactoryServicesManager, error) {
-	return CreateServiceManagerWithContext(context.Background(), serverDetails, isDryRun, 0, httpRetries, httpRetryWaitMilliSecs, 0)
+	return CreateServiceManagerWithTimeout(serverDetails, httpRetries, httpRetryWaitMilliSecs, isDryRun, 0)
+}
+
+func CreateServiceManagerWithTimeout(serverDetails *config.ServerDetails, httpRetries, httpRetryWaitMilliSecs int, isDryRun bool, timeout time.Duration) (artifactory.ArtifactoryServicesManager, error) {
+	return CreateServiceManagerWithContext(context.Background(), serverDetails, isDryRun, 0, httpRetries, httpRetryWaitMilliSecs, timeout)
 }
 
 // Create a service manager with threads.

--- a/lifecycle/createfromartifacts.go
+++ b/lifecycle/createfromartifacts.go
@@ -2,19 +2,28 @@ package lifecycle
 
 import (
 	"errors"
+	"os"
+	"path"
+	"time"
+
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	rtServicesUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/lifecycle"
 	"github.com/jfrog/jfrog-client-go/lifecycle/services"
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"path"
+)
+
+const (
+	TimeoutEnvKey = "JFROG_CLI_REQUEST_TIMEOUT"
 )
 
 func (rbc *ReleaseBundleCreateCommand) createFromArtifacts(lcServicesManager *lifecycle.LifecycleServicesManager,
 	rbDetails services.ReleaseBundleDetails, queryParams services.CommonOptionalQueryParams) (err error) {
 
-	rtServicesManager, err := utils.CreateServiceManager(rbc.serverDetails, 3, 0, false)
+	timeout, _ := time.ParseDuration(os.Getenv(TimeoutEnvKey))
+
+	rtServicesManager, err := utils.CreateServiceManagerWithTimeout(rbc.serverDetails, 3, 0, false, timeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
It adds additional parameter to set the timeout for service manager that is 0 by default.