### PR TITLE
JGC-501 - Force non-interactive mode when CLI is invoked by an agent

### DIFF
--- a/common/cliutils/utils.go
+++ b/common/cliutils/utils.go
@@ -187,6 +187,11 @@ func ShouldOfferConfig() (bool, error) {
 	if ci {
 		return false, nil
 	}
+	// Suppress the interactive prompt when invoked by an AI agent.
+	// Agents cannot respond to stdin prompts; hanging is worse than a fast failure.
+	if commands.DetectExecutionContext().IsAgent {
+		return false, nil
+	}
 
 	msg := fmt.Sprintf("To avoid this message in the future, set the %s environment variable to true.\n"+
 		"The CLI commands require the URL and authentication details\n"+

--- a/common/cliutils/utils_test.go
+++ b/common/cliutils/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jfrog/jfrog-cli-core/v2/common/commands"
 	testUtils "github.com/jfrog/jfrog-cli-core/v2/utils/tests"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -74,6 +75,71 @@ func TestReadJFrogApplicationKeyFromConfigOrEnv(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 			// delete temp folder
 			cleanUp()
+		})
+	}
+}
+
+func TestShouldOfferConfig_AgentSkipsPrompt(t *testing.T) {
+	tests := []struct {
+		name        string
+		ciEnv       string
+		agentEnv    string // CLAUDECODE env var to simulate an agent
+		wantOffer   bool
+		wantErr     bool
+	}{
+		{
+			name:      "agent env set — no prompt",
+			agentEnv:  "1",
+			wantOffer: false,
+		},
+		{
+			name:      "CI=true — no prompt",
+			ciEnv:     "true",
+			wantOffer: false,
+		},
+		{
+			name:      "CI=true and agent set — no prompt",
+			ciEnv:     "true",
+			agentEnv:  "1",
+			wantOffer: false,
+		},
+		{
+			name:      "neither CI nor agent — would prompt (AskYesNo returns false on non-TTY)",
+			wantOffer: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Ensure no server config exists for the duration of this subtest.
+			_, cleanUp := testUtils.CreateTestWorkspace(t, t.TempDir())
+			defer cleanUp()
+
+			// Reset the memoized execution context so our env var changes take effect.
+			commands.ResetExecutionContextForTest()
+			defer commands.ResetExecutionContextForTest()
+
+			if tt.ciEnv != "" {
+				assert.NoError(t, os.Setenv(coreutils.CI, tt.ciEnv))
+				defer func() { _ = os.Unsetenv(coreutils.CI) }()
+			} else {
+				_ = os.Unsetenv(coreutils.CI)
+			}
+
+			if tt.agentEnv != "" {
+				assert.NoError(t, os.Setenv("CLAUDECODE", tt.agentEnv))
+				defer func() { _ = os.Unsetenv("CLAUDECODE") }()
+			} else {
+				_ = os.Unsetenv("CLAUDECODE")
+			}
+
+			offer, err := ShouldOfferConfig()
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantOffer, offer)
 		})
 	}
 }


### PR DESCRIPTION
## Problem

Since v2.107.0, `jf api` (and any other command) prompts for interactive configuration when no server profile exists and `$CI` is not set. This causes automation scripts driven by AI agents (Claude Code, Cursor, Gemini, etc.) to hang waiting for a yes/no answer — even when `--url` and auth flags are supplied on the command line.

Root cause: `ShouldOfferConfig()` suppresses the prompt only for `$CI=true`. The existing `DetectExecutionContext().IsAgent` infrastructure — already used for AI-help rendering — was not consulted here.

## Fix

Add a second early-return guard in `ShouldOfferConfig()` (`common/cliutils/utils.go`) that mirrors the CI check:

```
server config exists?            → no offer (unchanged)
CI=true?                         → no offer (unchanged)
DetectExecutionContext().IsAgent? → no offer  ← new
AskYesNo(…)                      → interactive prompt (unchanged for human TTY)
```

When the guard fires, the CLI skips the offer and proceeds. If no URL is known (not configured, not passed via `--url`), the existing fast-fail error fires normally — the script gets a non-zero exit code instead of hanging.

-----
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.