### PR TITLE
Fix frogbot workflow missing checkout before install-go-with-cache

### DIFF
--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -8,6 +8,11 @@ jobs:
   scan-pull-request:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main
 

--- a/artifactory/utils/commandsummary/buildinfosummary_test.go
+++ b/artifactory/utils/commandsummary/buildinfosummary_test.go
@@ -40,14 +40,11 @@ func (m *MockScanResult) GetVulnerabilities() string {
 func prepareBuildInfoTest(t *testing.T) (*BuildInfoSummary, func()) {
 	// Set up test environment
 	originalWorkflow := os.Getenv(workflowEnvKey)
-	if originalWorkflow == "" {
-		// this make the test pass locally
-		err := os.Setenv(workflowEnvKey, "JFrog CLI Core Tests")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			_ = os.Setenv(workflowEnvKey, originalWorkflow)
-		})
-	}
+	err := os.Setenv(workflowEnvKey, "JFrog CLI Core Tests")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Setenv(workflowEnvKey, originalWorkflow)
+	})
 	// Mock the scan results defaults
 	StaticMarkdownConfig.scanResultsMapping = make(map[string]ScanResult)
 	StaticMarkdownConfig.scanResultsMapping[NonScannedResult] = &MockScanResult{

--- a/artifactory/utils/commandsummary/utils_test.go
+++ b/artifactory/utils/commandsummary/utils_test.go
@@ -16,16 +16,13 @@ const (
 
 func TestGenerateArtifactUrl(t *testing.T) {
 	// Set up test environment
-	originalWorklfow, exists := os.LookupEnv(workflowEnvKey)
-	if !exists {
-		// this make the test pass locally
-		err := os.Setenv(workflowEnvKey, "JFrog CLI Core Tests")
+	originalWorklfow := os.Getenv(workflowEnvKey)
+	err := os.Setenv(workflowEnvKey, "JFrog CLI Core Tests")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err = os.Setenv(workflowEnvKey, originalWorklfow)
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			err = os.Setenv(workflowEnvKey, originalWorklfow)
-			require.NoError(t, err)
-		})
-	}
+	})
 
 	cases := []struct {
 		testName     string


### PR DESCRIPTION
Follow-up to #1579. The `frogbot-scan-pull-request.yml` workflow was missing a
checkout step before `install-go-with-cache`, causing it to fail with:

> Error: The specified go version file at: go.mod does not exist

The action defaults `go-version-file` to `go.mod` and needs the repo checked out
to read it. Added `actions/checkout` before the Go setup step, matching the pattern
used in the test workflows.