### PR TITLE
fix slash issue in build name, number in rbc

### DIFF
--- a/common/spec/specfiles.go
+++ b/common/spec/specfiles.go
@@ -7,6 +7,7 @@ import (
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"strings"
 )
 
 type SpecFiles struct {
@@ -37,13 +38,15 @@ func CreateSpecFromFile(specFilePath string, specVars map[string]string) (spec *
 	}
 	return
 }
-
 func CreateSpecFromBuildNameNumberAndProject(buildName, buildNumber, projectKey string) (*SpecFiles, error) {
 	if buildName == "" || buildNumber == "" {
 		return nil, errorutils.CheckErrorf("build name and build number must be provided")
 	}
 
-	buildString := buildName + "/" + buildNumber
+	escapedBuildName := strings.ReplaceAll(buildName, "/", "\\/")
+	escapedBuildNumber := strings.ReplaceAll(buildNumber, "/", "\\/")
+
+	buildString := escapedBuildName + "/" + escapedBuildNumber
 	specFile := &SpecFiles{
 		Files: []File{
 			{

--- a/common/spec/specfiles_test.go
+++ b/common/spec/specfiles_test.go
@@ -45,4 +45,13 @@ func TestCreateSpecFromBuildNameAndNumber(t *testing.T) {
 		assert.Nil(t, spec)
 		assert.EqualError(t, err, "build name and build number must be provided")
 	})
+
+	t.Run("Build Name and Number with Slashes", func(t *testing.T) {
+		spec, err := CreateSpecFromBuildNameNumberAndProject("my/build/name", "1/2/3", "test")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, spec)
+		assert.Equal(t, "my\\/build\\/name/1\\/2\\/3", spec.Files[0].Build)
+		assert.Equal(t, "test", spec.Files[0].Project)
+	})
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
