### PR TITLE
Add UV package manager support

### DIFF
--- a/common/project/projectconfig.go
+++ b/common/project/projectconfig.go
@@ -48,6 +48,7 @@ const (
 	Helm
 	Ruby
 	Conan
+	UV
 )
 
 type ConfigType string
@@ -79,6 +80,7 @@ var ProjectTypes = []string{
 	"helm",
 	"ruby",
 	"conan",
+	"uv",
 }
 
 func (projectType ProjectType) String() string {

--- a/common/project/projectconfig_test.go
+++ b/common/project/projectconfig_test.go
@@ -18,6 +18,7 @@ func TestFromString(t *testing.T) {
 		{"pnpm", Pnpm},
 		{"ruby", Ruby},
 		{"conan", Conan},
+		{"uv", UV},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Summary

Add UV as a recognized `ProjectType` in jfrog-cli-core, enabling downstream repos (`jfrog-cli-artifactory`, `fly-desktop`) to implement UV-specific setup, status, and teardown logic.

## Details

- Added `UV` to the `ProjectType` iota enum (after `Conan`)
- Added `"uv"` to the `ProjectTypes` string slice for string↔enum conversion
- Added test case in `TestFromString` for the new type

UV is a fast, Rust-based Python package manager that uses `uv.toml` for index configuration and `uv auth login` for credential storage. This PR is the foundation — setup and handler logic live in `jfrog-cli-artifactory` and `fly-desktop` respectively.

## Related PRs

- `jfrog-cli-artifactory`: UV setup command (`configureUV`) + TOML manipulation utilities
- `fly-desktop`: UV handler (CheckStatus/Teardown), desktop detection, icon, local E2E test