### PR TITLE
RTECO-1564 - Add Apt to ProjectTypes and ProjectType constants

### DIFF
--- a/common/project/projectconfig.go
+++ b/common/project/projectconfig.go
@@ -49,6 +49,7 @@ const (
 	Ruby
 	Conan
 	UV
+	Apt
 )
 
 type ConfigType string
@@ -81,6 +82,7 @@ var ProjectTypes = []string{
 	"ruby",
 	"conan",
 	"uv",
+	"apt",
 }
 
 func (projectType ProjectType) String() string {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

## Summary
- Add `Apt ProjectType` constant to the `ProjectType` iota in `common/project/projectconfig.go`
- Add `"apt"` string to `ProjectTypes` slice at the matching index

## Why
`jf setup` and `jf setup apt` need to route the apt package manager through the
same `SetupCommand` framework used by npm, go, pip, etc. — for interactive repo
selection (`promptUserToSelectRepository`) and for listing apt in
`GetSupportedPackageManagersList()`. Both rely on a `ProjectType` value existing
for apt.

Without this change the string `"apt"` has no enum counterpart, so the setup
framework cannot filter debian repositories or dispatch to `configureApt()`.