### PR TITLE
Feature/docker validate sha

### DIFF
--- a/artifactory/utils/container/buildinfo.go
+++ b/artifactory/utils/container/buildinfo.go
@@ -2,10 +2,11 @@ package container
 
 import (
 	"encoding/json"
-	ioutils "github.com/jfrog/gofrog/io"
 	"os"
 	"path"
 	"strings"
+
+	ioutils "github.com/jfrog/gofrog/io"
 
 	buildinfo "github.com/jfrog/build-info-go/entities"
 
@@ -91,10 +92,23 @@ func (builder *buildInfoBuilder) getSearchableRepo() string {
 
 // Set build properties on image layers in Artifactory.
 func setBuildProperties(buildName, buildNumber, project string, imageLayers []utils.ResultItem, serviceManager artifactory.ArtifactoryServicesManager) (err error) {
+	// Skip if no build info is provided
+	if buildName == "" || buildNumber == "" {
+		log.Debug("Skipping setting properties - no build name or build number provided")
+		return nil
+	}
+
 	props, err := build.CreateBuildProperties(buildName, buildNumber, project)
 	if err != nil {
 		return
 	}
+
+	// Skip if no properties were created
+	if len(props) == 0 {
+		log.Debug("Skipping setting properties - no properties created")
+		return nil
+	}
+
 	pathToFile, err := writeLayersToFile(imageLayers)
 	if err != nil {
 		return

--- a/artifactory/utils/container/buildinfo.go
+++ b/artifactory/utils/container/buildinfo.go
@@ -94,7 +94,7 @@ func (builder *buildInfoBuilder) getSearchableRepo() string {
 func setBuildProperties(buildName, buildNumber, project string, imageLayers []utils.ResultItem, serviceManager artifactory.ArtifactoryServicesManager) (err error) {
 	// Skip if no build info is provided
 	if buildName == "" || buildNumber == "" {
-		log.Debug("Skipping setting properties - no build name or build number provided")
+		log.Debug("Skipping setting properties - build name and build number are required")
 		return nil
 	}
 

--- a/utils/coreutils/cmdutils.go
+++ b/utils/coreutils/cmdutils.go
@@ -1,10 +1,11 @@
 package coreutils
 
 import (
-	"github.com/forPelevin/gomoji"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 	"strconv"
 	"strings"
+
+	"github.com/forPelevin/gomoji"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 
 	"github.com/gookit/color"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -167,6 +168,11 @@ func ExtractInsecureTlsFromArgs(args []string) (cleanArgs []string, insecureTls 
 // Used by docker
 func ExtractSkipLoginFromArgs(args []string) (cleanArgs []string, skipLogin bool, err error) {
 	return extractBoolOptionFromArgs(args, "skip-login")
+}
+
+// Used by docker
+func ExtractBoolFlagFromArgs(args []string, flagName string) (cleanArgs []string, flagValue bool, err error) {
+	return extractBoolOptionFromArgs(args, flagName)
 }
 
 // Used by docker


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
# Add `--validate-sha` flag for Docker push command

## Description
This PR adds core support for the new `--validate-sha` flag in the Docker push command. When enabled, the flag allows the CLI to use the image's SHA digest for validation instead of the tag name during Docker push operations. This is particularly useful when pushing to virtual repositories where the tag might exist with different content in higher priority repositories.

## Changes
- Modified `artifactory/utils/container/remoteagent.go` to handle manifest digest mismatches gracefully
- Updated the manifest validation logic to log warnings instead of failing when using the `--validate-sha` flag
- Added detailed logging to help users understand what's happening during SHA-based validation

## Testing
- Manually tested the flag with both old and new CLI syntax
- Verified behavior when pushing to repositories with existing tags
- Confirmed build info collection works correctly with the flag

## Related PRs
- jfrog-cli: [here](https://github.com/jfrog/jfrog-cli/pull/2971)
- jfrog-cli-artifactory: [here](https://github.com/jfrog/jfrog-cli-artifactory/pull/73)