### PR TITLE
Fix build evidence summary URL format by removing redundant build nam…

### DIFF
--- a/artifactory/utils/commandsummary/evidence_url.go
+++ b/artifactory/utils/commandsummary/evidence_url.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	releaseBundleEvidenceFormat = "%sui/artifactory/lifecycle?range=Any+Time&bundleName=%s&repositoryKey=%s&releaseBundleVersion=%s&activeVersionTab=Evidence+Graph"
-	buildEvidenceFormat         = "%sui/builds/%s/%s/%s/Evidence/%s?buildRepo=%s"
+	buildEvidenceFormat         = "%sui/builds/%s/%s/%s/Evidence?buildRepo=%s"
 	artifactEvidenceFormat      = "%sui/repos/tree/Evidence/%s?clearFilter=true"
 )
 
@@ -56,7 +56,6 @@ func generateBuildEvidenceUrl(data EvidenceSummaryData, section summarySection) 
 		url.QueryEscape(data.BuildName),
 		data.BuildNumber,
 		data.BuildTimestamp,
-		url.QueryEscape(data.BuildName),
 		data.RepoKey)
 
 	return addGitHubTrackingToUrl(urlStr, section)

--- a/artifactory/utils/commandsummary/evidence_url_test.go
+++ b/artifactory/utils/commandsummary/evidence_url_test.go
@@ -73,7 +73,7 @@ func TestGenerateEvidenceUrlByType(t *testing.T) {
 				BuildTimestamp: "1234567890",
 				RepoKey:        "artifactory-build-info",
 			},
-			expectedURL: "https://myplatform.com/ui/builds/my-build/123/1234567890/Evidence/my-build?buildRepo=artifactory-build-info&gh_job_id=JFrog+CLI+Core+Tests&gh_section=evidence&m=3&s=1",
+			expectedURL: "https://myplatform.com/ui/builds/my-build/123/1234567890/Evidence?buildRepo=artifactory-build-info&gh_job_id=JFrog+CLI+Core+Tests&gh_section=evidence&m=3&s=1",
 		},
 		{
 			name: "Build with special characters in name",
@@ -85,7 +85,7 @@ func TestGenerateEvidenceUrlByType(t *testing.T) {
 				BuildTimestamp: "1234567890",
 				RepoKey:        "artifactory-build-info",
 			},
-			expectedURL: "https://myplatform.com/ui/builds/my+build+with+spaces/123/1234567890/Evidence/my+build+with+spaces?buildRepo=artifactory-build-info&gh_job_id=JFrog+CLI+Core+Tests&gh_section=evidence&m=3&s=1",
+			expectedURL: "https://myplatform.com/ui/builds/my+build+with+spaces/123/1234567890/Evidence?buildRepo=artifactory-build-info&gh_job_id=JFrog+CLI+Core+Tests&gh_section=evidence&m=3&s=1",
 		},
 		{
 			name: "Invalid release bundle falls back to artifact URL",


### PR DESCRIPTION
…e parameter (#1435)

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
