### PR TITLE
RTECO-1368 - Fix metrics collection for agent detection and interactive context fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ testdata/go/project1/go.sum
 testdata/go/tmp
 tmp
 out
+.gradle
 
 # Vim
 *~

--- a/common/commands/command.go
+++ b/common/commands/command.go
@@ -140,6 +140,9 @@ func reportUsageToVisibilitySystem(commandName string, serverDetails *config.Ser
 			IsCI:           metricsData.IsCI,
 			CISystem:       metricsData.CISystem,
 			IsContainer:    metricsData.IsContainer,
+			IsAgent:        metricsData.IsAgent,
+			Agent:          metricsData.Agent,
+			IsInteractive:  metricsData.IsInteractive,
 			PackageAlias:   metricsData.PackageAlias,
 			PackageManager: metricsData.PackageManager,
 		}

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -55,6 +55,19 @@ var (
 	cachedExecutionContext ExecutionContext
 )
 
+// ResetExecutionContextForTest clears the memoized ExecutionContext so the
+// next DetectExecutionContext call re-evaluates env vars. Exported for tests
+// in downstream modules (e.g. jfrog-cli) that need to assert agent-detection
+// behaviour against in-process command invocations after other tests in the
+// same binary have already triggered memoization.
+//
+// Production code MUST NOT call this. Calling it concurrently with
+// DetectExecutionContext is unsafe.
+func ResetExecutionContextForTest() {
+	executionContextOnce = sync.Once{}
+	cachedExecutionContext = ExecutionContext{}
+}
+
 func computeExecutionContext() ExecutionContext {
 	ec := ExecutionContext{
 		IsInteractive: clientlog.IsStdOutTerminal(),

--- a/common/commands/metrics_collector_test.go
+++ b/common/commands/metrics_collector_test.go
@@ -984,3 +984,58 @@ func TestMetricsIntegrationFlow(t *testing.T) {
 		t.Error("Expected metrics to be cleared after retrieval")
 	}
 }
+
+// TestAgentContextEndToEnd verifies that agent/is_agent/is_interactive
+// signals survive the full chain: env -> ExecutionContext -> CollectMetrics ->
+// GetCollectedMetrics -> visibility.MetricsData -> commandsCountLabels -> wire JSON.
+// This guards against any field being dropped at the boundaries between layers.
+func TestAgentContextEndToEnd(t *testing.T) {
+	ClearAllMetrics()
+	clearAgentEnvVars(t)
+	t.Setenv("CURSOR_AGENT", "1")
+	resetExecutionContextForTest(t)
+
+	commandName := "rt_download"
+	flags := []string{"recursive"}
+
+	CollectMetrics(commandName, flags)
+
+	collected := GetCollectedMetrics(commandName)
+	if collected == nil {
+		t.Fatal("Expected metrics to be collected")
+	}
+	if !collected.IsAgent || collected.Agent != "cursor" {
+		t.Errorf("collected IsAgent/Agent wrong: IsAgent=%v Agent=%q", collected.IsAgent, collected.Agent)
+	}
+
+	visibilityData := &visibility.MetricsData{
+		Flags:          collected.Flags,
+		Platform:       collected.Platform,
+		Architecture:   collected.Architecture,
+		IsCI:           collected.IsCI,
+		CISystem:       collected.CISystem,
+		IsContainer:    collected.IsContainer,
+		IsAgent:        collected.IsAgent,
+		Agent:          collected.Agent,
+		IsInteractive:  collected.IsInteractive,
+		PackageAlias:   collected.PackageAlias,
+		PackageManager: collected.PackageManager,
+	}
+
+	metric := visibility.NewCommandsCountMetricWithEnhancedData(commandName, visibilityData)
+	metricJSON, err := json.Marshal(metric)
+	if err != nil {
+		t.Fatalf("json marshal failed: %v", err)
+	}
+
+	wire := string(metricJSON)
+	if !strings.Contains(wire, `"is_agent":"true"`) {
+		t.Errorf("wire JSON missing is_agent=true: %s", wire)
+	}
+	if !strings.Contains(wire, `"agent":"cursor"`) {
+		t.Errorf("wire JSON missing agent=cursor: %s", wire)
+	}
+	if !strings.Contains(wire, `"is_interactive":`) {
+		t.Errorf("wire JSON missing is_interactive: %s", wire)
+	}
+}

--- a/utils/usage/visibility/commands_count_metric.go
+++ b/utils/usage/visibility/commands_count_metric.go
@@ -28,6 +28,9 @@ type commandsCountLabels struct {
 	IsCI                                 string `json:"is_ci"`
 	CISystem                             string `json:"ci_system,omitempty"`
 	IsContainer                          string `json:"is_container"`
+	IsAgent                              string `json:"is_agent,omitempty"`
+	Agent                                string `json:"agent,omitempty"`
+	IsInteractive                        string `json:"is_interactive,omitempty"`
 	PackageAlias                         string `json:"package_alias,omitempty"`
 	PackageManager                       string `json:"package_manager,omitempty"`
 }
@@ -78,6 +81,17 @@ func NewCommandsCountMetricWithEnhancedData(commandName string, metricsData *Met
 			labels.IsContainer = "true"
 		} else {
 			labels.IsContainer = "false"
+		}
+		if metricsData.IsAgent {
+			labels.IsAgent = "true"
+			labels.Agent = metricsData.Agent
+		} else {
+			labels.IsAgent = "false"
+		}
+		if metricsData.IsInteractive {
+			labels.IsInteractive = "true"
+		} else {
+			labels.IsInteractive = "false"
 		}
 		if metricsData.PackageAlias {
 			labels.PackageAlias = "true"

--- a/utils/usage/visibility/commands_count_metric_test.go
+++ b/utils/usage/visibility/commands_count_metric_test.go
@@ -63,12 +63,15 @@ func TestNewCommandsCountMetricWithEnhancedData(t *testing.T) {
 	commandName := "enhanced-test-command"
 
 	metricsData := &MetricsData{
-		Flags:        []string{"verbose", "recursive", "threads"},
-		Platform:     "linux",
-		Architecture: "amd64",
-		IsCI:         true,
-		CISystem:     "github_actions",
-		IsContainer:  false,
+		Flags:         []string{"verbose", "recursive", "threads"},
+		Platform:      "linux",
+		Architecture:  "amd64",
+		IsCI:          true,
+		CISystem:      "github_actions",
+		IsContainer:   false,
+		IsAgent:       true,
+		Agent:         "cursor",
+		IsInteractive: false,
 	}
 
 	metric := NewCommandsCountMetricWithEnhancedData(commandName, metricsData)
@@ -88,6 +91,9 @@ func TestNewCommandsCountMetricWithEnhancedData(t *testing.T) {
 	assert.Equal(t, "true", labels.IsCI)
 	assert.Equal(t, "github_actions", labels.CISystem)
 	assert.Equal(t, "false", labels.IsContainer)
+	assert.Equal(t, "true", labels.IsAgent)
+	assert.Equal(t, "cursor", labels.Agent)
+	assert.Equal(t, "false", labels.IsInteractive)
 }
 
 func TestNewCommandsCountMetricWithNilEnhancedData(t *testing.T) {
@@ -113,6 +119,58 @@ func TestNewCommandsCountMetricWithNilEnhancedData(t *testing.T) {
 	assert.Empty(t, labels.IsCI)
 	assert.Empty(t, labels.CISystem)
 	assert.Empty(t, labels.IsContainer)
+	assert.Empty(t, labels.IsAgent)
+	assert.Empty(t, labels.Agent)
+	assert.Empty(t, labels.IsInteractive)
+}
+
+func TestNewCommandsCountMetricWithAgentContext(t *testing.T) {
+	commandName := "rt_download"
+
+	metricsData := &MetricsData{
+		IsAgent:       true,
+		Agent:         "cursor",
+		IsInteractive: true,
+	}
+
+	metric := NewCommandsCountMetricWithEnhancedData(commandName, metricsData)
+
+	labels, ok := metric.Labels.(*commandsCountLabels)
+	assert.True(t, ok, "Expected labels to be of type commandsCountLabels")
+
+	assert.Equal(t, "true", labels.IsAgent)
+	assert.Equal(t, "cursor", labels.Agent)
+	assert.Equal(t, "true", labels.IsInteractive)
+
+	metricJSON, err := json.Marshal(metric)
+	assert.NoError(t, err)
+	assert.Contains(t, string(metricJSON), `"is_agent":"true"`)
+	assert.Contains(t, string(metricJSON), `"agent":"cursor"`)
+	assert.Contains(t, string(metricJSON), `"is_interactive":"true"`)
+}
+
+func TestNewCommandsCountMetricWithoutAgentContext(t *testing.T) {
+	commandName := "rt_upload"
+
+	metricsData := &MetricsData{
+		IsAgent:       false,
+		IsInteractive: false,
+	}
+
+	metric := NewCommandsCountMetricWithEnhancedData(commandName, metricsData)
+
+	labels, ok := metric.Labels.(*commandsCountLabels)
+	assert.True(t, ok, "Expected labels to be of type commandsCountLabels")
+
+	assert.Equal(t, "false", labels.IsAgent)
+	assert.Empty(t, labels.Agent)
+	assert.Equal(t, "false", labels.IsInteractive)
+
+	metricJSON, err := json.Marshal(metric)
+	assert.NoError(t, err)
+	assert.Contains(t, string(metricJSON), `"is_agent":"false"`)
+	assert.Contains(t, string(metricJSON), `"is_interactive":"false"`)
+	assert.NotContains(t, string(metricJSON), `"agent":`)
 }
 
 func TestMetricsDataStructure(t *testing.T) {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

## RTECO-1368: Fix dropped agent metric labels (`is_agent`, `agent`, `is_interactive`)
### Problem
PR #1555 (RTECO-1017) added agent/CI context fields to `MetricsData` and
populated them in `metrics_collector.go`, but the labels were silently dropped
on the way to the visibility wire payload. Prod logs (`jfcli_commands_count`)
still don't show `is_agent`, `agent`, or `is_interactive`.
### Root cause
Two broken links in the chain:
1. `commandsCountLabels` struct in `commands_count_metric.go` had no fields
   for the new agent labels, so they could never be serialized.
2. `reportUsageToVisibilitySystem` in `command.go` didn't copy the new
   fields from collected `MetricsData` into `visibility.MetricsData`.
   
   
 Depends on:
 1. cli - https://github.com/jfrog/jfrog-cli/pull/3518