### PR TITLE
Fix missing permissions block in build-gate orchestrator

### DIFF
--- a/.github/workflows/build-gate.yml
+++ b/.github/workflows/build-gate.yml
@@ -9,6 +9,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
+permissions:
+  pull-requests: write
+  contents: read
 jobs:
   gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -7,7 +7,6 @@ permissions:
 jobs:
   scan-pull-request:
     runs-on: ubuntu-latest
-    environment: frogbot
     steps:
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main


### PR DESCRIPTION
Follow-up to #1578. The `build-gate.yml` orchestrator was missing a top-level
`permissions` block, causing the workflow to fail with:

> Error calling workflow `frogbot-scan-pull-request.yml`. The workflow is requesting
> `pull-requests: write`, but is only allowed `pull-requests: none`.

### Fix
Added `permissions: pull-requests: write / contents: read` at the workflow level so
the frogbot reusable workflow can write PR comments.

### Required follow-up (repo settings)
- Create the `build-gate` GitHub Environment with Required reviewers.
- Repoint required status checks in branch protection to `Build Gate / build-gate-success`.