### PR TITLE
fix slash issue in build name, number in rbc

### DIFF
--- a/common/spec/specfiles.go
+++ b/common/spec/specfiles.go
@@ -7,6 +7,7 @@ import (
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"strings"
 )
 
 type SpecFiles struct {
@@ -43,7 +44,10 @@ func CreateSpecFromBuildNameNumberAndProject(buildName, buildNumber, projectKey 
 		return nil, errorutils.CheckErrorf("build name and build number must be provided")
 	}
 
-	buildString := buildName + "/" + buildNumber
+	escapedBuildName := strings.ReplaceAll(buildName, "/", "\\/")
+	escapedBuildNumber := strings.ReplaceAll(buildNumber, "/", "\\/")
+
+	buildString := escapedBuildName + "/" + escapedBuildNumber
 	specFile := &SpecFiles{
 		Files: []File{
 			{

--- a/common/spec/specfiles_test.go
+++ b/common/spec/specfiles_test.go
@@ -45,4 +45,13 @@ func TestCreateSpecFromBuildNameAndNumber(t *testing.T) {
 		assert.Nil(t, spec)
 		assert.EqualError(t, err, "build name and build number must be provided")
 	})
+
+	t.Run("Build Name and Number with Slashes", func(t *testing.T) {
+		spec, err := CreateSpecFromBuildNameNumberAndProject("my/build/name", "1/2/3", "test")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, spec)
+		assert.Equal(t, "my\\/build\\/name/1\\/2\\/3", spec.Files[0].Build)
+		assert.Equal(t, "test", spec.Files[0].Project)
+	})
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Issue: The CLI failed to handle build numbers containing forward slashes (e.g., 1-slash/slash) when creating a Release Bundle using jf rbc. This resulted in a 404 Not Found error because the slash in the build number was incorrectly parsed, splitting it into separate segments.

Solution: The issue was fixed by escaping forward slashes in both buildName and buildNumber, This ensures that the build string is correctly parsed as a single entity.

