### PR TITLE
JA-17729 - Provide ability to disable refresh token

### DIFF
--- a/plugins/common/server.go
+++ b/plugins/common/server.go
@@ -61,6 +61,7 @@ func CreateServerDetailsFromFlags(c *components.Context) (details *config.Server
 		details.ServerId = os.Getenv(coreutils.ServerID)
 	}
 	details.InsecureTls = c.GetBoolFlagValue("insecure-tls")
+	details.DisableTokenRefresh = c.GetBoolFlagValue("disable-token-refresh")
 	return
 }
 

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -601,6 +601,7 @@ type ServerDetails struct {
 	IsDefault                       bool   `json:"isDefault,omitempty"`
 	InsecureTls                     bool   `json:"-"`
 	WebLogin                        bool   `json:"webLogin,omitempty"`
+	DisableTokenRefresh             bool   `json:"disableTokenRefresh,omitempty"`
 }
 
 // Deprecated
@@ -802,7 +803,7 @@ func (serverDetails *ServerDetails) createAuthConfig(details auth.ServiceDetails
 	// If refresh token is not empty, set a refresh handler and skip other credentials.
 	// First we check access's token, if empty we check artifactory's token.
 	switch {
-	case serverDetails.RefreshToken != "":
+	case serverDetails.RefreshToken != "" && !serverDetails.DisableTokenRefresh:
 		// Save serverId for refreshing if needed. If empty serverId is saved, default will be used.
 		tokenRefreshServerId = serverDetails.ServerId
 		details.AppendPreRequestFunction(AccessTokenRefreshPreRequestInterceptor)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Provide ability to disable refresh token. By default token is refreshed it is expiring within 7 days. 