### PR TITLE
Add build-gate orchestrator and convert workflows to reusable

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -5,8 +5,8 @@ on:
       - "master"
     tags-ignore:
       - "**"
-  pull_request_target:
-    types: [labeled]
+  pull_request:
+    types: [opened, synchronize, reopened]
     branches:
       - "master"
 permissions:

--- a/.github/workflows/build-gate.yml
+++ b/.github/workflows/build-gate.yml
@@ -25,3 +25,22 @@ jobs:
     needs: gate
     uses: ./.github/workflows/test.yml
     secrets: inherit
+
+  # Single, stable required status check. Point branch protection at
+  # "Build Gate / build-gate-success" instead of the matrix-expanded suite checks.
+  build-gate-success:
+    name: build-gate-success
+    if: always()
+    needs:
+      - gate
+      - frogbot
+      - tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no suite failed or was cancelled
+        run: |
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::One or more suites failed or were cancelled."
+            exit 1
+          fi
+          echo "All suites succeeded (skipped suites are allowed)."

--- a/.github/workflows/build-gate.yml
+++ b/.github/workflows/build-gate.yml
@@ -1,0 +1,27 @@
+name: Build Gate
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'pull_request_target' && 'build-gate' || '' }}
+    steps:
+      - run: echo "Approved — releasing frogbot and test suite."
+
+  frogbot:
+    needs: gate
+    uses: ./.github/workflows/frogbot-scan-pull-request.yml
+    secrets: inherit
+
+  tests:
+    needs: gate
+    uses: ./.github/workflows/test.yml
+    secrets: inherit

--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -1,9 +1,6 @@
 name: "Frogbot Scan Pull Request"
 on:
-  pull_request_target:
-    types: [opened, synchronize]
-    branches:
-      - master
+  workflow_call:
 permissions:
   pull-requests: write
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,7 @@
 name: JFrog CLI Core Tests
 on:
+  workflow_call:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-    tags-ignore:
-      - "**"
-  pull_request_target:
-    branches:
-      - master
-    types: [labeled]
 jobs:
   test:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
Replaces the \`safe to test\` label gate with a single GitHub Environment deployment
approval (\`build-gate\`). One maintainer approval per PR now releases both frogbot
and the test suite in a single run.

### Changes
- **\`build-gate.yml\`** (new) — orchestrator with a \`gate\` job that requires the
  \`build-gate\` environment approval on \`pull_request_target\` runs (push and
  \`workflow_dispatch\` skip the gate). Frogbot and the test suite fan out behind
  \`needs: gate\`. A \`build-gate-success\` aggregator job provides a single stable
  required status check for branch protection.
- **\`test.yml\`** — converted to \`workflow_call\` + \`workflow_dispatch\`; removed
  \`push\` and \`pull_request_target: [labeled]\` triggers.
- **\`frogbot-scan-pull-request.yml\`** — converted to \`workflow_call\`; removed
  standalone \`environment: frogbot\` (gate job now holds the approval).
- **\`analysis.yml\`** — changed trigger from \`pull_request_target: [labeled]\` to
  \`pull_request: [opened, synchronize, reopened]\`. This workflow uses no platform
  secrets so \`pull_request\` is correct and safe for forks.

### Required follow-up (repo settings)
- Create the \`build-gate\` GitHub Environment with Required reviewers.
- Repoint required status checks in branch protection to \`Build Gate / build-gate-success\`.

---

- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.