### PR TITLE
Include default true bool flags in CLI flag mapping

### DIFF
--- a/plugins/components/conversionlayer.go
+++ b/plugins/components/conversionlayer.go
@@ -416,8 +416,16 @@ func fillFlagMaps(c *Context, baseContext *cli.Context, originalFlags []Flag) er
 				c.stringFlags[stringFlag.Name] = finalValue
 			}
 		}
-		if boolFlag, ok := flag.(BoolFlag); ok && (baseContext.IsSet(boolFlag.Name) || boolFlag.DefaultValue) {
-			c.boolFlags[boolFlag.Name] = getValueForBoolFlag(boolFlag, baseContext)
+		if boolFlag, ok := flag.(BoolFlag); ok {
+			val := getValueForBoolFlag(boolFlag, baseContext)
+			// Only store the flag if:
+			// - The user explicitly set it, OR
+			// - The resolved value is 'true' (e.g., default is true and user didn't override it)
+			// This avoids adding unnecessary 'false' flags that aren't relevant.
+			if baseContext.IsSet(boolFlag.Name) || val {
+				// Store the flag and its resolved value in the context map
+				c.boolFlags[boolFlag.Name] = val
+			}
 		}
 	}
 	return nil

--- a/plugins/components/conversionlayer.go
+++ b/plugins/components/conversionlayer.go
@@ -416,7 +416,7 @@ func fillFlagMaps(c *Context, baseContext *cli.Context, originalFlags []Flag) er
 				c.stringFlags[stringFlag.Name] = finalValue
 			}
 		}
-		if boolFlag, ok := flag.(BoolFlag); ok && baseContext.IsSet(boolFlag.Name) {
+		if boolFlag, ok := flag.(BoolFlag); ok {
 			c.boolFlags[boolFlag.Name] = getValueForBoolFlag(boolFlag, baseContext)
 		}
 	}

--- a/plugins/components/conversionlayer.go
+++ b/plugins/components/conversionlayer.go
@@ -416,7 +416,7 @@ func fillFlagMaps(c *Context, baseContext *cli.Context, originalFlags []Flag) er
 				c.stringFlags[stringFlag.Name] = finalValue
 			}
 		}
-		if boolFlag, ok := flag.(BoolFlag); ok {
+		if boolFlag, ok := flag.(BoolFlag); ok && (baseContext.IsSet(boolFlag.Name) || boolFlag.DefaultValue) {
 			c.boolFlags[boolFlag.Name] = getValueForBoolFlag(boolFlag, baseContext)
 		}
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

### 🔧 Summary

This PR updates the handling of boolean flags (`BoolFlag`) in the `fillFlagMaps` function.

### ✅ Behavior Change

Previously, `BoolFlag`s were only added to the internal context (`c.boolFlags`) if they were explicitly set by the user:
```go
if boolFlag, ok := flag.(BoolFlag); ok && baseContext.IsSet(boolFlag.Name) {
```

This caused flags with a default value of `true` to be skipped unless manually provided.

The updated logic:
```go
if boolFlag, ok := flag.(BoolFlag); ok {
    val := getValueForBoolFlag(boolFlag, baseContext)
    if baseContext.IsSet(boolFlag.Name) || val {
        c.boolFlags[boolFlag.Name] = val
    }
}
```

Now, a boolean flag is included if:
- It was explicitly set by the user (`baseContext.IsSet(...)`)
- **OR** its resolved value is `true` (e.g., default `true`)

This ensures all effective boolean flags are passed to plugin commands.

### 🛠 Fixes

This change resolves issues that broke certain **CLI-Security** plugin commands that rely on `BoolFlag`s with `DefaultValue = true`.


