### PR TITLE
Added logic for checking first if JFROG_CLI_ENCRYPTION_KEY is filepat…

### DIFF
--- a/utils/config/encryption.go
+++ b/utils/config/encryption.go
@@ -5,9 +5,11 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
 
 	ioutils "github.com/jfrog/gofrog/io"
@@ -98,8 +100,16 @@ func handleSecrets(config *Config, handler secretHandler, key string) error {
 }
 
 func getEncryptionKey() (string, error) {
-	if key, exist := os.LookupEnv(coreutils.EncryptionKey); exist {
-		return key, nil
+	if keyOrPath, exist := os.LookupEnv(coreutils.EncryptionKey); exist {
+		fileInfo, err := os.Stat(keyOrPath)
+		if err == nil && !fileInfo.IsDir() {
+			keyBytes, readErr := os.ReadFile(keyOrPath)
+			if readErr != nil {
+				return "", fmt.Errorf("failed to read encryption key from file '%s': %w", keyOrPath, readErr)
+			}
+			return strings.TrimSpace(string(keyBytes)), nil
+		}
+		return keyOrPath, nil
 	}
 	return getEncryptionKeyFromSecurityConfFile()
 }


### PR DESCRIPTION
…h and then key

- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Description:
https://jfrog-int.atlassian.net/browse/RTECO-389

JFROG_CLI_ENCRYPTION_KEY is stored in os env due to which it is accessible in logs.

Solution:
Instead of storing encryption key itself in os env, we have stored the path where encryption key is stored, in this way, we are only exposing file path in logs which is local path only, so no risk of information leakage.