### PR TITLE
fix: wait before opening the browser

### DIFF
--- a/artifactory/utils/weblogin.go
+++ b/artifactory/utils/weblogin.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"bufio"
 	"errors"
+	"io"
+	"os"
 	"time"
 
 	"github.com/google/uuid"
@@ -40,6 +43,7 @@ func DoWebLogin(serverDetails *config.ServerDetails) (token auth.CommonTokenPara
 	log.Info("Please open the following URL in your browser to authenticate:")
 	log.Info(loginUrl)
 
+	waitForEnterBeforeBrowserOpen()
 	// Attempt to open in browser if available
 	if err = browser.OpenURL(loginUrl); err != nil {
 		log.Warn("Failed to automatically open the browser. Please open the URL manually.")
@@ -57,6 +61,22 @@ func DoWebLogin(serverDetails *config.ServerDetails) (token auth.CommonTokenPara
 	}
 	log.Info("You're now logged in!")
 	return
+}
+
+func waitForEnterBeforeBrowserOpen() {
+	stdinStat, err := os.Stdin.Stat()
+	if err != nil {
+		log.Debug("Skipping enter wait before opening browser:", err.Error())
+		return
+	}
+	if (stdinStat.Mode() & os.ModeCharDevice) == 0 {
+		return
+	}
+	log.Info("Press Enter to open the browser.")
+	_, err = bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		log.Warn("Failed to read Enter input. Continuing with login flow.")
+	}
 }
 
 func sendUnauthenticatedPing(serverDetails *config.ServerDetails) error {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
it is a bit annoying that the browser opens immediately after the server selection without giving you time to read the code beforehand. @naveenku-jfrog can you also please take a look here? Our TSM is Douglas Hemsworth. Thanks!