### PR TITLE
Add twine package manager type

### DIFF
--- a/common/project/projectconfig.go
+++ b/common/project/projectconfig.go
@@ -44,6 +44,7 @@ const (
 	Swift
 	Docker
 	Podman
+	Twine
 )
 
 type ConfigType string
@@ -71,6 +72,7 @@ var ProjectTypes = []string{
 	"swift",
 	"docker",
 	"podman",
+	"twine",
 }
 
 func (projectType ProjectType) String() string {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Add twine as project type (package manager) to support `jf setup twine` command 