### PR TITLE
Added ValidateRepoType method in utils.

### DIFF
--- a/artifactory/utils/utils.go
+++ b/artifactory/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/access"
 	"github.com/jfrog/jfrog-client-go/artifactory"
+	artifactoryServices "github.com/jfrog/jfrog-client-go/artifactory/services"
 	"github.com/jfrog/jfrog-client-go/auth"
 	clientConfig "github.com/jfrog/jfrog-client-go/config"
 	"github.com/jfrog/jfrog-client-go/distribution"
@@ -342,6 +343,23 @@ func ValidateRepoExists(repoKey string, serviceDetails auth.ServiceDetails) erro
 
 	if !exists {
 		return errorutils.CheckErrorf("The repository '" + repoKey + "' does not exist.")
+	}
+	return nil
+}
+
+// ValidateRepoType checks if the repository exists and is of the expected package type (e.g., "vscode", "jetbrains").
+func ValidateRepoType(repoKey string, serviceDetails auth.ServiceDetails, expectedType string) error {
+	servicesManager, err := createServiceManager(serviceDetails)
+	if err != nil {
+		return err
+	}
+	repoDetails := &artifactoryServices.RepositoryDetails{}
+	err = servicesManager.GetRepository(repoKey, repoDetails)
+	if err != nil {
+		return fmt.Errorf("failed to fetch repository details for %q: %w", repoKey, err)
+	}
+	if !strings.EqualFold(repoDetails.PackageType, expectedType) {
+		return fmt.Errorf("repository '%s' is of type '%s', but expected type is '%s'", repoKey, repoDetails.PackageType, expectedType)
 	}
 	return nil
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
# Add `ValidateRepoType` Utility for Repository Type Validation

## Overview

This PR introduces a new utility function, `ValidateRepoType`, to the Artifactory utils package. This function allows consumers to validate that a given repository exists and is of the expected `packageType` (e.g., `vscode`, `jetbrains`).

## Changes

- **New Function:**
  - `ValidateRepoType(repoKey, serviceDetails, expectedType string) error`
    - Fetches repository details and checks that the `packageType` matches the expected value.
    - Returns a clear error if the type does not match.
- **Intended Usage:**
  - Designed for use in CLI commands and integrations that require strict repository type validation (e.g., IDE integrations in `jfrog-cli-artifactory`).

## Related

- Consumed by `jfrog-cli-artifactory` for VSCode and JetBrains IDE integrations.
https://github.com/jfrog/jfrog-cli-artifactory/pull/111