### PR TITLE
Add image embedding functionality for Markdown with base64 conversion

### DIFF
--- a/utils/image/base64converter.go
+++ b/utils/image/base64converter.go
@@ -1,0 +1,187 @@
+package image
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const (
+	pngFormat             = "png"
+	gifFormat             = "gif"
+	svgMimeType           = "image/svg+xml"
+	pngMimeType           = "image/png"
+	gifMimeType           = "image/gif"
+	jpegMimeType          = "image/jpeg"
+	widthAttr             = "width"
+	heightAttr            = "height"
+	defaultHTTPTimeout    = 30 * time.Second
+	svgDoubleQuotePattern = `%s="([^"]+)"`
+	svgSingleQuotePattern = `%s='([^']+)'`
+	svgTagPattern         = `(?i)^\s*(?:<\?xml[^>]*>\s*)?(?:<!DOCTYPE[^>]*>\s*)?<svg\s`
+)
+
+var (
+	widthDoubleQuoteRegex  = regexp.MustCompile(fmt.Sprintf(svgDoubleQuotePattern, widthAttr))
+	widthSingleQuoteRegex  = regexp.MustCompile(fmt.Sprintf(svgSingleQuotePattern, widthAttr))
+	heightDoubleQuoteRegex = regexp.MustCompile(fmt.Sprintf(svgDoubleQuotePattern, heightAttr))
+	heightSingleQuoteRegex = regexp.MustCompile(fmt.Sprintf(svgSingleQuotePattern, heightAttr))
+	svgTagRegex            = regexp.MustCompile(svgTagPattern)
+)
+
+func ToBase64(imagePath, baseDir string, width, height int) (string, string, error) {
+	var content []byte
+	var err error
+
+	if isURL(imagePath) {
+		content, err = downloadImageContent(imagePath)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to download image: %v", err)
+		}
+	} else {
+		resolvedPath := resolveImagePath(imagePath, baseDir)
+		content, err = os.ReadFile(resolvedPath)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to read image file: %v", err)
+		}
+	}
+
+	if svgTagRegex.Match(content) {
+		if err = validateSVGDimensions(content, width, height); err != nil {
+			return "", "", err
+		}
+		return base64.StdEncoding.EncodeToString(content), svgMimeType, nil
+	}
+
+	img, format, err := image.Decode(bytes.NewReader(content))
+	if err != nil {
+		return "", "", fmt.Errorf("unsupported image format: %v", err)
+	}
+
+	if err = validateImageDimensions(img, width, height); err != nil {
+		return "", "", err
+	}
+
+	var mimeType string
+	switch format {
+	case pngFormat:
+		mimeType = pngMimeType
+	case gifFormat:
+		mimeType = gifMimeType
+	default:
+		mimeType = jpegMimeType
+	}
+
+	return base64.StdEncoding.EncodeToString(content), mimeType, nil
+}
+
+func downloadImageContent(imageURL string) ([]byte, error) {
+	client := &http.Client{Timeout: defaultHTTPTimeout}
+	resp, err := client.Get(imageURL)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Warn("failed to close response body: ", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status: %s", resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func validateImageDimensions(img image.Image, maxWidth, maxHeight int) error {
+	srcWidth := img.Bounds().Dx()
+	srcHeight := img.Bounds().Dy()
+
+	if maxWidth <= 0 && maxHeight <= 0 {
+		return nil
+	}
+
+	if maxWidth > 0 && srcWidth > maxWidth {
+		return fmt.Errorf("image width %d exceeds maximum allowed width %d", srcWidth, maxWidth)
+	}
+	if maxHeight > 0 && srcHeight > maxHeight {
+		return fmt.Errorf("image height %d exceeds maximum allowed height %d", srcHeight, maxHeight)
+	}
+
+	return nil
+}
+
+func validateSVGDimensions(content []byte, maxWidth, maxHeight int) error {
+	contentStr := string(content)
+
+	if maxWidth <= 0 && maxHeight <= 0 {
+		return nil
+	}
+
+	widthMatch := widthDoubleQuoteRegex.FindStringSubmatch(contentStr)
+	if len(widthMatch) == 0 {
+		widthMatch = widthSingleQuoteRegex.FindStringSubmatch(contentStr)
+	}
+
+	heightMatch := heightDoubleQuoteRegex.FindStringSubmatch(contentStr)
+	if len(heightMatch) == 0 {
+		heightMatch = heightSingleQuoteRegex.FindStringSubmatch(contentStr)
+	}
+
+	var currentWidth, currentHeight int
+	var hasWidth, hasHeight bool
+
+	if len(widthMatch) > 1 {
+		if _, err := fmt.Sscanf(widthMatch[1], "%d", &currentWidth); err == nil {
+			hasWidth = true
+		}
+	}
+	if len(heightMatch) > 1 {
+		if _, err := fmt.Sscanf(heightMatch[1], "%d", &currentHeight); err == nil {
+			hasHeight = true
+		}
+	}
+
+	if !hasWidth && !hasHeight {
+		return nil
+	}
+
+	if hasWidth && maxWidth > 0 && currentWidth > maxWidth {
+		return fmt.Errorf("SVG width %d exceeds maximum allowed width %d", currentWidth, maxWidth)
+	}
+	if hasHeight && maxHeight > 0 && currentHeight > maxHeight {
+		return fmt.Errorf("SVG height %d exceeds maximum allowed height %d", currentHeight, maxHeight)
+	}
+
+	return nil
+}
+
+func resolveImagePath(imagePath, baseDir string) string {
+	if filepath.IsAbs(imagePath) {
+		return imagePath
+	}
+
+	if baseDir == "" {
+		return imagePath
+	}
+
+	return filepath.Join(baseDir, imagePath)
+}
+
+func isURL(str string) bool {
+	u, err := url.Parse(str)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}

--- a/utils/image/base64converter_test.go
+++ b/utils/image/base64converter_test.go
@@ -1,0 +1,465 @@
+package image
+
+import (
+	"encoding/base64"
+	"image"
+	"image/color"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageToBase64_LocalPNG(t *testing.T) {
+	tempDir := t.TempDir()
+
+	pngFile := createTestPNG(t, tempDir, "test.png", 100, 100)
+
+	_, _, err := ToBase64(pngFile, "", 50, 50)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+	assert.NoError(t, os.Remove(pngFile))
+}
+
+func TestImageToBase64_LocalJPEG(t *testing.T) {
+	tempDir := t.TempDir()
+
+	jpegFile := createTestJPEG(t, tempDir, "test.jpg", 200, 150)
+
+	_, _, err := ToBase64(jpegFile, "", 100, 75)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+	assert.NoError(t, os.Remove(jpegFile))
+}
+
+func TestImageToBase64_LocalGIF(t *testing.T) {
+	tempDir := t.TempDir()
+
+	gifFile := createTestGIF(t, tempDir, "test.gif", 80, 60)
+
+	_, _, err := ToBase64(gifFile, "", 40, 30)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+	assert.NoError(t, os.Remove(gifFile))
+}
+
+func TestImageToBase64_LocalSVG(t *testing.T) {
+	tempDir := t.TempDir()
+
+	svgContent := `<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+		<rect width="100" height="100" fill="red"/>
+	</svg>`
+	svgFile := filepath.Join(tempDir, "test.svg")
+	err := os.WriteFile(svgFile, []byte(svgContent), 0644)
+	require.NoError(t, err)
+	_, _, err = ToBase64(svgFile, "", 50, 50)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+	assert.NoError(t, os.Remove(svgFile))
+}
+
+func TestImageToBase64_URLImage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		img := createTestImage(50, 50)
+		w.Header().Set("Content-Type", "image/png")
+		if err := png.Encode(w, img); err != nil {
+			t.Errorf("failed to encode PNG: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	_, _, err := ToBase64(server.URL, "", 25, 25)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+}
+
+func TestImageToBase64_URLImageError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, _, err := ToBase64(server.URL, "", 0, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status:")
+}
+
+func TestImageToBase64_InvalidPath(t *testing.T) {
+	_, _, err := ToBase64("nonexistent.png", "", 0, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read image file")
+}
+
+func TestImageToBase64_UnsupportedFormat(t *testing.T) {
+	tempDir := t.TempDir()
+
+	invalidFile := filepath.Join(tempDir, "test.txt")
+	err := os.WriteFile(invalidFile, []byte("not an image"), 0644)
+	require.NoError(t, err)
+	_, _, err = ToBase64(invalidFile, "", 0, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported image format")
+	assert.NoError(t, os.Remove(invalidFile))
+}
+
+func TestValidateImageDimensions_NoValidation(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 100, 100))
+	err := validateImageDimensions(src, 0, 0)
+	require.NoError(t, err)
+}
+
+func TestValidateImageDimensions_WithinLimits(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 500, 300))
+	err := validateImageDimensions(src, 600, 400)
+	require.NoError(t, err)
+}
+
+func TestValidateImageDimensions_WidthExceeds(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 200, 100))
+	err := validateImageDimensions(src, 150, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "width 200 exceeds maximum allowed width 150")
+}
+
+func TestValidateImageDimensions_HeightExceeds(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 200, 100))
+	err := validateImageDimensions(src, 0, 75)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "height 100 exceeds maximum allowed height 75")
+}
+
+func TestValidateImageDimensions_BothDimensionsExceed(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 200, 100))
+	err := validateImageDimensions(src, 150, 75)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+}
+
+func TestValidateImageDimensions_ExactLimits(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 100, 100))
+	err := validateImageDimensions(src, 100, 100)
+	require.NoError(t, err)
+}
+
+func TestImageToBase64_WithinLimits(t *testing.T) {
+	tempDir := t.TempDir()
+
+	pngFile := createTestPNG(t, tempDir, "test.png", 50, 50)
+
+	base64Str, mimeType, err := ToBase64(pngFile, "", 100, 100)
+	require.NoError(t, err)
+	assert.Equal(t, "image/png", mimeType)
+	assert.NotEmpty(t, base64Str)
+	assert.NoError(t, os.Remove(pngFile))
+}
+
+func TestValidateSVGDimensions_ExceedsLimits(t *testing.T) {
+	svgContent := `<svg width="200" height="150" xmlns="http://www.w3.org/2000/svg">
+		<rect width="200" height="150" fill="red"/>
+	</svg>`
+
+	err := validateSVGDimensions([]byte(svgContent), 100, 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+}
+
+func TestValidateSVGDimensions_WithinLimits(t *testing.T) {
+	svgContent := `<svg width="100" height="200" xmlns="http://www.w3.org/2000/svg">
+		<rect width="100" height="200" fill="red"/>
+	</svg>`
+
+	err := validateSVGDimensions([]byte(svgContent), 300, 400)
+	require.NoError(t, err)
+}
+
+func TestValidateSVGDimensions_NoDimensions(t *testing.T) {
+	svgContent := `<svg xmlns="http://www.w3.org/2000/svg">
+		<rect fill="red"/>
+	</svg>`
+
+	err := validateSVGDimensions([]byte(svgContent), 300, 400)
+	require.NoError(t, err)
+}
+
+func TestValidateSVGDimensions_SingleQuotes(t *testing.T) {
+	svgContent := `<svg width='200' height='150' xmlns="http://www.w3.org/2000/svg">
+		<rect width='200' height='150' fill="red"/>
+	</svg>`
+
+	err := validateSVGDimensions([]byte(svgContent), 100, 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+}
+
+func TestValidateSVGDimensions_MixedQuotes(t *testing.T) {
+	svgContent := `<svg width="200" height='150' xmlns="http://www.w3.org/2000/svg">
+		<rect width="200" height='150' fill="red"/>
+	</svg>`
+
+	err := validateSVGDimensions([]byte(svgContent), 100, 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+}
+
+func TestValidateSVGDimensions_SingleQuotesWithinLimits(t *testing.T) {
+	svgContent := `<svg width='100' height='200' xmlns="http://www.w3.org/2000/svg">
+		<rect width='100' height='200' fill="red"/>
+	</svg>`
+
+	err := validateSVGDimensions([]byte(svgContent), 300, 400)
+	require.NoError(t, err)
+}
+
+func TestValidateSVGDimensions_MismatchedQuotes(t *testing.T) {
+	svgContent := `<svg width='200" height="150' xmlns="http://www.w3.org/2000/svg">
+		<rect width='200" height="150' fill="red"/>
+	</svg>`
+
+	err := validateSVGDimensions([]byte(svgContent), 100, 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+}
+
+func TestIsURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"https://example.com/image.png", true},
+		{"ftp://example.com/image.png", true},
+		{"image.png", false},
+		{"./image.png", false},
+		{"../image.png", false},
+		{"", false},
+		{"not-a-url", false},
+	}
+
+	for _, test := range tests {
+		result := isURL(test.input)
+		assert.Equal(t, test.expected, result, "isURL(%q)", test.input)
+	}
+}
+
+func TestToBase64WithBaseDir_RelativePath(t *testing.T) {
+	tempDir := t.TempDir()
+	subDir := filepath.Join(tempDir, "images")
+	err := os.Mkdir(subDir, 0755)
+	require.NoError(t, err)
+
+	pngFile := createTestPNG(t, subDir, "test.png", 100, 100)
+
+	_, _, err = ToBase64("images/test.png", tempDir, 50, 50)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+	assert.NoError(t, os.Remove(pngFile))
+}
+
+func TestToBase64WithBaseDir_AbsolutePath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	pngFile := createTestPNG(t, tempDir, "test.png", 100, 100)
+
+	_, _, err := ToBase64(pngFile, "/some/other/dir", 50, 50)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+	assert.NoError(t, os.Remove(pngFile))
+}
+
+func TestToBase64WithBaseDir_EmptyBaseDir(t *testing.T) {
+	tempDir := t.TempDir()
+
+	pngFile := createTestPNG(t, tempDir, "test.png", 100, 100)
+
+	_, _, err := ToBase64(pngFile, "", 50, 50)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+	assert.NoError(t, os.Remove(pngFile))
+}
+
+func TestResolveImagePath(t *testing.T) {
+	absolutePath, err := filepath.Abs(filepath.Join("absolute", "path", "pic.png"))
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
+	baseDir := filepath.Join("base", "dir")
+	relativePath := filepath.Join("images", "pic.png")
+
+	tests := []struct {
+		name      string
+		imagePath string
+		baseDir   string
+		expected  string
+	}{
+		{"absolute path", absolutePath, "", absolutePath},
+		{"relative path with base", relativePath, baseDir, filepath.Join(baseDir, relativePath)},
+		{"relative path no base", relativePath, "", relativePath},
+		{"current dir relative", filepath.Join(".", "pic.png"), baseDir, filepath.Join(baseDir, "pic.png")},
+		{"parent dir relative", filepath.Join("..", "pic.png"), baseDir, filepath.Join(baseDir, "..", "pic.png")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := resolveImagePath(test.imagePath, test.baseDir)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestDownloadImageContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte("test image content")); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	content, err := downloadImageContent(server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "test image content", string(content))
+}
+
+func TestDownloadImageContent_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := downloadImageContent(server.URL)
+	require.Error(t, err)
+}
+
+func TestDownloadImageContent_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		if _, err := w.Write([]byte("delayed response")); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: 50 * time.Millisecond}
+	_, err := client.Get(server.URL)
+	require.Error(t, err)
+}
+
+func TestImageToBase64_E2E_RealImages(t *testing.T) {
+	tempDir := t.TempDir()
+
+	pngFile := createTestPNG(t, tempDir, "e2e.png", 300, 200)
+	jpegFile := createTestJPEG(t, tempDir, "e2e.jpg", 400, 300)
+	gifFile := createTestGIF(t, tempDir, "e2e.gif", 150, 100)
+
+	svgContent := `<svg width="250" height="150" xmlns="http://www.w3.org/2000/svg">
+		<rect width="250" height="150" fill="blue"/>
+		<circle cx="125" cy="75" r="50" fill="yellow"/>
+	</svg>`
+	svgFile := filepath.Join(tempDir, "e2e.svg")
+	err := os.WriteFile(svgFile, []byte(svgContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to create SVG file: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		filePath     string
+		width        int
+		height       int
+		expectedMime string
+		shouldError  bool
+	}{
+		{"PNG", pngFile, 150, 100, "image/png", true},
+		{"JPEG", jpegFile, 200, 150, "image/jpeg", true},
+		{"GIF", gifFile, 75, 50, "image/gif", true},
+		{"SVG", svgFile, 200, 100, "image/svg+xml", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base64Str, mimeType, err := ToBase64(test.filePath, "", test.width, test.height)
+			if test.shouldError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "exceeds maximum allowed")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedMime, mimeType)
+				assert.NotEmpty(t, base64Str)
+				decoded, decErr := base64.StdEncoding.DecodeString(base64Str)
+				require.NoError(t, decErr)
+				assert.NotEmpty(t, decoded)
+			}
+		})
+	}
+
+	assert.NoError(t, os.Remove(pngFile))
+	assert.NoError(t, os.Remove(jpegFile))
+	assert.NoError(t, os.Remove(gifFile))
+	assert.NoError(t, os.Remove(svgFile))
+}
+
+func createTestPNG(t *testing.T, dir, filename string, width, height int) string {
+	filePath := filepath.Join(dir, filename)
+	file, err := os.Create(filePath)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, file.Close())
+	}()
+
+	img := createTestImage(width, height)
+	err = png.Encode(file, img)
+	require.NoError(t, err)
+
+	return filePath
+}
+
+func createTestJPEG(t *testing.T, dir, filename string, width, height int) string {
+	filePath := filepath.Join(dir, filename)
+	file, err := os.Create(filePath)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, file.Close())
+	}()
+
+	img := createTestImage(width, height)
+	err = jpeg.Encode(file, img, &jpeg.Options{Quality: 90})
+	require.NoError(t, err)
+
+	return filePath
+}
+
+func createTestGIF(t *testing.T, dir, filename string, width, height int) string {
+	filePath := filepath.Join(dir, filename)
+	file, err := os.Create(filePath)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, file.Close())
+	}()
+
+	img := createTestImage(width, height)
+	err = gif.Encode(file, img, nil)
+	require.NoError(t, err)
+
+	return filePath
+}
+
+func createTestImage(width, height int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			r := uint8(float64(x) * 255 / float64(width))
+			g := uint8(float64(y) * 255 / float64(height))
+			b := uint8(float64(x+y) * 255 / float64(width+height))
+			img.Set(x, y, color.RGBA{R: r, G: g, B: b, A: 255})
+		}
+	}
+
+	return img
+}

--- a/utils/markdown/imagereplacer.go
+++ b/utils/markdown/imagereplacer.go
@@ -1,0 +1,113 @@
+package markdown
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/image"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+type ImageReference struct {
+	FullMatch string
+	AltText   string
+	ImagePath string
+	StartPos  int
+	EndPos    int
+}
+
+func EmbedMarkdownImages(markdown []byte, baseDir string, widthLimit, heightLimit int) ([]byte, error) {
+	content := string(markdown)
+	imageRefs := findImageReferences(content)
+
+	if len(imageRefs) == 0 {
+		return markdown, nil
+	}
+
+	sort.Slice(imageRefs, func(i, j int) bool {
+		return imageRefs[i].StartPos < imageRefs[j].StartPos
+	})
+
+	var buffer bytes.Buffer
+	lastIndex := 0
+	hasReplacements := false
+
+	for _, imgRef := range imageRefs {
+		buffer.WriteString(content[lastIndex:imgRef.StartPos])
+
+		base64Data, mimeType, err1 := image.ToBase64(imgRef.ImagePath, baseDir, widthLimit, heightLimit)
+		if err1 != nil {
+			log.Warn(fmt.Sprintf("Could not convert image %s to base64: %v. Keeping original reference.", imgRef.ImagePath, err1))
+			buffer.WriteString(imgRef.FullMatch)
+		} else {
+			newImageRef := fmt.Sprintf("![%s](data:%s;base64,%s)", imgRef.AltText, mimeType, base64Data)
+			buffer.WriteString(newImageRef)
+			hasReplacements = true
+		}
+		lastIndex = imgRef.EndPos
+	}
+
+	if !hasReplacements {
+		return markdown, nil
+	}
+	buffer.WriteString(content[lastIndex:])
+	return buffer.Bytes(), nil
+}
+
+var imageStartRegex = regexp.MustCompile(`!\[([^]]*)]\(`)
+
+func findImageReferences(content string) []ImageReference {
+	var refs []ImageReference
+
+	matches := imageStartRegex.FindAllStringSubmatchIndex(content, -1)
+	for _, match := range matches {
+		if len(match) < 4 {
+			continue
+		}
+
+		altText := content[match[2]:match[3]]
+		pathStart := match[1]
+
+		pathEnd := findMatchingParen(content, pathStart-1)
+		if pathEnd == -1 {
+			continue
+		}
+
+		imagePath := content[pathStart:pathEnd]
+
+		if strings.HasPrefix(imagePath, "data:") {
+			continue
+		}
+
+		fullMatch := content[match[0] : pathEnd+1]
+
+		refs = append(refs, ImageReference{
+			FullMatch: fullMatch,
+			AltText:   altText,
+			ImagePath: imagePath,
+			StartPos:  match[0],
+			EndPos:    pathEnd + 1,
+		})
+	}
+
+	return refs
+}
+
+func findMatchingParen(content string, openPos int) int {
+	parenCount := 1
+	for i := openPos + 1; i < len(content); i++ {
+		switch content[i] {
+		case '(':
+			parenCount++
+		case ')':
+			parenCount--
+			if parenCount == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}

--- a/utils/markdown/imagereplacer_test.go
+++ b/utils/markdown/imagereplacer_test.go
@@ -1,0 +1,338 @@
+package markdown
+
+import (
+	"image"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbedMarkdownImages_BasicImage(t *testing.T) {
+	content := `![alt text](./image.png)`
+
+	result, err := EmbedMarkdownImages([]byte(content), "", 100, 100)
+	require.NoError(t, err)
+
+	// Should keep original since image doesn't exist
+	assert.Contains(t, string(result), "![alt text](./image.png)")
+}
+
+func TestEmbedMarkdownImages_ImageWithParentheses(t *testing.T) {
+	content := `![the big one](./image(3).png)`
+
+	result, err := EmbedMarkdownImages([]byte(content), "", 100, 100)
+	require.NoError(t, err)
+
+	// Should keep original since image doesn't exist
+	assert.Contains(t, string(result), "![the big one](./image(3).png)")
+}
+
+func TestEmbedMarkdownImages_MultipleImages(t *testing.T) {
+	content := `![first](./image1.png) and ![second](./image(2).png)`
+
+	result, err := EmbedMarkdownImages([]byte(content), "", 100, 100)
+	require.NoError(t, err)
+
+	// Should preserve both images
+	assert.Contains(t, string(result), "![first](./image1.png)")
+	assert.Contains(t, string(result), "![second](./image(2).png)")
+}
+
+func TestEmbedMarkdownImages_ComplexParentheses(t *testing.T) {
+	testCases := []string{
+		`![test](./path/with(multiple)parentheses.png)`,
+		`![test](./file(1)(2).jpg)`,
+		`![test](./normal.png)`,
+	}
+
+	for _, content := range testCases {
+		t.Run(content, func(t *testing.T) {
+			result, err := EmbedMarkdownImages([]byte(content), "", 100, 100)
+			require.NoError(t, err)
+			assert.Equal(t, content, string(result))
+		})
+	}
+}
+
+func TestEmbedMarkdownImages_NoImages(t *testing.T) {
+	content := `This is just text with no images.`
+
+	result, err := EmbedMarkdownImages([]byte(content), "", 100, 100)
+	require.NoError(t, err)
+
+	assert.Equal(t, content, string(result))
+}
+
+func TestEmbedMarkdownImages_EmptyContent(t *testing.T) {
+	content := ``
+
+	result, err := EmbedMarkdownImages([]byte(content), "", 100, 100)
+	require.NoError(t, err)
+
+	assert.Equal(t, content, string(result))
+}
+
+func TestEmbedMarkdownImages_WithBaseDir(t *testing.T) {
+	content := `![test](./image.png)`
+	baseDir := "/some/base/dir"
+
+	result, err := EmbedMarkdownImages([]byte(content), baseDir, 100, 100)
+	require.NoError(t, err)
+
+	// Should preserve original since image doesn't exist
+	assert.Contains(t, string(result), "![test](./image.png)")
+}
+
+func TestFindImageReferences_Basic(t *testing.T) {
+	content := `![alt text](./image.png)`
+
+	refs := findImageReferences(content)
+
+	require.Len(t, refs, 1)
+
+	ref := refs[0]
+	assert.Equal(t, "alt text", ref.AltText)
+	assert.Equal(t, "./image.png", ref.ImagePath)
+	assert.GreaterOrEqual(t, ref.StartPos, 0)
+	assert.Less(t, ref.StartPos, len(content))
+	assert.Greater(t, ref.EndPos, ref.StartPos)
+}
+
+func TestFindImageReferences_WithParentheses(t *testing.T) {
+	content := `![the big one](./image(3).png)`
+
+	refs := findImageReferences(content)
+
+	require.Len(t, refs, 1)
+
+	ref := refs[0]
+	assert.Equal(t, "the big one", ref.AltText)
+	assert.Equal(t, "./image(3).png", ref.ImagePath)
+}
+
+func TestFindImageReferences_Multiple(t *testing.T) {
+	content := `![first](./image1.png) and ![second](./image(2).png)`
+
+	refs := findImageReferences(content)
+
+	require.Len(t, refs, 2)
+
+	// Check first image
+	assert.Equal(t, "first", refs[0].AltText)
+	assert.Equal(t, "./image1.png", refs[0].ImagePath)
+
+	// Check second image
+	assert.Equal(t, "second", refs[1].AltText)
+	assert.Equal(t, "./image(2).png", refs[1].ImagePath)
+}
+
+func TestFindImageReferences_NoImages(t *testing.T) {
+	content := `This is just text with no images.`
+
+	refs := findImageReferences(content)
+
+	require.Len(t, refs, 0)
+}
+
+func TestFindImageReferences_DataURL(t *testing.T) {
+	content := `![alt](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==)`
+
+	refs := findImageReferences(content)
+
+	// Data URLs should be skipped
+	require.Len(t, refs, 0)
+}
+
+func TestFindImageReferences_EdgeCases(t *testing.T) {
+	testCases := []struct {
+		name     string
+		content  string
+		expected int
+	}{
+		{"empty content", "", 0},
+		{"only text", "just text", 0},
+		{"malformed image", "![alt](", 0},
+		{"incomplete image", "![alt", 0},
+		{"complex path", `![test](./path/with(multiple)parentheses.png)`, 1},
+		{"multiple parentheses", `![test](./file(1)(2).jpg)`, 1},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			refs := findImageReferences(tc.content)
+			assert.Equal(t, tc.expected, len(refs))
+		})
+	}
+}
+
+func TestEmbedMarkdownImages_HappyPath_EmbedsDataURI(t *testing.T) {
+	tempDir := t.TempDir()
+	imgPath := filepath.Join(tempDir, "img.png")
+	f, err := os.Create(imgPath)
+	require.NoError(t, err)
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	require.NoError(t, png.Encode(f, img))
+	require.NoError(t, f.Close())
+
+	content := `before ![x](img.png) after`
+	result, err := EmbedMarkdownImages([]byte(content), tempDir, 0, 0)
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "data:image/png;base64,")
+	assert.NotContains(t, string(result), "](img.png)")
+}
+
+func TestEmbedMarkdownImages_AvoidsCopyWhenNoChanges(t *testing.T) {
+	content := `This has no images at all.`
+	input := []byte(content)
+	result, err := EmbedMarkdownImages(input, "", 100, 100)
+	require.NoError(t, err)
+
+	// Verify it returns the same slice when no changes are made
+	assert.Equal(t, &input[0], &result[0], "Should return the same slice when no replacements are made")
+}
+
+func TestEmbedMarkdownImages_AvoidsCopyWhenAllImagesFail(t *testing.T) {
+	content := `before ![x](nonexistent.png) after`
+	input := []byte(content)
+	result, err := EmbedMarkdownImages(input, "", 100, 100)
+	require.NoError(t, err)
+
+	// Verify it returns the same slice when all images fail to convert
+	assert.Equal(t, &input[0], &result[0], "Should return the same slice when all conversions fail")
+}
+
+func TestEmbedMarkdownImages_URLImage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		img := createTestImage(50, 50)
+		w.Header().Set("Content-Type", "image/png")
+		if err := png.Encode(w, img); err != nil {
+			t.Errorf("failed to encode PNG: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	content := `![test image](` + server.URL + `)`
+	result, err := EmbedMarkdownImages([]byte(content), "", 0, 0)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(result), "data:image/png;base64,")
+	assert.NotContains(t, string(result), "](`+server.URL+`)")
+}
+
+func TestEmbedMarkdownImages_URLImageWithLimits(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		img := createTestImage(200, 150)
+		w.Header().Set("Content-Type", "image/png")
+		if err := png.Encode(w, img); err != nil {
+			t.Errorf("failed to encode PNG: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	content := `![large image](` + server.URL + `)`
+	result, err := EmbedMarkdownImages([]byte(content), "", 100, 100)
+	require.NoError(t, err)
+
+	// Should keep original since image exceeds limits
+	assert.Contains(t, string(result), "![large image]("+server.URL+")")
+	assert.NotContains(t, string(result), "data:image/png;base64,")
+}
+
+func TestEmbedMarkdownImages_URLImageError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	content := `![missing image](` + server.URL + `)`
+	result, err := EmbedMarkdownImages([]byte(content), "", 0, 0)
+	require.NoError(t, err)
+
+	// Should keep original since URL returns error
+	assert.Contains(t, string(result), "![missing image]("+server.URL+")")
+	assert.NotContains(t, string(result), "data:image/png;base64,")
+}
+
+func TestEmbedMarkdownImages_MixedLocalAndURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		img := createTestImage(50, 50)
+		w.Header().Set("Content-Type", "image/png")
+		if err := png.Encode(w, img); err != nil {
+			t.Errorf("failed to encode PNG: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	imgPath := filepath.Join(tempDir, "local.png")
+	f, err := os.Create(imgPath)
+	require.NoError(t, err)
+	img := createTestImage(30, 30)
+	require.NoError(t, png.Encode(f, img))
+	require.NoError(t, f.Close())
+
+	content := `![local](local.png) and ![remote](` + server.URL + `)`
+	result, err := EmbedMarkdownImages([]byte(content), tempDir, 0, 0)
+	require.NoError(t, err)
+
+	// Both should be converted to data URIs
+	assert.Contains(t, string(result), "data:image/png;base64,")
+	assert.NotContains(t, string(result), "](local.png)")
+	assert.NotContains(t, string(result), "]("+server.URL+")")
+}
+
+func TestEmbedMarkdownImages_URLWithDifferentFormats(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		img := createTestImage(50, 50)
+		w.Header().Set("Content-Type", "image/png")
+		if err := png.Encode(w, img); err != nil {
+			t.Errorf("failed to encode image: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	content := `![png image](` + server.URL + `)`
+	result, err := EmbedMarkdownImages([]byte(content), "", 0, 0)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(result), "data:image/png;base64,")
+	assert.NotContains(t, string(result), "]("+server.URL+")")
+}
+
+func TestFindImageReferences_URLImages(t *testing.T) {
+	content := `![local](./image.png) and ![remote](https://example.com/image.jpg)`
+
+	refs := findImageReferences(content)
+
+	require.Len(t, refs, 2)
+
+	// Check local image
+	assert.Equal(t, "local", refs[0].AltText)
+	assert.Equal(t, "./image.png", refs[0].ImagePath)
+
+	// Check URL image
+	assert.Equal(t, "remote", refs[1].AltText)
+	assert.Equal(t, "https://example.com/image.jpg", refs[1].ImagePath)
+}
+
+func TestFindImageReferences_DataURLSkipped(t *testing.T) {
+	content := `![data](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==) and ![url](https://example.com/image.png)`
+
+	refs := findImageReferences(content)
+
+	// Only URL should be found, data URL should be skipped
+	require.Len(t, refs, 1)
+	assert.Equal(t, "url", refs[0].AltText)
+	assert.Equal(t, "https://example.com/image.png", refs[0].ImagePath)
+}
+
+func createTestImage(width, height int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	return img
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Converting local images and refs to base64 for markdown files