### PR TITLE
RTECO-992 - Added support for uv package manager

### DIFF
--- a/common/project/projectconfig.go
+++ b/common/project/projectconfig.go
@@ -48,6 +48,7 @@ const (
 	Helm
 	Ruby
 	Conan
+	UV
 )
 
 type ConfigType string
@@ -79,6 +80,7 @@ var ProjectTypes = []string{
 	"helm",
 	"ruby",
 	"conan",
+	"uv",
 }
 
 func (projectType ProjectType) String() string {

--- a/common/project/projectconfig.go
+++ b/common/project/projectconfig.go
@@ -48,7 +48,7 @@ const (
 	Helm
 	Ruby
 	Conan
-	UV
+	Uv
 )
 
 type ConfigType string

--- a/common/project/projectconfig.go
+++ b/common/project/projectconfig.go
@@ -48,7 +48,7 @@ const (
 	Helm
 	Ruby
 	Conan
-	Uv
+	UV
 )
 
 type ConfigType string

--- a/common/project/projectconfig.go
+++ b/common/project/projectconfig.go
@@ -48,7 +48,6 @@ const (
 	Helm
 	Ruby
 	Conan
-	UV
 )
 
 type ConfigType string
@@ -80,7 +79,6 @@ var ProjectTypes = []string{
 	"helm",
 	"ruby",
 	"conan",
-	"uv",
 }
 
 func (projectType ProjectType) String() string {

--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,4 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go master
 
-// replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d
-
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.3.3-0.20231223133729-ef57bd08cedc

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gookit/color v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.6.8
-	github.com/jfrog/build-info-go v1.13.1-0.20260106203543-03b99793ca5a
+	github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-client-go v1.55.1-0.20251223101502-1a13a993b0c7
 	github.com/magiconair/properties v1.8.10
@@ -94,6 +94,6 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go master
 
-//replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105064157-73c3f6f22ba2
+// replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.3.3-0.20231223133729-ef57bd08cedc

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gookit/color v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.6.8
-	github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d
+	github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-client-go v1.55.1-0.20251223101502-1a13a993b0c7
 	github.com/magiconair/properties v1.8.10
@@ -93,5 +93,7 @@ require (
 )
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go master
+
+//replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105064157-73c3f6f22ba2
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.3.3-0.20231223133729-ef57bd08cedc

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/jedib0t/go-pretty/v6 v6.6.8 h1:JnnzQeRz2bACBobIaa/r+nqjvws4yEhcmaZ4n1
 github.com/jedib0t/go-pretty/v6 v6.6.8/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
 github.com/jfrog/archiver/v3 v3.6.1 h1:LOxnkw9pOn45DzCbZNFV6K0+6dCsQ0L8mR3ZcujO5eI=
 github.com/jfrog/archiver/v3 v3.6.1/go.mod h1:VgR+3WZS4N+i9FaDwLZbq+jeU4B4zctXL+gL4EMzfLw=
-github.com/jfrog/build-info-go v1.13.1-0.20260106203543-03b99793ca5a h1:vFjLpuSwRCQCPGjGoZcC3zn+cAGYmsuKV4mSXHq94LU=
-github.com/jfrog/build-info-go v1.13.1-0.20260106203543-03b99793ca5a/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
+github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d h1:5bKXhuCQZ5O2xfRKe2lg+T3b7NOIXnLVjA/X1t1Kc3Q=
+github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20251223101502-1a13a993b0c7 h1:5JUiqmBV9ikFOZEH+ZgvJLHshT1aAuw08bfdJOLHbzQ=

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/jedib0t/go-pretty/v6 v6.6.8 h1:JnnzQeRz2bACBobIaa/r+nqjvws4yEhcmaZ4n1
 github.com/jedib0t/go-pretty/v6 v6.6.8/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
 github.com/jfrog/archiver/v3 v3.6.1 h1:LOxnkw9pOn45DzCbZNFV6K0+6dCsQ0L8mR3ZcujO5eI=
 github.com/jfrog/archiver/v3 v3.6.1/go.mod h1:VgR+3WZS4N+i9FaDwLZbq+jeU4B4zctXL+gL4EMzfLw=
-github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d h1:5bKXhuCQZ5O2xfRKe2lg+T3b7NOIXnLVjA/X1t1Kc3Q=
-github.com/jfrog/build-info-go v1.13.1-0.20260415162635-b0c4ad10c59d/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
+github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295 h1:EH0h86KwGvNHWyEBQoHoU9WfMMKy1GJ6jJQNmfy6E0U=
+github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20251223101502-1a13a993b0c7 h1:5JUiqmBV9ikFOZEH+ZgvJLHshT1aAuw08bfdJOLHbzQ=


### PR DESCRIPTION
## Summary

Adds `UV` to the `ProjectType` enum and `"uv"` to `ProjectTypes` to register the UV package manager as a known project type.

> **Note:** `project.UV` is intentionally not added — the native UV implementation routes directly through `NativeUVCommand` and does not use the `pythonCmd` routing path, so the constant is not required.