### PR TITLE
RTECO-945: Add Apk to ProjectType enum for jf setup apk support

### DIFF
--- a/common/project/projectconfig.go
+++ b/common/project/projectconfig.go
@@ -50,6 +50,7 @@ const (
 	Conan
 	UV
 	Apt
+	Apk
 )
 
 type ConfigType string
@@ -83,6 +84,7 @@ var ProjectTypes = []string{
 	"conan",
 	"uv",
 	"apt",
+	"apk",
 }
 
 func (projectType ProjectType) String() string {


### PR DESCRIPTION
Add Apk ProjectType and "apk" string to ProjectTypes slice so that the unified jf setup command can route to Alpine APK configuration.

- [ ] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the master branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
**RTECO-945: Add apk as a supported project type**
Summary
This PR adds apk (Alpine Package Manager) to the ProjectType enum in jfrog-cli-core, enabling the unified jf setup command to recognize and route Alpine APK configuration.

Change: common/project/projectconfig.go

Added Apk to the ProjectType enum
Added "apk" to the ProjectTypes string slice
Why
The jf setup command uses ProjectType to determine which package manager setup flow to invoke. Without this entry, jf setup apk cannot be dispatched to the Alpine configuration handler in jfrog-cli-artifactory.

This is a prerequisite for:

[jfrog-cli-artifactory#496](https://github.com/jfrog/jfrog-cli-artifactory/pull/496) — Alpine APK command support (jf apk add, jf apk upload, jf setup apk)
[jfrog-cli#3561](https://github.com/jfrog/jfrog-cli/pull/3561) — CLI wiring for jf apk commands
Testing
No standalone tests needed — this is a data-only enum extension. Integration is covered by the Alpine e2e tests in jfrog-cli.