### PR TITLE
Expand usage metrics of jfrog-cli

### DIFF
--- a/common/commands/command.go
+++ b/common/commands/command.go
@@ -29,14 +29,10 @@ type Command interface {
 	CommandName() string
 }
 
-// Exec executes a command and collects enhanced metrics
 func Exec(command Command) error {
 	commandName := command.CommandName()
 	flags := GetContextFlags()
-
-	log.Debug("Exec() collecting metrics for command:", commandName, "with flags:", flags)
 	CollectMetrics(commandName, flags)
-
 	channel := make(chan bool)
 	go reportUsage(command, channel)
 	err := command.Run()
@@ -118,9 +114,7 @@ func reportUsageToVisibilitySystem(command Command, serverDetails *config.Server
 
 	commandName := command.CommandName()
 	metricsData := GetCollectedMetrics(commandName)
-
 	if metricsData != nil {
-		log.Debug("Using enhanced metrics for command:", commandName)
 		visibilityMetricsData := &visibility.MetricsData{
 			FlagsUsed:    metricsData.FlagsUsed,
 			OS:           metricsData.OS,
@@ -132,7 +126,6 @@ func reportUsageToVisibilitySystem(command Command, serverDetails *config.Server
 		commandsCountMetric = visibility.NewCommandsCountMetricWithEnhancedData(commandName, visibilityMetricsData)
 		ClearCollectedMetrics(commandName)
 	} else {
-		log.Debug("No enhanced metrics found for command:", commandName, "- using standard metric")
 		commandsCountMetric = visibility.NewCommandsCountMetric(commandName)
 	}
 

--- a/common/commands/command.go
+++ b/common/commands/command.go
@@ -45,6 +45,7 @@ func Exec(command Command) error {
 
 // ExecAndThenReportUsage runs the command and then triggers a usage report.
 // Used for commands which don't have the full server details before execution.
+// For example: oidc exchange command, which will get access token only after execution.
 func ExecAndThenReportUsage(cc Command) (err error) {
 	commandName := cc.CommandName()
 	flags := GetContextFlags()

--- a/common/commands/command.go
+++ b/common/commands/command.go
@@ -45,10 +45,7 @@ func Exec(command Command) error {
 func ExecAndThenReportUsage(cc Command) (err error) {
 	commandName := cc.CommandName()
 	flags := GetContextFlags()
-
-	log.Debug("ExecAndThenReportUsage() collecting metrics for command:", commandName, "with flags:", flags)
 	CollectMetrics(commandName, flags)
-
 	if err = cc.Run(); err != nil {
 		return
 	}
@@ -116,8 +113,8 @@ func reportUsageToVisibilitySystem(command Command, serverDetails *config.Server
 	metricsData := GetCollectedMetrics(commandName)
 	if metricsData != nil {
 		visibilityMetricsData := &visibility.MetricsData{
-			FlagsUsed:    metricsData.FlagsUsed,
-			OS:           metricsData.OS,
+			Flags:        metricsData.Flags,
+			Platform:     metricsData.Platform,
 			Architecture: metricsData.Architecture,
 			IsCI:         metricsData.IsCI,
 			CISystem:     metricsData.CISystem,

--- a/common/commands/metrics_collector.go
+++ b/common/commands/metrics_collector.go
@@ -1,0 +1,204 @@
+package commands
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+// MetricsData holds enhanced metrics information for command execution
+type MetricsData struct {
+	FlagsUsed    []string `json:"flags_used,omitempty"`
+	OS           string   `json:"os,omitempty"`
+	Architecture string   `json:"architecture,omitempty"`
+	IsCI         bool     `json:"is_ci,omitempty"`
+	CISystem     string   `json:"ci_system,omitempty"`
+	IsContainer  bool     `json:"is_container,omitempty"`
+}
+
+// metricsCollector provides thread-safe collection and storage of command metrics
+type metricsCollector struct {
+	mu   sync.RWMutex
+	data map[string]*MetricsData
+}
+
+var globalMetricsCollector = &metricsCollector{
+	data: make(map[string]*MetricsData),
+}
+
+// CollectMetrics stores enhanced metrics data for a command execution.
+// Collects system information, CI environment details, and container detection.
+func CollectMetrics(commandName string, flags []string) {
+	globalMetricsCollector.mu.Lock()
+	defer globalMetricsCollector.mu.Unlock()
+
+	ciSystem := detectCISystem()
+	isCI := ciSystem != ""
+
+	if ciSystem == "" {
+		ciSystem = "unknown"
+	}
+
+	metricsData := &MetricsData{
+		FlagsUsed:    flags,
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
+		IsCI:         isCI,
+		CISystem:     ciSystem,
+		IsContainer:  isRunningInContainer(),
+	}
+
+	globalMetricsCollector.data[commandName] = metricsData
+}
+
+// GetCollectedMetrics retrieves collected metrics for a command.
+// Returns a copy of the metrics data without clearing the original.
+func GetCollectedMetrics(commandName string) *MetricsData {
+	globalMetricsCollector.mu.RLock()
+	metrics, exists := globalMetricsCollector.data[commandName]
+	globalMetricsCollector.mu.RUnlock()
+
+	if !exists {
+		return nil
+	}
+
+	return &MetricsData{
+		FlagsUsed:    append([]string(nil), metrics.FlagsUsed...),
+		OS:           metrics.OS,
+		Architecture: metrics.Architecture,
+		IsCI:         metrics.IsCI,
+		CISystem:     metrics.CISystem,
+		IsContainer:  metrics.IsContainer,
+	}
+}
+
+// detectCISystem identifies the CI environment and returns the system name
+func detectCISystem() string {
+	ciEnvVars := map[string]string{
+		"JENKINS_URL":            "jenkins",
+		"TRAVIS":                 "travis",
+		"CIRCLECI":               "circleci",
+		"GITHUB_ACTIONS":         "github_actions",
+		"GITLAB_CI":              "gitlab",
+		"BUILDKITE":              "buildkite",
+		"BAMBOO_BUILD_KEY":       "bamboo",
+		"TF_BUILD":               "azure_devops",
+		"TEAMCITY_VERSION":       "teamcity",
+		"DRONE":                  "drone",
+		"BITBUCKET_BUILD_NUMBER": "bitbucket",
+		"CODEBUILD_BUILD_ID":     "aws_codebuild",
+	}
+
+	for envVar, system := range ciEnvVars {
+		if os.Getenv(envVar) != "" {
+			return system
+		}
+	}
+
+	genericCIVars := []string{
+		"CI",
+		"CONTINUOUS_INTEGRATION",
+		"BUILD_ID",
+		"BUILD_NUMBER",
+	}
+
+	for _, envVar := range genericCIVars {
+		if os.Getenv(envVar) != "" {
+			return "unknown"
+		}
+	}
+
+	return ""
+}
+
+// isRunningInContainer detects if the CLI is running inside a container
+func isRunningInContainer() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		return true
+	}
+
+	if os.Getenv("container") != "" {
+		return true
+	}
+
+	if data, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+		content := string(data)
+		if strings.Contains(content, "docker") ||
+			strings.Contains(content, "containerd") ||
+			strings.Contains(content, "kubepods") ||
+			strings.Contains(content, "lxc") {
+			return true
+		}
+	}
+
+	if data, err := os.ReadFile("/proc/self/cgroup"); err == nil {
+		content := string(data)
+		if strings.Contains(content, "docker") ||
+			strings.Contains(content, "containerd") ||
+			strings.Contains(content, "kubepods") {
+			return true
+		}
+	}
+
+	if data, err := os.ReadFile("/proc/self/mountinfo"); err == nil {
+		content := string(data)
+		if strings.Contains(content, "docker") ||
+			strings.Contains(content, "overlay") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ClearCollectedMetrics removes metrics data for a specific command
+func ClearCollectedMetrics(commandName string) {
+	globalMetricsCollector.mu.Lock()
+	defer globalMetricsCollector.mu.Unlock()
+	delete(globalMetricsCollector.data, commandName)
+}
+
+// ClearAllMetrics clears all stored metrics
+func ClearAllMetrics() {
+	globalMetricsCollector.mu.Lock()
+	defer globalMetricsCollector.mu.Unlock()
+	globalMetricsCollector.data = make(map[string]*MetricsData)
+}
+
+var contextFlags []string
+var contextFlagsMutex sync.Mutex
+
+// SetContextFlags stores flags for the current command execution
+func SetContextFlags(flags []string) {
+	contextFlagsMutex.Lock()
+	defer contextFlagsMutex.Unlock()
+	contextFlags = append([]string(nil), flags...)
+}
+
+// GetContextFlags retrieves and clears the stored flags
+func GetContextFlags() []string {
+	contextFlagsMutex.Lock()
+	defer contextFlagsMutex.Unlock()
+	flags := contextFlags
+	contextFlags = nil
+	return flags
+}
+
+// TransferMetrics moves metrics from one command name to another.
+// Useful when collecting metrics with a temporary key that needs to be moved to the actual command name.
+func TransferMetrics(fromCommandName, toCommandName string) bool {
+	globalMetricsCollector.mu.Lock()
+	defer globalMetricsCollector.mu.Unlock()
+
+	if metricsData, exists := globalMetricsCollector.data[fromCommandName]; exists {
+		globalMetricsCollector.data[toCommandName] = metricsData
+		delete(globalMetricsCollector.data, fromCommandName)
+		return true
+	}
+	return false
+}

--- a/common/commands/metrics_collector.go
+++ b/common/commands/metrics_collector.go
@@ -32,17 +32,18 @@ func CollectMetrics(commandName string, flags []string) {
 	ciSystem := detectCISystem()
 	isCI := ciSystem != ""
 
-	if ciSystem == "" {
-		ciSystem = "unknown"
-	}
-
 	metricsData := &MetricsData{
 		Flags:        flags,
 		Platform:     runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		IsCI:         isCI,
-		CISystem:     ciSystem,
-		IsContainer:  isRunningInContainer(),
+		CISystem: func() string {
+			if isCI {
+				return ciSystem
+			}
+			return ""
+		}(),
+		IsContainer: isRunningInContainer(),
 	}
 
 	globalMetricsCollector.metricsData[commandName] = metricsData
@@ -150,13 +151,6 @@ func isRunningInContainer() bool {
 	}
 
 	return false
-}
-
-// ClearCollectedMetrics removes metrics data for a specific command
-func ClearCollectedMetrics(commandName string) {
-	globalMetricsCollector.mu.Lock()
-	defer globalMetricsCollector.mu.Unlock()
-	delete(globalMetricsCollector.metricsData, commandName)
 }
 
 // SetContextFlags stores flags for the current command execution

--- a/common/commands/metrics_collector.go
+++ b/common/commands/metrics_collector.go
@@ -23,6 +23,7 @@ type metricsCollector struct {
 	data map[string]*MetricsData
 }
 
+var contextFlags []string
 var globalMetricsCollector = &metricsCollector{
 	data: make(map[string]*MetricsData),
 }
@@ -163,42 +164,14 @@ func ClearCollectedMetrics(commandName string) {
 	delete(globalMetricsCollector.data, commandName)
 }
 
-// ClearAllMetrics clears all stored metrics
-func ClearAllMetrics() {
-	globalMetricsCollector.mu.Lock()
-	defer globalMetricsCollector.mu.Unlock()
-	globalMetricsCollector.data = make(map[string]*MetricsData)
-}
-
-var contextFlags []string
-var contextFlagsMutex sync.Mutex
-
 // SetContextFlags stores flags for the current command execution
 func SetContextFlags(flags []string) {
-	contextFlagsMutex.Lock()
-	defer contextFlagsMutex.Unlock()
 	contextFlags = append([]string(nil), flags...)
 }
 
 // GetContextFlags retrieves and clears the stored flags
 func GetContextFlags() []string {
-	contextFlagsMutex.Lock()
-	defer contextFlagsMutex.Unlock()
 	flags := contextFlags
 	contextFlags = nil
 	return flags
-}
-
-// TransferMetrics moves metrics from one command name to another.
-// Useful when collecting metrics with a temporary key that needs to be moved to the actual command name.
-func TransferMetrics(fromCommandName, toCommandName string) bool {
-	globalMetricsCollector.mu.Lock()
-	defer globalMetricsCollector.mu.Unlock()
-
-	if metricsData, exists := globalMetricsCollector.data[fromCommandName]; exists {
-		globalMetricsCollector.data[toCommandName] = metricsData
-		delete(globalMetricsCollector.data, fromCommandName)
-		return true
-	}
-	return false
 }

--- a/common/commands/metrics_collector_test.go
+++ b/common/commands/metrics_collector_test.go
@@ -1,0 +1,917 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/usage/visibility"
+)
+
+func TestCollectMetrics(t *testing.T) {
+	// Clear any existing metrics
+	globalMetricsCollector.mu.Lock()
+	globalMetricsCollector.data = make(map[string]*MetricsData)
+	globalMetricsCollector.mu.Unlock()
+
+	tests := []struct {
+		name        string
+		commandName string
+		flags       []string
+		expected    *MetricsData
+	}{
+		{
+			name:        "Single flag",
+			commandName: "test-command",
+			flags:       []string{"verbose"},
+			expected: &MetricsData{
+				FlagsUsed:    []string{"verbose"},
+				OS:           runtime.GOOS,
+				Architecture: runtime.GOARCH,
+				IsCI:         detectCISystem() != "",
+				CISystem: func() string {
+					ci := detectCISystem()
+					if ci == "" {
+						return "unknown"
+					} else {
+						return ci
+					}
+				}(),
+				IsContainer: isRunningInContainer(),
+			},
+		},
+		{
+			name:        "Multiple flags",
+			commandName: "upload-command",
+			flags:       []string{"recursive", "threads", "dry-run"},
+			expected: &MetricsData{
+				FlagsUsed:    []string{"recursive", "threads", "dry-run"},
+				OS:           runtime.GOOS,
+				Architecture: runtime.GOARCH,
+				IsCI:         detectCISystem() != "",
+				CISystem: func() string {
+					ci := detectCISystem()
+					if ci == "" {
+						return "unknown"
+					} else {
+						return ci
+					}
+				}(),
+				IsContainer: isRunningInContainer(),
+			},
+		},
+		{
+			name:        "No flags",
+			commandName: "simple-command",
+			flags:       []string{},
+			expected: &MetricsData{
+				FlagsUsed:    []string{},
+				OS:           runtime.GOOS,
+				Architecture: runtime.GOARCH,
+				IsCI:         detectCISystem() != "",
+				CISystem: func() string {
+					ci := detectCISystem()
+					if ci == "" {
+						return "unknown"
+					} else {
+						return ci
+					}
+				}(),
+				IsContainer: isRunningInContainer(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Collect metrics
+			CollectMetrics(tt.commandName, tt.flags)
+
+			// Retrieve metrics
+			metrics := GetCollectedMetrics(tt.commandName)
+
+			// Verify metrics
+			if metrics == nil {
+				t.Error("Expected metrics to be collected, but got nil")
+				return
+			}
+
+			// Compare flags
+			if len(metrics.FlagsUsed) != len(tt.expected.FlagsUsed) {
+				t.Errorf("Expected %d flags, got %d", len(tt.expected.FlagsUsed), len(metrics.FlagsUsed))
+			}
+			for i, flag := range tt.expected.FlagsUsed {
+				if i >= len(metrics.FlagsUsed) || metrics.FlagsUsed[i] != flag {
+					t.Errorf("Expected flag %s at index %d, got %s", flag, i, metrics.FlagsUsed[i])
+				}
+			}
+
+			// Compare system information
+			if metrics.OS != tt.expected.OS {
+				t.Errorf("Expected OS %s, got %s", tt.expected.OS, metrics.OS)
+			}
+			if metrics.Architecture != tt.expected.Architecture {
+				t.Errorf("Expected Architecture %s, got %s", tt.expected.Architecture, metrics.Architecture)
+			}
+			if metrics.IsCI != tt.expected.IsCI {
+				t.Errorf("Expected IsCI %v, got %v", tt.expected.IsCI, metrics.IsCI)
+			}
+			if metrics.CISystem != tt.expected.CISystem {
+				t.Errorf("Expected CISystem %s, got %s", tt.expected.CISystem, metrics.CISystem)
+			}
+			if metrics.IsContainer != tt.expected.IsContainer {
+				t.Errorf("Expected IsContainer %v, got %v", tt.expected.IsContainer, metrics.IsContainer)
+			}
+		})
+	}
+}
+
+func TestGetCollectedMetricsDoesNotClearData(t *testing.T) {
+	// Clear any existing metrics
+	ClearAllMetrics()
+
+	commandName := "test-clear-command"
+	flags := []string{"test-flag"}
+
+	// Collect metrics
+	CollectMetrics(commandName, flags)
+
+	// Retrieve metrics first time
+	metrics1 := GetCollectedMetrics(commandName)
+	if metrics1 == nil {
+		t.Error("Expected metrics to be collected")
+		return
+	}
+
+	// Retrieve metrics second time should still return data (not cleared automatically)
+	metrics2 := GetCollectedMetrics(commandName)
+	if metrics2 == nil {
+		t.Error("Expected metrics to still be available after retrieval")
+		return
+	}
+
+	// Verify data is the same
+	if len(metrics1.FlagsUsed) != len(metrics2.FlagsUsed) {
+		t.Error("Expected same metrics data on repeated retrieval")
+	}
+
+	// Manually clear and verify
+	ClearCollectedMetrics(commandName)
+	metrics3 := GetCollectedMetrics(commandName)
+	if metrics3 != nil {
+		t.Error("Expected metrics to be cleared after explicit clear")
+	}
+}
+
+func TestDetectCISystem(t *testing.T) {
+	// Save original environment
+	originalEnv := make(map[string]string)
+	ciEnvVars := []string{
+		"JENKINS_URL", "TRAVIS", "CIRCLECI", "GITHUB_ACTIONS",
+		"GITLAB_CI", "BUILDKITE", "BAMBOO_BUILD_KEY", "TF_BUILD",
+		"TEAMCITY_VERSION", "DRONE", "BITBUCKET_BUILD_NUMBER",
+		"CODEBUILD_BUILD_ID", "CI",
+	}
+
+	for _, envVar := range ciEnvVars {
+		originalEnv[envVar] = os.Getenv(envVar)
+		os.Unsetenv(envVar)
+	}
+
+	// Restore environment after test
+	defer func() {
+		for envVar, value := range originalEnv {
+			if value != "" {
+				os.Setenv(envVar, value)
+			} else {
+				os.Unsetenv(envVar)
+			}
+		}
+	}()
+
+	tests := []struct {
+		name     string
+		envVar   string
+		envValue string
+		expected string
+	}{
+		{"GitHub Actions", "GITHUB_ACTIONS", "true", "github_actions"},
+		{"Jenkins", "JENKINS_URL", "http://jenkins.example.com", "jenkins"},
+		{"GitLab CI", "GITLAB_CI", "true", "gitlab"},
+		{"CircleCI", "CIRCLECI", "true", "circleci"},
+		{"Travis", "TRAVIS", "true", "travis"},
+		{"Azure DevOps", "TF_BUILD", "True", "azure_devops"},
+		{"Generic CI", "CI", "true", "unknown"},
+		{"No CI", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear all CI environment variables
+			for _, envVar := range ciEnvVars {
+				os.Unsetenv(envVar)
+			}
+
+			// Set the specific test environment variable
+			if tt.envVar != "" {
+				os.Setenv(tt.envVar, tt.envValue)
+			}
+
+			result := detectCISystem()
+			if result != tt.expected {
+				t.Errorf("Expected CI system %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsRunningInContainer(t *testing.T) {
+	// This test will mostly work on the actual environment
+	// We can't easily mock filesystem calls without more complex mocking
+	result := isRunningInContainer()
+
+	// Just verify it returns a boolean value
+	if result != true && result != false {
+		t.Error("isRunningInContainer should return a boolean value")
+	}
+
+	// Test with environment variable
+	originalContainer := os.Getenv("container")
+	defer func() {
+		if originalContainer != "" {
+			os.Setenv("container", originalContainer)
+		} else {
+			os.Unsetenv("container")
+		}
+	}()
+
+	os.Setenv("container", "docker")
+	if !isRunningInContainer() {
+		t.Error("Expected container detection when 'container' env var is set")
+	}
+
+	os.Unsetenv("container")
+
+	// Test with Kubernetes environment
+	originalK8s := os.Getenv("KUBERNETES_SERVICE_HOST")
+	defer func() {
+		if originalK8s != "" {
+			os.Setenv("KUBERNETES_SERVICE_HOST", originalK8s)
+		} else {
+			os.Unsetenv("KUBERNETES_SERVICE_HOST")
+		}
+	}()
+
+	os.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	if !isRunningInContainer() {
+		t.Error("Expected container detection when Kubernetes env var is set")
+	}
+}
+
+func TestSanitizeFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "Basic flags",
+			input:    []string{"verbose", "recursive", "threads"},
+			expected: []string{"verbose", "recursive", "threads"},
+		},
+		{
+			name:     "Empty flags",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "Single flag",
+			input:    []string{"dry-run"},
+			expected: []string{"dry-run"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeFlags(tt.input)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d flags, got %d", len(tt.expected), len(result))
+				return
+			}
+
+			for i, flag := range tt.expected {
+				if result[i] != flag {
+					t.Errorf("Expected flag %s at index %d, got %s", flag, i, result[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMetricsDataStructure(t *testing.T) {
+	metrics := &MetricsData{
+		FlagsUsed:    []string{"test-flag1", "test-flag2"},
+		OS:           "test-os",
+		Architecture: "test-arch",
+		IsCI:         true,
+		CISystem:     "test-ci",
+		IsContainer:  false,
+	}
+
+	// Verify all fields are properly set
+	if len(metrics.FlagsUsed) != 2 {
+		t.Errorf("Expected 2 flags, got %d", len(metrics.FlagsUsed))
+	}
+	if metrics.FlagsUsed[0] != "test-flag1" {
+		t.Errorf("Expected first flag to be 'test-flag1', got %s", metrics.FlagsUsed[0])
+	}
+	if metrics.OS != "test-os" {
+		t.Errorf("Expected OS to be 'test-os', got %s", metrics.OS)
+	}
+	if metrics.Architecture != "test-arch" {
+		t.Errorf("Expected Architecture to be 'test-arch', got %s", metrics.Architecture)
+	}
+	if !metrics.IsCI {
+		t.Error("Expected IsCI to be true")
+	}
+	if metrics.CISystem != "test-ci" {
+		t.Errorf("Expected CISystem to be 'test-ci', got %s", metrics.CISystem)
+	}
+	if metrics.IsContainer {
+		t.Error("Expected IsContainer to be false")
+	}
+}
+
+// TestCommand implements the Command interface for E2E testing
+type TestCommand struct {
+	name           string
+	flags          []string
+	serverDetails  *config.ServerDetails
+	executionError error
+	executed       bool
+}
+
+func (tc *TestCommand) Run() error {
+	tc.executed = true
+	return tc.executionError
+}
+
+func (tc *TestCommand) ServerDetails() (*config.ServerDetails, error) {
+	if tc.serverDetails != nil {
+		return tc.serverDetails, nil
+	}
+	return &config.ServerDetails{
+		ArtifactoryUrl: "https://test-e2e.jfrog.io/artifactory/",
+		User:           "test-user",
+		Password:       "test-password",
+	}, nil
+}
+
+func (tc *TestCommand) CommandName() string {
+	return tc.name
+}
+
+func (tc *TestCommand) GetFlags() []string {
+	return tc.flags
+}
+
+func TestE2EBasicMetricsFlow(t *testing.T) {
+	// Clear metrics to start fresh
+	ClearAllMetrics()
+	commandName := "upload"
+	flags := []string{"recursive", "threads", "dry-run"}
+	CollectMetrics(commandName, flags)
+	cmd := &TestCommand{
+		name:  commandName,
+		flags: flags,
+	}
+	err := Exec(cmd)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !cmd.executed {
+		t.Error("Command should have been executed")
+	}
+	CollectMetrics(commandName, flags)
+	metrics := GetCollectedMetrics(commandName)
+
+	if metrics == nil {
+		t.Error("Metrics should be collected")
+		return
+	}
+	if len(metrics.FlagsUsed) != len(flags) {
+		t.Errorf("Expected %d flags, got %d", len(flags), len(metrics.FlagsUsed))
+	}
+	if metrics.OS != runtime.GOOS {
+		t.Errorf("Expected OS %s, got %s", runtime.GOOS, metrics.OS)
+	}
+	if metrics.Architecture != runtime.GOARCH {
+		t.Errorf("Expected Architecture %s, got %s", runtime.GOARCH, metrics.Architecture)
+	}
+}
+
+func TestE2EGitHubActionsEnvironment(t *testing.T) {
+	// Setup GitHub Actions environment
+	originalGH := os.Getenv("GITHUB_ACTIONS")
+	originalCI := os.Getenv("CI")
+
+	os.Setenv("GITHUB_ACTIONS", "true")
+	os.Setenv("CI", "true")
+
+	defer func() {
+		if originalGH == "" {
+			os.Unsetenv("GITHUB_ACTIONS")
+		} else {
+			os.Setenv("GITHUB_ACTIONS", originalGH)
+		}
+		if originalCI == "" {
+			os.Unsetenv("CI")
+		} else {
+			os.Setenv("CI", originalCI)
+		}
+	}()
+
+	ClearAllMetrics()
+
+	commandName := "download"
+	flags := []string{"threads", "flat"}
+
+	// Collect metrics
+	CollectMetrics(commandName, flags)
+	metrics := GetCollectedMetrics(commandName)
+
+	if metrics == nil {
+		t.Error("Metrics should be collected")
+		return
+	}
+
+	if !metrics.IsCI {
+		t.Error("Should detect CI environment")
+	}
+	if metrics.CISystem != "github_actions" {
+		t.Errorf("Expected CI system 'github_actions', got '%s'", metrics.CISystem)
+	}
+}
+
+func TestE2EVisibilityIntegration(t *testing.T) {
+	ClearAllMetrics()
+
+	commandName := "full-integration-test"
+	flags := []string{"recursive", "threads", "exclude", "dry-run"}
+
+	// Collect metrics
+	CollectMetrics(commandName, flags)
+	metrics := GetCollectedMetrics(commandName)
+
+	if metrics == nil {
+		t.Error("Metrics should be collected")
+		return
+	}
+
+	// Create visibility metrics
+	visibilityData := &visibility.MetricsData{
+		FlagsUsed:    metrics.FlagsUsed,
+		OS:           metrics.OS,
+		Architecture: metrics.Architecture,
+		IsCI:         metrics.IsCI,
+		CISystem:     metrics.CISystem,
+		IsContainer:  metrics.IsContainer,
+	}
+
+	visibilityMetric := visibility.NewCommandsCountMetricWithEnhancedData(commandName, visibilityData)
+
+	// Verify metric structure
+	if visibilityMetric.Name != "jfcli_commands_count" {
+		t.Errorf("Expected metric name 'jfcli_commands_count', got %s", visibilityMetric.Name)
+	}
+	if visibilityMetric.Value != 1 {
+		t.Errorf("Expected metric value 1, got %d", visibilityMetric.Value)
+	}
+
+	// Verify JSON serialization
+	metricJSON, err := json.Marshal(visibilityMetric)
+	if err != nil {
+		t.Errorf("Failed to marshal metric: %v", err)
+	}
+
+	jsonStr := string(metricJSON)
+	if !strings.Contains(jsonStr, "flags_used") {
+		t.Error("JSON should contain flags_used")
+	}
+	if !strings.Contains(jsonStr, "os") {
+		t.Error("JSON should contain os")
+	}
+	if !strings.Contains(jsonStr, "architecture") {
+		t.Error("JSON should contain architecture")
+	}
+}
+
+func TestE2EFlagSanitization(t *testing.T) {
+	ClearAllMetrics()
+
+	testCases := []struct {
+		name     string
+		flags    []string
+		expected []string
+	}{
+		{
+			name:     "Safe flags only",
+			flags:    []string{"recursive", "threads", "dry-run"},
+			expected: []string{"recursive", "threads", "dry-run"},
+		},
+		{
+			name:     "Empty flags",
+			flags:    []string{},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			commandName := "sanitization-test-" + strings.ReplaceAll(tc.name, " ", "-")
+
+			// Collect metrics
+			CollectMetrics(commandName, tc.flags)
+			metrics := GetCollectedMetrics(commandName)
+
+			if metrics == nil {
+				t.Error("Metrics should be collected")
+				return
+			}
+
+			sanitized := SanitizeFlags(metrics.FlagsUsed)
+			if len(sanitized) != len(tc.expected) {
+				t.Errorf("Expected %d sanitized flags, got %d", len(tc.expected), len(sanitized))
+			}
+			for i, expected := range tc.expected {
+				if i >= len(sanitized) || sanitized[i] != expected {
+					t.Errorf("Expected flag %s at index %d, got %s", expected, i, sanitized[i])
+				}
+			}
+		})
+	}
+}
+
+func TestE2EConcurrentMetricsCollection(t *testing.T) {
+	ClearAllMetrics()
+
+	numCommands := 5
+	done := make(chan struct{}, numCommands)
+
+	// Simulate concurrent command executions
+	for i := 0; i < numCommands; i++ {
+		go func(id int) {
+			defer func() { done <- struct{}{} }()
+
+			commandName := fmt.Sprintf("concurrent-cmd-%d", id)
+			flags := []string{fmt.Sprintf("flag-%d", id)}
+
+			// Collect metrics
+			CollectMetrics(commandName, flags)
+
+			// Verify metrics were collected
+			metrics := GetCollectedMetrics(commandName)
+			if metrics == nil {
+				t.Errorf("Metrics should be collected for command %s", commandName)
+				return
+			}
+
+			if len(metrics.FlagsUsed) != 1 || metrics.FlagsUsed[0] != flags[0] {
+				t.Errorf("Expected flag %s, got %v", flags[0], metrics.FlagsUsed)
+			}
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < numCommands; i++ {
+		select {
+		case <-done:
+			// Success
+		case <-time.After(time.Second * 2):
+			t.Fatal("Timeout waiting for concurrent operations")
+		}
+	}
+}
+
+func TestE2EMetricsClearing(t *testing.T) {
+	ClearAllMetrics()
+
+	commandName := "clear-test-command"
+	flags := []string{"test-flag"}
+
+	// Collect metrics
+	CollectMetrics(commandName, flags)
+
+	// Retrieve metrics (should NOT clear them - that's done by Exec)
+	metrics1 := GetCollectedMetrics(commandName)
+	if metrics1 == nil {
+		t.Error("First retrieval should return metrics")
+	}
+
+	// Clear metrics explicitly
+	ClearCollectedMetrics(commandName)
+
+	// Try to retrieve again (should be nil after clearing)
+	metrics2 := GetCollectedMetrics(commandName)
+	if metrics2 != nil {
+		t.Error("After clearing, retrieval should return nil")
+	}
+}
+
+func TestE2EEnvironmentDetection(t *testing.T) {
+	ClearAllMetrics()
+
+	// Test Jenkins detection
+	originalJenkins := os.Getenv("JENKINS_URL")
+	os.Setenv("JENKINS_URL", "http://jenkins.test")
+
+	defer func() {
+		if originalJenkins == "" {
+			os.Unsetenv("JENKINS_URL")
+		} else {
+			os.Setenv("JENKINS_URL", originalJenkins)
+		}
+	}()
+
+	commandName := "jenkins-test"
+	flags := []string{"test-flag"}
+
+	CollectMetrics(commandName, flags)
+	metrics := GetCollectedMetrics(commandName)
+
+	if metrics == nil {
+		t.Error("Metrics should be collected")
+		return
+	}
+
+	if !metrics.IsCI {
+		t.Error("Should detect CI environment")
+	}
+	if metrics.CISystem != "jenkins" {
+		t.Errorf("Expected CI system 'jenkins', got '%s'", metrics.CISystem)
+	}
+}
+
+// MockCommand implements the Command interface for testing
+type MockCommand struct {
+	name          string
+	serverDetails *config.ServerDetails
+	runFunc       func() error
+	shouldError   bool
+}
+
+func (m *MockCommand) Run() error {
+	if m.runFunc != nil {
+		return m.runFunc()
+	}
+	if m.shouldError {
+		return mockError("mock command error")
+	}
+	return nil
+}
+
+func (m *MockCommand) ServerDetails() (*config.ServerDetails, error) {
+	if m.serverDetails != nil {
+		return m.serverDetails, nil
+	}
+	return &config.ServerDetails{
+		ArtifactoryUrl: "https://test.jfrog.io/artifactory/",
+		User:           "test-user",
+		Password:       "test-password",
+	}, nil
+}
+
+func (m *MockCommand) CommandName() string {
+	return m.name
+}
+
+type mockError string
+
+func (e mockError) Error() string {
+	return string(e)
+}
+
+func TestExecWithBasicCommand(t *testing.T) {
+	// Clear any existing metrics
+	globalMetricsCollector.mu.Lock()
+	globalMetricsCollector.data = make(map[string]*MetricsData)
+	globalMetricsCollector.mu.Unlock()
+
+	commandName := "test-basic-command"
+	executed := false
+
+	cmd := &MockCommand{
+		name: commandName,
+		runFunc: func() error {
+			executed = true
+			return nil
+		},
+	}
+
+	err := Exec(cmd)
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if !executed {
+		t.Error("Expected command to be executed")
+	}
+}
+
+func TestExecWithCommandError(t *testing.T) {
+	commandName := "test-error-command"
+
+	cmd := &MockCommand{
+		name:        commandName,
+		shouldError: true,
+	}
+
+	err := Exec(cmd)
+
+	if err == nil {
+		t.Error("Expected command to return error")
+	}
+
+	if err.Error() != "mock command error" {
+		t.Errorf("Expected specific error message, got %v", err)
+	}
+}
+
+func TestReportUsageToVisibilitySystemWithMetrics(t *testing.T) {
+	// Clear any existing metrics
+	globalMetricsCollector.mu.Lock()
+	globalMetricsCollector.data = make(map[string]*MetricsData)
+	globalMetricsCollector.mu.Unlock()
+
+	commandName := "test-metrics-command"
+	flags := []string{"verbose", "recursive"}
+
+	// Collect metrics first
+	CollectMetrics(commandName, flags)
+
+	// Step 2: Create command for testing server details
+	cmd := &MockCommand{
+		name: commandName,
+		serverDetails: &config.ServerDetails{
+			ArtifactoryUrl: "https://test.jfrog.io/artifactory/",
+		},
+	}
+
+	// This will test the reportUsageToVisibilitySystem function indirectly
+	// In a real scenario, this would send metrics to the visibility system
+	serverDetails, err := cmd.ServerDetails()
+	if err != nil {
+		t.Errorf("Unexpected error getting server details: %v", err)
+		return
+	}
+
+	// Verify that metrics exist before reporting
+	metrics := GetCollectedMetrics(commandName)
+	if metrics == nil {
+		t.Error("Expected metrics to be collected")
+		return
+	}
+
+	// Verify the metrics content
+	if len(metrics.FlagsUsed) != 2 {
+		t.Errorf("Expected 2 flags, got %d", len(metrics.FlagsUsed))
+	}
+
+	// Test the visibility metric creation
+	visibilityMetricsData := &visibility.MetricsData{
+		FlagsUsed:    metrics.FlagsUsed,
+		OS:           metrics.OS,
+		Architecture: metrics.Architecture,
+		IsCI:         metrics.IsCI,
+		CISystem:     metrics.CISystem,
+		IsContainer:  metrics.IsContainer,
+	}
+
+	metric := visibility.NewCommandsCountMetricWithEnhancedData(commandName, visibilityMetricsData)
+
+	if metric.Value != 1 {
+		t.Errorf("Expected metric value to be 1, got %d", metric.Value)
+	}
+
+	if metric.Name != "jfcli_commands_count" {
+		t.Errorf("Expected metric name to be 'jfcli_commands_count', got %s", metric.Name)
+	}
+
+	// Verify that serverDetails is properly formed
+	if serverDetails.ArtifactoryUrl == "" {
+		t.Error("Expected server details to have ArtifactoryUrl")
+	}
+}
+
+func TestReportUsageToVisibilitySystemWithoutMetrics(t *testing.T) {
+	// Clear any existing metrics
+	globalMetricsCollector.mu.Lock()
+	globalMetricsCollector.data = make(map[string]*MetricsData)
+	globalMetricsCollector.mu.Unlock()
+
+	commandName := "test-no-metrics-command"
+
+	// Don't collect any metrics first
+
+	// Verify that no metrics exist
+	metrics := GetCollectedMetrics(commandName)
+	if metrics != nil {
+		t.Error("Expected no metrics to be collected")
+		return
+	}
+
+	// Test the visibility metric creation without enhanced data
+	metric := visibility.NewCommandsCountMetric(commandName)
+
+	if metric.Value != 1 {
+		t.Errorf("Expected metric value to be 1, got %d", metric.Value)
+	}
+
+	if metric.Name != "jfcli_commands_count" {
+		t.Errorf("Expected metric name to be 'jfcli_commands_count', got %s", metric.Name)
+	}
+}
+
+func TestMetricsIntegrationFlow(t *testing.T) {
+	// Clear any existing metrics
+	globalMetricsCollector.mu.Lock()
+	globalMetricsCollector.data = make(map[string]*MetricsData)
+	globalMetricsCollector.mu.Unlock()
+
+	commandName := "integration-test-command"
+	flags := []string{"recursive", "threads", "exclude"}
+
+	// Step 1: Collect metrics (simulates CLI flag interception)
+	CollectMetrics(commandName, flags)
+
+	// Step 2: Create and execute command
+	executed := false
+	cmd := &MockCommand{
+		name: commandName,
+		runFunc: func() error {
+			executed = true
+			return nil
+		},
+	}
+
+	// Step 3: Execute command (this would normally trigger metrics reporting)
+	err := Exec(cmd)
+	if err != nil {
+		t.Errorf("Unexpected error executing command: %v", err)
+	}
+
+	if !executed {
+		t.Error("Expected command to be executed")
+	}
+
+	// Step 4: Verify metrics were collected and can be retrieved
+	// Note: In the real flow, GetCollectedMetrics is called during reportUsageToVisibilitySystem
+	// and the metrics are cleared after retrieval
+
+	// Since Exec() -> reportUsage() -> reportUsageToVisibilitySystem() -> GetCollectedMetrics()
+	// the metrics should have been cleared. Let's test this behavior by collecting again
+	// and then manually calling the visibility system integration
+
+	CollectMetrics(commandName, flags)
+
+	// Get metrics (this simulates what happens in reportUsageToVisibilitySystem)
+	metrics := GetCollectedMetrics(commandName)
+	if metrics == nil {
+		t.Error("Expected metrics to be available")
+		return
+	}
+
+	// Verify metrics content
+	if len(metrics.FlagsUsed) != 3 {
+		t.Errorf("Expected 3 flags, got %d", len(metrics.FlagsUsed))
+	}
+
+	expectedFlags := []string{"recursive", "threads", "exclude"}
+	for i, expectedFlag := range expectedFlags {
+		if i >= len(metrics.FlagsUsed) || metrics.FlagsUsed[i] != expectedFlag {
+			t.Errorf("Expected flag %s at index %d, got %s", expectedFlag, i, metrics.FlagsUsed[i])
+		}
+	}
+
+	// Verify system information is collected
+	if metrics.OS == "" {
+		t.Error("Expected OS to be populated")
+	}
+
+	if metrics.Architecture == "" {
+		t.Error("Expected Architecture to be populated")
+	}
+
+	// Verify metrics are cleared after retrieval
+	metricsAfter := GetCollectedMetrics(commandName)
+	if metricsAfter != nil {
+		t.Error("Expected metrics to be cleared after retrieval")
+	}
+}

--- a/common/commands/metrics_collector_test.go
+++ b/common/commands/metrics_collector_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/utils/usage/visibility"
 )
 
+// ClearAllMetrics clears all stored metrics
+func ClearAllMetrics() {
+	globalMetricsCollector.mu.Lock()
+	defer globalMetricsCollector.mu.Unlock()
+	globalMetricsCollector.data = make(map[string]*MetricsData)
+}
+
 func TestCollectMetrics(t *testing.T) {
 	// Clear any existing metrics
 	globalMetricsCollector.mu.Lock()

--- a/common/commands/metrics_collector_test.go
+++ b/common/commands/metrics_collector_test.go
@@ -194,7 +194,9 @@ func TestDetectCISystem(t *testing.T) {
 	defer func() {
 		for envVar, value := range originalEnv {
 			if value != "" {
-				os.Setenv(envVar, value)
+				if err := os.Setenv(envVar, value); err != nil {
+					t.Logf("failed restoring %s: %v", envVar, err)
+				}
 			} else {
 				os.Unsetenv(envVar)
 			}

--- a/plugins/components/commandcomp.go
+++ b/plugins/components/commandcomp.go
@@ -56,6 +56,7 @@ type Context struct {
 	boolFlags        map[string]bool
 	PrintCommandHelp func(commandName string) error
 	ParentContext    *Context
+	FlagsUsed        []string
 }
 
 func (c *Context) GetStringFlagValue(flagName string) string {

--- a/utils/metrics/metrics.go
+++ b/utils/metrics/metrics.go
@@ -1,0 +1,12 @@
+package metrics
+
+// MetricsData holds enhanced metrics information for command execution.
+// Shared between commands and visibility packages to avoid import cycles.
+type MetricsData struct {
+	Flags        []string `json:"flags,omitempty"`
+	Platform     string   `json:"platform,omitempty"`
+	Architecture string   `json:"architecture,omitempty"`
+	IsCI         bool     `json:"is_ci,omitempty"`
+	CISystem     string   `json:"ci_system,omitempty"`
+	IsContainer  bool     `json:"is_container,omitempty"`
+}

--- a/utils/usage/visibility/commands_count_metric.go
+++ b/utils/usage/visibility/commands_count_metric.go
@@ -6,17 +6,12 @@ import (
 	"strings"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	metrics "github.com/jfrog/jfrog-cli-core/v2/utils/metrics"
 	"github.com/jfrog/jfrog-client-go/jfconnect/services"
 )
 
-type MetricsData struct {
-	FlagsUsed    []string `json:"flags_used,omitempty"`
-	OS           string   `json:"os,omitempty"`
-	Architecture string   `json:"architecture,omitempty"`
-	IsCI         bool     `json:"is_ci,omitempty"`
-	CISystem     string   `json:"ci_system,omitempty"`
-	IsContainer  bool     `json:"is_container,omitempty"`
-}
+// MetricsData is shared from utils/metrics to avoid import cycles.
+type MetricsData = metrics.MetricsData
 
 type commandsCountLabels struct {
 	ProductID                            string `json:"product_id"`
@@ -77,12 +72,12 @@ func NewCommandsCountMetricWithEnhancedData(commandName string, metricsData *Met
 	}
 
 	if metricsData != nil {
-		if len(metricsData.FlagsUsed) > 0 {
-			flags := append([]string(nil), metricsData.FlagsUsed...)
+		if len(metricsData.Flags) > 0 {
+			flags := append([]string(nil), metricsData.Flags...)
 			sort.Strings(flags)
 			labels.Flags = strings.Join(flags, ",")
 		}
-		labels.Platform = metricsData.OS
+		labels.Platform = metricsData.Platform
 		labels.Architecture = metricsData.Architecture
 		if metricsData.IsCI {
 			labels.IsCI = "true"

--- a/utils/usage/visibility/commands_count_metric.go
+++ b/utils/usage/visibility/commands_count_metric.go
@@ -2,6 +2,7 @@ package visibility
 
 import (
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -76,7 +77,11 @@ func NewCommandsCountMetricWithEnhancedData(commandName string, metricsData *Met
 	}
 
 	if metricsData != nil {
-		labels.Flags = strings.Join(metricsData.FlagsUsed, ",")
+		if len(metricsData.FlagsUsed) > 0 {
+			flags := append([]string(nil), metricsData.FlagsUsed...)
+			sort.Strings(flags)
+			labels.Flags = strings.Join(flags, ",")
+		}
 		labels.Platform = metricsData.OS
 		labels.Architecture = metricsData.Architecture
 		if metricsData.IsCI {

--- a/utils/usage/visibility/commands_count_metric.go
+++ b/utils/usage/visibility/commands_count_metric.go
@@ -54,22 +54,8 @@ func NewCommandsCountMetric(commandName string) services.VisibilityMetric {
 }
 
 func NewCommandsCountMetricWithEnhancedData(commandName string, metricsData *MetricsData) services.VisibilityMetric {
-	labels := &commandsCountLabels{
-		ProductID:                            coreutils.GetCliUserAgentName(),
-		ProductVersion:                       coreutils.GetCliUserAgentVersion(),
-		FeatureID:                            commandName,
-		ProviderType:                         os.Getenv(coreutils.OidcProviderType),
-		JobID:                                os.Getenv(coreutils.CIJobID),
-		RunID:                                os.Getenv(coreutils.CIRunID),
-		GitRepo:                              os.Getenv(coreutils.SourceCodeRepository),
-		GhTokenForCodeScanningAlertsProvided: os.Getenv("JFROG_CLI_USAGE_GH_TOKEN_FOR_CODE_SCANNING_ALERTS_PROVIDED"),
-		Flags:                                "",
-		Platform:                             "",
-		Architecture:                         "",
-		IsCI:                                 "",
-		CISystem:                             "",
-		IsContainer:                          "",
-	}
+	metric := NewCommandsCountMetric(commandName)
+	labels, _ := metric.Labels.(*commandsCountLabels)
 
 	if metricsData != nil {
 		if len(metricsData.Flags) > 0 {
@@ -93,9 +79,5 @@ func NewCommandsCountMetricWithEnhancedData(commandName string, metricsData *Met
 		}
 	}
 
-	return services.VisibilityMetric{
-		Value:  1,
-		Name:   "jfcli_commands_count",
-		Labels: labels,
-	}
+	return metric
 }

--- a/utils/usage/visibility/commands_count_metric.go
+++ b/utils/usage/visibility/commands_count_metric.go
@@ -1,20 +1,37 @@
 package visibility
 
 import (
+	"os"
+	"strings"
+
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/jfconnect/services"
-	"os"
 )
+
+type MetricsData struct {
+	FlagsUsed    []string `json:"flags_used,omitempty"`
+	OS           string   `json:"os,omitempty"`
+	Architecture string   `json:"architecture,omitempty"`
+	IsCI         bool     `json:"is_ci,omitempty"`
+	CISystem     string   `json:"ci_system,omitempty"`
+	IsContainer  bool     `json:"is_container,omitempty"`
+}
 
 type commandsCountLabels struct {
 	ProductID                            string `json:"product_id"`
 	ProductVersion                       string `json:"product_version"`
 	FeatureID                            string `json:"feature_id"`
-	ProviderType                         string `json:"provider_type"`
+	OIDCUsed                             string `json:"oidc_used"`
 	JobID                                string `json:"job_id"`
 	RunID                                string `json:"run_id"`
 	GitRepo                              string `json:"git_repo"`
 	GhTokenForCodeScanningAlertsProvided string `json:"gh_token_for_code_scanning_alerts_provided"`
+	Flags                                string `json:"flags"`
+	Platform                             string `json:"platform"`
+	Architecture                         string `json:"architecture"`
+	IsCI                                 string `json:"is_ci"`
+	CISystem                             string `json:"ci_system,omitempty"`
+	IsContainer                          string `json:"is_container"`
 }
 
 func NewCommandsCountMetric(commandName string) services.VisibilityMetric {
@@ -25,11 +42,60 @@ func NewCommandsCountMetric(commandName string) services.VisibilityMetric {
 			ProductID:                            coreutils.GetCliUserAgentName(),
 			ProductVersion:                       coreutils.GetCliUserAgentVersion(),
 			FeatureID:                            commandName,
-			ProviderType:                         os.Getenv(coreutils.OidcProviderType),
+			OIDCUsed:                             os.Getenv(coreutils.OidcProviderType),
 			JobID:                                os.Getenv(coreutils.CIJobID),
 			RunID:                                os.Getenv(coreutils.CIRunID),
 			GitRepo:                              os.Getenv(coreutils.SourceCodeRepository),
 			GhTokenForCodeScanningAlertsProvided: os.Getenv("JFROG_CLI_USAGE_GH_TOKEN_FOR_CODE_SCANNING_ALERTS_PROVIDED"),
+			Flags:                                "",
+			Platform:                             "",
+			Architecture:                         "",
+			IsCI:                                 "",
+			CISystem:                             "",
+			IsContainer:                          "",
 		},
+	}
+}
+
+func NewCommandsCountMetricWithEnhancedData(commandName string, metricsData *MetricsData) services.VisibilityMetric {
+	labels := &commandsCountLabels{
+		ProductID:                            coreutils.GetCliUserAgentName(),
+		ProductVersion:                       coreutils.GetCliUserAgentVersion(),
+		FeatureID:                            commandName,
+		OIDCUsed:                             os.Getenv("JFROG_CLI_USAGE_OIDC_USED"),
+		JobID:                                os.Getenv("JFROG_CLI_USAGE_JOB_ID"),
+		RunID:                                os.Getenv("JFROG_CLI_USAGE_RUN_ID"),
+		GitRepo:                              os.Getenv("JFROG_CLI_USAGE_GIT_REPO"),
+		GhTokenForCodeScanningAlertsProvided: os.Getenv("JFROG_CLI_USAGE_GH_TOKEN_FOR_CODE_SCANNING_ALERTS_PROVIDED"),
+		Flags:                                "",
+		Platform:                             "",
+		Architecture:                         "",
+		IsCI:                                 "",
+		CISystem:                             "",
+		IsContainer:                          "",
+	}
+
+	if metricsData != nil {
+		labels.Flags = strings.Join(metricsData.FlagsUsed, ",")
+		labels.Platform = metricsData.OS
+		labels.Architecture = metricsData.Architecture
+		if metricsData.IsCI {
+			labels.IsCI = "true"
+			labels.CISystem = metricsData.CISystem
+		} else {
+			labels.IsCI = "false"
+			labels.CISystem = ""
+		}
+		if metricsData.IsContainer {
+			labels.IsContainer = "true"
+		} else {
+			labels.IsContainer = "false"
+		}
+	}
+
+	return services.VisibilityMetric{
+		Value:  1,
+		Name:   "jfcli_commands_count",
+		Labels: labels,
 	}
 }

--- a/utils/usage/visibility/commands_count_metric.go
+++ b/utils/usage/visibility/commands_count_metric.go
@@ -22,7 +22,7 @@ type commandsCountLabels struct {
 	ProductID                            string `json:"product_id"`
 	ProductVersion                       string `json:"product_version"`
 	FeatureID                            string `json:"feature_id"`
-	OIDCUsed                             string `json:"oidc_used"`
+	ProviderType                         string `json:"provider_type"`
 	JobID                                string `json:"job_id"`
 	RunID                                string `json:"run_id"`
 	GitRepo                              string `json:"git_repo"`
@@ -43,7 +43,7 @@ func NewCommandsCountMetric(commandName string) services.VisibilityMetric {
 			ProductID:                            coreutils.GetCliUserAgentName(),
 			ProductVersion:                       coreutils.GetCliUserAgentVersion(),
 			FeatureID:                            commandName,
-			OIDCUsed:                             os.Getenv(coreutils.OidcProviderType),
+			ProviderType:                         os.Getenv(coreutils.OidcProviderType),
 			JobID:                                os.Getenv(coreutils.CIJobID),
 			RunID:                                os.Getenv(coreutils.CIRunID),
 			GitRepo:                              os.Getenv(coreutils.SourceCodeRepository),
@@ -63,10 +63,10 @@ func NewCommandsCountMetricWithEnhancedData(commandName string, metricsData *Met
 		ProductID:                            coreutils.GetCliUserAgentName(),
 		ProductVersion:                       coreutils.GetCliUserAgentVersion(),
 		FeatureID:                            commandName,
-		OIDCUsed:                             os.Getenv("JFROG_CLI_USAGE_OIDC_USED"),
-		JobID:                                os.Getenv("JFROG_CLI_USAGE_JOB_ID"),
-		RunID:                                os.Getenv("JFROG_CLI_USAGE_RUN_ID"),
-		GitRepo:                              os.Getenv("JFROG_CLI_USAGE_GIT_REPO"),
+		ProviderType:                         os.Getenv(coreutils.OidcProviderType),
+		JobID:                                os.Getenv(coreutils.CIJobID),
+		RunID:                                os.Getenv(coreutils.CIRunID),
+		GitRepo:                              os.Getenv(coreutils.SourceCodeRepository),
 		GhTokenForCodeScanningAlertsProvided: os.Getenv("JFROG_CLI_USAGE_GH_TOKEN_FOR_CODE_SCANNING_ALERTS_PROVIDED"),
 		Flags:                                "",
 		Platform:                             "",

--- a/utils/usage/visibility/commands_count_metric_test.go
+++ b/utils/usage/visibility/commands_count_metric_test.go
@@ -2,11 +2,12 @@ package visibility
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/jfrog/jfrog-cli-core/v2/general/token"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	testsutils "github.com/jfrog/jfrog-client-go/utils/tests"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCreateCommandsCountMetric(t *testing.T) {
@@ -42,7 +43,13 @@ func TestCreateCommandsCountMetric(t *testing.T) {
 			"product_id": "` + coreutils.GetCliUserAgentName() + `",
 			"product_version": "` + coreutils.GetCliUserAgentVersion() + `",
 			"feature_id": "testCommand",
-     		"provider_type": "GitHub",
+			"flags_used": [],
+			"os": "",
+			"architecture": "",
+			"is_ci": false,
+			"is_container": false,
+			"ci_system": "",
+			"oidc_used": "GitHub",
 			"job_id": "job123",
 			"run_id": "run456",
 			"git_repo": "test-repo",
@@ -52,4 +59,159 @@ func TestCreateCommandsCountMetric(t *testing.T) {
 
 	// Compare the generated JSON to the expected JSON
 	assert.JSONEq(t, expectedJSON, string(metricJSON))
+}
+
+func TestNewCommandsCountMetricWithEnhancedData(t *testing.T) {
+	commandName := "enhanced-test-command"
+
+	metricsData := &MetricsData{
+		FlagsUsed:    []string{"verbose", "recursive", "threads"},
+		OS:           "linux",
+		Architecture: "amd64",
+		IsCI:         true,
+		CISystem:     "github_actions",
+		IsContainer:  false,
+	}
+
+	metric := NewCommandsCountMetricWithEnhancedData(commandName, metricsData)
+
+	// Verify basic metric structure
+	assert.Equal(t, 1, metric.Value)
+	assert.Equal(t, "jfcli_commands_count", metric.Name)
+
+	// Verify labels
+	labels, ok := metric.Labels.(*commandsCountLabels)
+	assert.True(t, ok, "Expected labels to be of type commandsCountLabels")
+
+	// Verify basic fields
+	assert.Equal(t, coreutils.GetCliUserAgentName(), labels.ProductID)
+	assert.Equal(t, commandName, labels.FeatureID)
+
+	// Verify enhanced fields
+	assert.Equal(t, []string{"verbose", "recursive", "threads"}, labels.FlagsUsed)
+	assert.Equal(t, "linux", labels.OS)
+	assert.Equal(t, "amd64", labels.Architecture)
+	assert.True(t, labels.IsCI)
+	assert.Equal(t, "github_actions", labels.CISystem)
+	assert.False(t, labels.IsContainer)
+}
+
+func TestNewCommandsCountMetricWithNilEnhancedData(t *testing.T) {
+	commandName := "nil-enhanced-test-command"
+
+	metric := NewCommandsCountMetricWithEnhancedData(commandName, nil)
+
+	// Verify basic metric structure
+	assert.Equal(t, 1, metric.Value)
+	assert.Equal(t, "jfcli_commands_count", metric.Name)
+
+	// Verify labels
+	labels, ok := metric.Labels.(*commandsCountLabels)
+	assert.True(t, ok, "Expected labels to be of type commandsCountLabels")
+
+	// Verify basic fields are still set
+	assert.Equal(t, commandName, labels.FeatureID)
+
+	// Verify enhanced fields are empty/default
+	assert.Empty(t, labels.FlagsUsed)
+	assert.Empty(t, labels.OS)
+	assert.Empty(t, labels.Architecture)
+	assert.False(t, labels.IsCI)
+	assert.Empty(t, labels.CISystem)
+	assert.False(t, labels.IsContainer)
+}
+
+func TestMetricsDataStructure(t *testing.T) {
+	data := &MetricsData{
+		FlagsUsed:    []string{"flag1", "flag2"},
+		OS:           "windows",
+		Architecture: "arm64",
+		IsCI:         false,
+		CISystem:     "",
+		IsContainer:  true,
+	}
+
+	// Verify all fields are accessible
+	assert.Len(t, data.FlagsUsed, 2)
+	assert.Equal(t, "flag1", data.FlagsUsed[0])
+	assert.Equal(t, "windows", data.OS)
+	assert.Equal(t, "arm64", data.Architecture)
+	assert.False(t, data.IsCI)
+	assert.Empty(t, data.CISystem)
+	assert.True(t, data.IsContainer)
+}
+
+func TestCommandsCountLabelsJSONSerialization(t *testing.T) {
+	metricsData := &MetricsData{
+		FlagsUsed:    []string{"recursive", "dry-run"},
+		OS:           "darwin",
+		Architecture: "arm64",
+		IsCI:         true,
+		CISystem:     "github_actions",
+		IsContainer:  false,
+	}
+
+	commandName := "test-upload"
+	metric := NewCommandsCountMetricWithEnhancedData(commandName, metricsData)
+
+	// Serialize to JSON
+	metricJSON, err := json.Marshal(metric)
+	assert.NoError(t, err)
+
+	// Verify the JSON contains our enhanced fields
+	assert.Contains(t, string(metricJSON), "\"flags_used\":[\"recursive\",\"dry-run\"]")
+	assert.Contains(t, string(metricJSON), "\"os\":\"darwin\"")
+	assert.Contains(t, string(metricJSON), "\"architecture\":\"arm64\"")
+	assert.Contains(t, string(metricJSON), "\"is_ci\":true")
+	assert.Contains(t, string(metricJSON), "\"ci_system\":\"github_actions\"")
+	assert.Contains(t, string(metricJSON), "\"is_container\":false")
+}
+
+func TestEnhancedMetricsEnvironmentIntegration(t *testing.T) {
+	// Set environment variables for the test
+	envVars := map[string]string{
+		"JFROG_CLI_USAGE_OIDC_USED": "true",
+		"JFROG_CLI_USAGE_JOB_ID":    "test-job-123",
+		"JFROG_CLI_USAGE_RUN_ID":    "test-run-456",
+		"JFROG_CLI_USAGE_GIT_REPO":  "owner/repo",
+	}
+	cleanupFuncs := []func(){}
+	for key, value := range envVars {
+		cleanup := testsutils.SetEnvWithCallbackAndAssert(t, key, value)
+		cleanupFuncs = append(cleanupFuncs, cleanup)
+	}
+	defer func() {
+		for _, cleanup := range cleanupFuncs {
+			cleanup()
+		}
+	}()
+
+	metricsData := &MetricsData{
+		FlagsUsed:    []string{"threads", "retry"},
+		OS:           "linux",
+		Architecture: "amd64",
+		IsCI:         true,
+		CISystem:     "jenkins",
+		IsContainer:  true,
+	}
+
+	commandName := "env-test-command"
+	metric := NewCommandsCountMetricWithEnhancedData(commandName, metricsData)
+
+	labels, ok := metric.Labels.(*commandsCountLabels)
+	assert.True(t, ok, "Expected labels to be of type commandsCountLabels")
+
+	// Verify environment variables are picked up
+	assert.Equal(t, "true", labels.OIDCUsed)
+	assert.Equal(t, "test-job-123", labels.JobID)
+	assert.Equal(t, "test-run-456", labels.RunID)
+	assert.Equal(t, "owner/repo", labels.GitRepo)
+
+	// Verify enhanced metrics data is also included
+	assert.Equal(t, []string{"threads", "retry"}, labels.FlagsUsed)
+	assert.Equal(t, "linux", labels.OS)
+	assert.Equal(t, "amd64", labels.Architecture)
+	assert.True(t, labels.IsCI)
+	assert.Equal(t, "jenkins", labels.CISystem)
+	assert.True(t, labels.IsContainer)
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
### Changes
The existing usage metrics collects only the command name. This PR adds more details into usage metrics to understand jfrog cli command usage.