### PR TITLE
JFMIG-46 - Migration-transfer-file-timestamp-support

### DIFF
--- a/artifactory/commands/transferfiles/filediff_test.go
+++ b/artifactory/commands/transferfiles/filediff_test.go
@@ -52,10 +52,31 @@ var generateDiffAqlQueryTestCases = []struct {
 func TestGenerateDiffAqlQuery(t *testing.T) {
 	for _, testCase := range generateDiffAqlQueryTestCases {
 		t.Run("", func(*testing.T) {
-			results := generateDiffAqlQuery(repo1Key, "1", "2", testCase.paginationOffset, testCase.disabledDistinctiveAql)
+			results := generateDiffAqlQuery(repo1Key, "1", "2", testCase.paginationOffset, testCase.disabledDistinctiveAql, nil)
 			assert.Equal(t, testCase.expectedAql, results)
 		})
 	}
+}
+
+func TestGenerateDiffAqlQueryWithTimestampFilter(t *testing.T) {
+	createdFilter := &timestampFilter{field: createdFilterField, timestamp: "2025-01-01T00:00:00.000Z"}
+	downloadedFilter := &timestampFilter{field: downloadedFilterField, timestamp: "2025-01-01T00:00:00.000Z"}
+
+	t.Run("created after filters files keeps folders", func(t *testing.T) {
+		query := generateDiffAqlQuery(repo1Key, "1", "2", 0, false, createdFilter)
+		assert.Contains(t, query, `"modified":{"$gte":"1"}`)
+		assert.Contains(t, query, `"modified":{"$lt":"2"}`)
+		assert.Contains(t, query, `"repo":"repo1"`)
+		assert.NotContains(t, query, `"type":"any"`)
+		assert.Equal(t,
+			`items.find({"$and":[{"modified":{"$gte":"1"}},{"modified":{"$lt":"2"}},{"repo":"repo1"},{"$or":[{"type":"folder"},{"$and":[{"type":"file"},{"created":{"$gte":"2025-01-01T00:00:00.000Z"}}]}]}]}).include("repo","path","name","type","modified","size").sort({"$asc":["name","path"]}).offset(0).limit(10000)`,
+			query)
+	})
+
+	t.Run("downloaded after uses stat.downloaded", func(t *testing.T) {
+		query := generateDiffAqlQuery(repo1Key, "1", "2", 0, false, downloadedFilter)
+		assert.Contains(t, query, `,{"$or":[{"type":"folder"},{"$and":[{"type":"file"},{"stat.downloaded":{"$gte":"2025-01-01T00:00:00.000Z"}}]}]}`)
+	})
 }
 
 var generateDockerManifestAqlQueryTestCases = []struct {
@@ -72,10 +93,26 @@ var generateDockerManifestAqlQueryTestCases = []struct {
 func TestGenerateDockerManifestAqlQuery(t *testing.T) {
 	for _, testCase := range generateDockerManifestAqlQueryTestCases {
 		t.Run("", func(*testing.T) {
-			results := generateDockerManifestAqlQuery(repo1Key, "1", "2", testCase.paginationOffset, testCase.disabledDistinctiveAql)
+			results := generateDockerManifestAqlQuery(repo1Key, "1", "2", testCase.paginationOffset, testCase.disabledDistinctiveAql, nil)
 			assert.Equal(t, testCase.expectedAql, results)
 		})
 	}
+}
+
+func TestGenerateDockerManifestAqlQueryWithTimestampFilter(t *testing.T) {
+	filter := &timestampFilter{field: createdFilterField, timestamp: "2025-01-01T00:00:00.000Z"}
+	query := generateDockerManifestAqlQuery(repo1Key, "1", "2", 0, false, filter)
+	assert.Contains(t, query, `"name":"manifest.json"`)
+	assert.Contains(t, query, `"created":{"$gte":"2025-01-01T00:00:00.000Z"}`)
+	assert.Contains(t, query, `"modified":{"$gte":"1"}`)
+}
+
+func TestGenerateGetDirContentAqlQueryUnfiltered(t *testing.T) {
+	query := generateGetDirContentAqlQuery(repo1Key, []string{"library/nginx/1.0"})
+	assert.NotContains(t, query, `"$gte"`)
+	assert.NotContains(t, query, "stat.downloaded")
+	assert.NotContains(t, query, `"created":{`)
+	assert.Contains(t, query, `"path":{"$match":"library/nginx/1.0"}`)
 }
 
 // TestGetNonDockerTimeFrameFilesDiffWithPatterns tests that getNonDockerTimeFrameFilesDiff uses pattern filtering when patterns are set

--- a/artifactory/commands/transferfiles/filesdiff.go
+++ b/artifactory/commands/transferfiles/filesdiff.go
@@ -218,10 +218,10 @@ func (f *filesDiffPhase) getNonDockerTimeFrameFilesDiff(fromTimestamp, toTimesta
 	var query string
 	if len(f.includeFilesPatterns) > 0 {
 		// Use AQL with pattern filtering
-		query = generateDiffAqlQueryWithPatterns(f.repoKey, fromTimestamp, toTimestamp, f.includeFilesPatterns, paginationOffset, f.disabledDistinctiveAql)
+		query = generateDiffAqlQueryWithPatterns(f.repoKey, fromTimestamp, toTimestamp, f.includeFilesPatterns, paginationOffset, f.disabledDistinctiveAql, f.timestampFilter)
 	} else {
 		// Use default query without pattern filtering
-		query = generateDiffAqlQuery(f.repoKey, fromTimestamp, toTimestamp, paginationOffset, f.disabledDistinctiveAql)
+		query = generateDiffAqlQuery(f.repoKey, fromTimestamp, toTimestamp, paginationOffset, f.disabledDistinctiveAql, f.timestampFilter)
 	}
 	return runAql(f.context, f.srcRtDetails, query)
 }
@@ -235,9 +235,9 @@ func (f *filesDiffPhase) getDockerTimeFrameFilesDiff(fromTimestamp, toTimestamp 
 	// Get all newly created or modified manifest files ("manifest.json" and "list.manifest.json" files)
 	var query string
 	if len(f.includeFilesPatterns) > 0 {
-		query = generateDockerManifestAqlQueryWithPatterns(f.repoKey, fromTimestamp, toTimestamp, f.includeFilesPatterns, paginationOffset, f.disabledDistinctiveAql)
+		query = generateDockerManifestAqlQueryWithPatterns(f.repoKey, fromTimestamp, toTimestamp, f.includeFilesPatterns, paginationOffset, f.disabledDistinctiveAql, f.timestampFilter)
 	} else {
-		query = generateDockerManifestAqlQuery(f.repoKey, fromTimestamp, toTimestamp, paginationOffset, f.disabledDistinctiveAql)
+		query = generateDockerManifestAqlQuery(f.repoKey, fromTimestamp, toTimestamp, paginationOffset, f.disabledDistinctiveAql, f.timestampFilter)
 	}
 	manifestFilesResult, err := runAql(f.context, f.srcRtDetails, query)
 	if err != nil {
@@ -275,8 +275,14 @@ func (f *filesDiffPhase) getDockerTimeFrameFilesDiff(fromTimestamp, toTimestamp 
 	return
 }
 
-func generateDiffAqlQuery(repoKey, fromTimestamp, toTimestamp string, paginationOffset int, disabledDistinctiveAql bool) string {
-	query := fmt.Sprintf(`items.find({"$and":[{"modified":{"$gte":"%s"}},{"modified":{"$lt":"%s"}},{"repo":"%s","type":"any"}]})`, fromTimestamp, toTimestamp, repoKey)
+func generateDiffAqlQuery(repoKey, fromTimestamp, toTimestamp string, paginationOffset int, disabledDistinctiveAql bool, filter *timestampFilter) string {
+	repoClause := fmt.Sprintf(`{"repo":"%s","type":"any"}`, repoKey)
+	timestampClause := ""
+	if filter != nil {
+		repoClause = fmt.Sprintf(`{"repo":"%s"}`, repoKey)
+		timestampClause = aqlMixedContentTimestampAndCondition(filter)
+	}
+	query := fmt.Sprintf(`items.find({"$and":[{"modified":{"$gte":"%s"}},{"modified":{"$lt":"%s"}},%s%s]})`, fromTimestamp, toTimestamp, repoClause, timestampClause)
 	query += `.include("repo","path","name","type","modified","size")`
 	return query + generateAqlSortingPart(paginationOffset, disabledDistinctiveAql)
 }
@@ -296,9 +302,10 @@ func generateGetDirContentAqlQuery(repoKey string, paths []string) string {
 }
 
 // This function generates an AQL that searches for all files named "manifest.json" and "list.manifest.json" in a specific repository.
-func generateDockerManifestAqlQuery(repoKey, fromTimestamp, toTimestamp string, paginationOffset int, disabledDistinctiveAql bool) string {
+func generateDockerManifestAqlQuery(repoKey, fromTimestamp, toTimestamp string, paginationOffset int, disabledDistinctiveAql bool, filter *timestampFilter) string {
+	timestampClause := aqlInclusiveTimestampAndCondition(filter)
 	query := `items.find({"$and":`
-	query += fmt.Sprintf(`[{"repo":"%s"},{"modified":{"$gte":"%s"}},{"modified":{"$lt":"%s"}},{"$or":[{"name":"manifest.json"},{"name":"list.manifest.json"}]}`, repoKey, fromTimestamp, toTimestamp)
+	query += fmt.Sprintf(`[{"repo":"%s"},{"modified":{"$gte":"%s"}},{"modified":{"$lt":"%s"}},{"$or":[{"name":"manifest.json"},{"name":"list.manifest.json"}]}%s`, repoKey, fromTimestamp, toTimestamp, timestampClause)
 	query += `]}).include("repo","path","name","type","modified")`
 	return query + generateAqlSortingPart(paginationOffset, disabledDistinctiveAql)
 }

--- a/artifactory/commands/transferfiles/fulltransfer.go
+++ b/artifactory/commands/transferfiles/fulltransfer.go
@@ -3,6 +3,7 @@ package transferfiles
 import (
 	"fmt"
 	"path"
+	"sync"
 	"time"
 
 	"github.com/jfrog/gofrog/safeconvert"
@@ -23,7 +24,8 @@ import (
 // New folders found are handled as a separate task, and files are uploaded in chunks and polled on for status.
 type fullTransferPhase struct {
 	phaseBase
-	transferManager *transferManager
+	transferManager              *transferManager
+	completedFolderFilterWarning sync.Once
 }
 
 func (m *fullTransferPhase) initProgressBar() error {
@@ -191,7 +193,7 @@ func (m *fullTransferPhase) runWithAqlPatternFiltering() error {
 
 // getPatternMatchingFiles fetches files from source Artifactory using AQL with pattern filtering.
 func (m *fullTransferPhase) getPatternMatchingFiles(paginationOffset int) (result []servicesUtils.ResultItem, lastPage bool, err error) {
-	query := generatePatternBasedAqlQuery(m.repoKey, m.includeFilesPatterns, paginationOffset, m.disabledDistinctiveAql)
+	query := generatePatternBasedAqlQuery(m.repoKey, m.includeFilesPatterns, paginationOffset, m.disabledDistinctiveAql, m.timestampFilter)
 	aqlResults, err := runAql(m.context, m.srcRtDetails, query)
 	if err != nil {
 		return []servicesUtils.ResultItem{}, false, err
@@ -364,7 +366,7 @@ func getFolderRelativePath(folderName, relativeLocation string) string {
 }
 
 func (m *fullTransferPhase) getDirectoryContentAql(relativePath string, paginationOffset int) (result []servicesUtils.ResultItem, lastPage bool, err error) {
-	query := generateFolderContentAqlQuery(m.repoKey, relativePath, paginationOffset, m.disabledDistinctiveAql)
+	query := generateFolderContentAqlQuery(m.repoKey, relativePath, paginationOffset, m.disabledDistinctiveAql, m.timestampFilter)
 	aqlResults, err := runAql(m.context, m.srcRtDetails, query)
 	if err != nil {
 		return []servicesUtils.ResultItem{}, false, err
@@ -375,8 +377,15 @@ func (m *fullTransferPhase) getDirectoryContentAql(relativePath string, paginati
 	return
 }
 
-func generateFolderContentAqlQuery(repoKey, relativePath string, paginationOffset int, disabledDistinctiveAql bool) string {
-	query := fmt.Sprintf(`items.find({"type":"any","$or":[{"$and":[{"repo":"%s","path":{"$match":"%s"},"name":{"$match":"*"}}]}]})`, repoKey, relativePath)
+func generateFolderContentAqlQuery(repoKey, relativePath string, paginationOffset int, disabledDistinctiveAql bool, filter *timestampFilter) string {
+	var query string
+	if filter == nil {
+		query = fmt.Sprintf(`items.find({"type":"any","$or":[{"$and":[{"repo":"%s","path":{"$match":"%s"},"name":{"$match":"*"}}]}]})`, repoKey, relativePath)
+	} else {
+		// Keep folders unfiltered so old parents do not hide newer files; require files to match the timestamp.
+		query = fmt.Sprintf(`items.find({"$and":[{"repo":"%s","path":{"$match":"%s"},"name":{"$match":"*"}},{"$or":[{"type":"folder"},{"$and":[{"type":"file"},%s]}]}]})`,
+			repoKey, relativePath, aqlInclusiveTimestampCondition(filter))
+	}
 	query += `.include("repo","path","name","type","size")`
 	query += fmt.Sprintf(`.sort({"$asc":["name"]}).offset(%d).limit(%d)`, paginationOffset*AqlPaginationLimit, AqlPaginationLimit)
 	query += appendDistinctIfNeeded(disabledDistinctiveAql)
@@ -404,6 +413,7 @@ func (m *fullTransferPhase) getAndHandleDirectoryNode(relativePath string) (node
 		return
 	}
 	if completed {
+		m.maybeWarnCompletedFolderSkippedWithFilter()
 		log.Debug("Skipping completed folder:", path.Join(m.repoKey, relativePath))
 		return
 	}
@@ -411,4 +421,16 @@ func (m *fullTransferPhase) getAndHandleDirectoryNode(relativePath string) (node
 	// Remove all files names because we will begin exploring from the beginning.
 	err = node.RestartExploring()
 	return
+}
+
+// maybeWarnCompletedFolderSkippedWithFilter emits one informational warning when a timestamp filter is
+// active and Phase 1 skips folders already marked completed by a previous run.
+func (m *fullTransferPhase) maybeWarnCompletedFolderSkippedWithFilter() {
+	if m.timestampFilter == nil {
+		return
+	}
+	m.completedFolderFilterWarning.Do(func() {
+		log.Warn("A timestamp filter is active, but some folders were already marked completed by a previous transfer. " +
+			"Those folders will not be re-scanned under the current filter. Use --ignore-state for a full re-scan.")
+	})
 }

--- a/artifactory/commands/transferfiles/fulltransfer_test.go
+++ b/artifactory/commands/transferfiles/fulltransfer_test.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/transferfiles/state"
 	commonTests "github.com/jfrog/jfrog-cli-core/v2/common/tests"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
 	servicesUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -186,4 +190,40 @@ func TestRunWithAqlPatternFilteringPagination(t *testing.T) {
 
 	// Verify both pages were fetched
 	assert.Equal(t, 2, aqlCallCount, "AQL should be called twice for two pages")
+}
+
+func TestMaybeWarnCompletedFolderSkippedWithFilter(t *testing.T) {
+	t.Run("no warning without filter", func(t *testing.T) {
+		buffer, stderrBuffer, previousLog := tests.RedirectLogOutputToBuffer()
+		defer log.SetLogger(previousLog)
+
+		phase := &fullTransferPhase{}
+		phase.maybeWarnCompletedFolderSkippedWithFilter()
+		phase.maybeWarnCompletedFolderSkippedWithFilter()
+		assert.NotContains(t, buffer.String()+stderrBuffer.String(), "--ignore-state")
+	})
+
+	t.Run("warns once when filter active", func(t *testing.T) {
+		buffer, stderrBuffer, previousLog := tests.RedirectLogOutputToBuffer()
+		defer log.SetLogger(previousLog)
+
+		phase := &fullTransferPhase{
+			phaseBase: phaseBase{
+				timestampFilter: &timestampFilter{field: createdFilterField, timestamp: "2025-01-01T00:00:00.000Z"},
+			},
+		}
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				phase.maybeWarnCompletedFolderSkippedWithFilter()
+			}()
+		}
+		wg.Wait()
+
+		output := buffer.String() + stderrBuffer.String()
+		assert.Contains(t, output, "--ignore-state")
+		assert.Equal(t, 1, strings.Count(output, "--ignore-state"))
+	})
 }

--- a/artifactory/commands/transferfiles/phase.go
+++ b/artifactory/commands/transferfiles/phase.go
@@ -40,6 +40,7 @@ type transferPhase interface {
 	setStopSignal(stopSignal chan os.Signal)
 	setMinCheckSumDeploySize(minCheckSumDeploySize int64)
 	setIncludeFilesPatterns(includeFilesPatterns []string)
+	setTimestampFilter(filter *timestampFilter)
 	StopGracefully()
 }
 
@@ -63,6 +64,7 @@ type phaseBase struct {
 	locallyGeneratedFilter    *locallyGeneratedFilter
 	stopSignal                chan os.Signal
 	includeFilesPatterns      []string
+	timestampFilter           *timestampFilter
 	// Optimization in Artifactory version 7.37 and above enables the exclusion of setting DISTINCT in SQL queries
 	disabledDistinctiveAql bool
 	minCheckSumDeploySize  int64
@@ -161,6 +163,10 @@ func (pb *phaseBase) setStopSignal(stopSignal chan os.Signal) {
 
 func (pb *phaseBase) setIncludeFilesPatterns(includeFilesPatterns []string) {
 	pb.includeFilesPatterns = includeFilesPatterns
+}
+
+func (pb *phaseBase) setTimestampFilter(filter *timestampFilter) {
+	pb.timestampFilter = filter
 }
 
 func createTransferPhase(i int) transferPhase {

--- a/artifactory/commands/transferfiles/transfer.go
+++ b/artifactory/commands/transferfiles/transfer.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/jfrog/gofrog/safeconvert"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
@@ -38,7 +39,22 @@ const (
 	retriesWaitMilliSecs         = 5000
 	dataTransferPluginMinVersion = "1.7.0"
 	disableDistinctAqlMinVersion = "7.37"
+	// Exact UTC-millisecond timestamp expected by --created-after / --downloaded-after.
+	timestampFilterLayout = "2006-01-02T15:04:05.000Z"
 )
+
+type timestampFilterField string
+
+const (
+	createdFilterField    timestampFilterField = "created"
+	downloadedFilterField timestampFilterField = "stat.downloaded"
+)
+
+// timestampFilter is the resolved AQL timestamp criterion for the current invocation.
+type timestampFilter struct {
+	field     timestampFilterField
+	timestamp string
+}
 
 type TransferFilesCommand struct {
 	context                   context.Context
@@ -52,6 +68,9 @@ type TransferFilesCommand struct {
 	includeReposPatterns      []string
 	excludeReposPatterns      []string
 	includeFilesPatterns      []string
+	createdAfter              string
+	downloadedAfter           string
+	timestampFilter           *timestampFilter
 	ignoreState               bool
 	proxyKey                  string
 	status                    bool
@@ -100,8 +119,39 @@ func (tdc *TransferFilesCommand) SetIncludeFilesPatterns(includeFilesPatterns []
 	tdc.includeFilesPatterns = includeFilesPatterns
 }
 
+func (tdc *TransferFilesCommand) SetCreatedAfter(createdAfter string) {
+	tdc.createdAfter = createdAfter
+}
+
+func (tdc *TransferFilesCommand) SetDownloadedAfter(downloadedAfter string) {
+	tdc.downloadedAfter = downloadedAfter
+}
+
 func (tdc *TransferFilesCommand) SetIgnoreState(ignoreState bool) {
 	tdc.ignoreState = ignoreState
+}
+
+// resolveTimestampFilter validates the raw timestamp options and returns the effective filter.
+// When both options are set, --created-after takes precedence and --downloaded-after is ignored with a warning.
+func (tdc *TransferFilesCommand) resolveTimestampFilter() (*timestampFilter, error) {
+	if tdc.createdAfter == "" && tdc.downloadedAfter == "" {
+		return nil, nil
+	}
+	if tdc.createdAfter != "" {
+		if tdc.downloadedAfter != "" {
+			log.Warn("Both --created-after and --downloaded-after were provided; using --created-after and ignoring --downloaded-after")
+		}
+		return parseTimestampFilter(createdFilterField, tdc.createdAfter)
+	}
+	return parseTimestampFilter(downloadedFilterField, tdc.downloadedAfter)
+}
+
+func parseTimestampFilter(field timestampFilterField, value string) (*timestampFilter, error) {
+	parsed, err := time.Parse(timestampFilterLayout, value)
+	if err != nil || parsed.Format(timestampFilterLayout) != value {
+		return nil, errorutils.CheckErrorf("invalid timestamp %q: expected format YYYY-MM-DDTHH:mm:ss.sssZ", value)
+	}
+	return &timestampFilter{field: field, timestamp: value}, nil
 }
 
 func (tdc *TransferFilesCommand) SetProxyKey(proxyKey string) {
@@ -161,6 +211,9 @@ func (tdc *TransferFilesCommand) Run() (err error) {
 	}
 	if tdc.stop {
 		return tdc.signalStop()
+	}
+	if tdc.timestampFilter, err = tdc.resolveTimestampFilter(); err != nil {
+		return err
 	}
 	if err = tdc.stateManager.TryLockTransferStateManager(); err != nil {
 		return err
@@ -628,6 +681,7 @@ func (tdc *TransferFilesCommand) initNewPhase(newPhase transferPhase, srcUpServi
 	newPhase.setStopSignal(tdc.stopSignal)
 	newPhase.setMinCheckSumDeploySize(minChecksumDeploySize)
 	newPhase.setIncludeFilesPatterns(tdc.includeFilesPatterns)
+	newPhase.setTimestampFilter(tdc.timestampFilter)
 }
 
 // Get all local and build-info repositories of the input server

--- a/artifactory/commands/transferfiles/transfer_test.go
+++ b/artifactory/commands/transferfiles/transfer_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
 	artifactoryUtils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleStopInitAndClose(t *testing.T) {
@@ -479,4 +481,122 @@ func TestCreateErrorsSummaryFile(t *testing.T) {
 	expectedFileErrors := new([]api.FileUploadStatusResponse)
 	assert.NoError(t, gocsv.UnmarshalFile(expectedFile, expectedFileErrors))
 	assert.ElementsMatch(t, *expectedFileErrors, *actualFileErrors)
+}
+
+func TestResolveTimestampFilter(t *testing.T) {
+	const validTs = "2025-01-01T00:00:00.000Z"
+
+	cases := []struct {
+		name            string
+		createdAfter    string
+		downloadedAfter string
+		wantField       timestampFilterField
+		wantTimestamp   string
+		wantNil         bool
+		wantErrContains string
+		wantWarn        bool
+	}{
+		{
+			name:    "no filter",
+			wantNil: true,
+		},
+		{
+			name:          "created after only",
+			createdAfter:  validTs,
+			wantField:     createdFilterField,
+			wantTimestamp: validTs,
+		},
+		{
+			name:            "downloaded after only",
+			downloadedAfter: validTs,
+			wantField:       downloadedFilterField,
+			wantTimestamp:   validTs,
+		},
+		{
+			name:            "created takes precedence when both set",
+			createdAfter:    validTs,
+			downloadedAfter: "2024-06-01T12:30:45.123Z",
+			wantField:       createdFilterField,
+			wantTimestamp:   validTs,
+			wantWarn:        true,
+		},
+		{
+			name:            "rejects date only",
+			createdAfter:    "2025-01-01",
+			wantErrContains: "YYYY-MM-DDTHH:mm:ss.sssZ",
+		},
+		{
+			name:            "rejects missing milliseconds",
+			createdAfter:    "2025-01-01T00:00:00Z",
+			wantErrContains: "YYYY-MM-DDTHH:mm:ss.sssZ",
+		},
+		{
+			name:            "rejects timezone offset",
+			createdAfter:    "2025-01-01T00:00:00.000+00:00",
+			wantErrContains: "YYYY-MM-DDTHH:mm:ss.sssZ",
+		},
+		{
+			name:            "rejects invalid date",
+			createdAfter:    "2025-13-01T00:00:00.000Z",
+			wantErrContains: "YYYY-MM-DDTHH:mm:ss.sssZ",
+		},
+		{
+			name:            "rejects trailing data",
+			createdAfter:    "2025-01-01T00:00:00.000Zextra",
+			wantErrContains: "YYYY-MM-DDTHH:mm:ss.sssZ",
+		},
+		{
+			name:            "rejects downloaded after with bad format",
+			downloadedAfter: "not-a-timestamp",
+			wantErrContains: "YYYY-MM-DDTHH:mm:ss.sssZ",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buffer, stderrBuffer, previousLog := tests.RedirectLogOutputToBuffer()
+			defer log.SetLogger(previousLog)
+
+			cmd, err := NewTransferFilesCommand(nil, nil)
+			assert.NoError(t, err)
+			cmd.SetCreatedAfter(tc.createdAfter)
+			cmd.SetDownloadedAfter(tc.downloadedAfter)
+
+			filter, err := cmd.resolveTimestampFilter()
+			if tc.wantErrContains != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrContains)
+				assert.Nil(t, filter)
+				return
+			}
+			assert.NoError(t, err)
+			if tc.wantNil {
+				assert.Nil(t, filter)
+			} else {
+				require.NotNil(t, filter)
+				assert.Equal(t, tc.wantField, filter.field)
+				assert.Equal(t, tc.wantTimestamp, filter.timestamp)
+			}
+			logOutput := buffer.String() + stderrBuffer.String()
+			if tc.wantWarn {
+				assert.Contains(t, logOutput, "ignoring --downloaded-after")
+			} else {
+				assert.NotContains(t, logOutput, "ignoring --downloaded-after")
+			}
+		})
+	}
+}
+
+func TestInitNewPhasePropagatesTimestampFilter(t *testing.T) {
+	cmd, err := NewTransferFilesCommand(nil, nil)
+	assert.NoError(t, err)
+	cmd.SetCreatedAfter("2025-01-01T00:00:00.000Z")
+	filter, err := cmd.resolveTimestampFilter()
+	assert.NoError(t, err)
+	require.NotNil(t, filter)
+	cmd.timestampFilter = filter
+
+	phase := &fullTransferPhase{}
+	cmd.initNewPhase(phase, nil, artifactoryUtils.RepositorySummary{}, "repo1", false, 0)
+	assert.Equal(t, filter, phase.timestampFilter)
 }

--- a/artifactory/commands/transferfiles/utils.go
+++ b/artifactory/commands/transferfiles/utils.go
@@ -814,14 +814,51 @@ func filterFilesByPattern(files []api.FileRepresentation, patterns []string) []a
 	return filtered
 }
 
+// aqlInclusiveTimestampCondition returns an inclusive AQL predicate for the effective filter,
+// e.g. {"created":{"$gte":"..."}}. Returns empty string when filter is nil.
+func aqlInclusiveTimestampCondition(filter *timestampFilter) string {
+	if filter == nil {
+		return ""
+	}
+	return fmt.Sprintf(`{"%s":{"$gte":"%s"}}`, filter.field, filter.timestamp)
+}
+
+// aqlInclusiveTimestampAndCondition returns a comma-prefixed predicate suitable for an AQL $and array.
+func aqlInclusiveTimestampAndCondition(filter *timestampFilter) string {
+	if filter == nil {
+		return ""
+	}
+	return "," + aqlInclusiveTimestampCondition(filter)
+}
+
+// aqlFileOnlyTimestampAndCondition returns a comma-prefixed field condition suitable for appending
+// inside a file-only items.find object. Returns empty string when filter is nil.
+func aqlFileOnlyTimestampAndCondition(filter *timestampFilter) string {
+	if filter == nil {
+		return ""
+	}
+	return fmt.Sprintf(`,"%s":{"$gte":"%s"}`, filter.field, filter.timestamp)
+}
+
+// aqlMixedContentTimestampAndCondition returns a comma-prefixed $or object suitable for an AQL $and
+// array. It keeps all folders while requiring files to match the inclusive timestamp predicate.
+// Returns empty string when filter is nil.
+func aqlMixedContentTimestampAndCondition(filter *timestampFilter) string {
+	if filter == nil {
+		return ""
+	}
+	return fmt.Sprintf(`,{"$or":[{"type":"folder"},{"$and":[{"type":"file"},%s]}]}`, aqlInclusiveTimestampCondition(filter))
+}
+
 // generatePatternBasedAqlQuery generates an AQL query that fetches all files matching the include patterns.
 // This is used when --include-files is provided, as an alternative to folder traversal.
 // The query uses $or to combine multiple pattern conditions.
-func generatePatternBasedAqlQuery(repoKey string, patterns []string, paginationOffset int, disabledDistinctiveAql bool) string {
+func generatePatternBasedAqlQuery(repoKey string, patterns []string, paginationOffset int, disabledDistinctiveAql bool, filter *timestampFilter) string {
 	// Build pattern conditions for AQL
 	patternConditions := generatePatternConditionsAql(patterns)
+	timestampCondition := aqlFileOnlyTimestampAndCondition(filter)
 
-	query := fmt.Sprintf(`items.find({"type":"file","repo":"%s"%s})`, repoKey, patternConditions)
+	query := fmt.Sprintf(`items.find({"type":"file","repo":"%s"%s%s})`, repoKey, timestampCondition, patternConditions)
 	query += `.include("repo","path","name","type","size")`
 	query += fmt.Sprintf(`.sort({"$asc":["path","name"]}).offset(%d).limit(%d)`, paginationOffset*AqlPaginationLimit, AqlPaginationLimit)
 	query += appendDistinctIfNeeded(disabledDistinctiveAql)
@@ -869,18 +906,25 @@ func convertPatternToAqlMatch(pattern string) string {
 }
 
 // generateDiffAqlQueryWithPatterns generates a diff AQL query with pattern filtering.
-func generateDiffAqlQueryWithPatterns(repoKey, fromTimestamp, toTimestamp string, patterns []string, paginationOffset int, disabledDistinctiveAql bool) string {
+func generateDiffAqlQueryWithPatterns(repoKey, fromTimestamp, toTimestamp string, patterns []string, paginationOffset int, disabledDistinctiveAql bool, filter *timestampFilter) string {
 	patternOrCondition := generatePatternOrConditionForAnd(patterns)
-	query := fmt.Sprintf(`items.find({"$and":[{"modified":{"$gte":"%s"}},{"modified":{"$lt":"%s"}},{"repo":"%s","type":"any"}%s]})`, fromTimestamp, toTimestamp, repoKey, patternOrCondition)
+	repoClause := fmt.Sprintf(`{"repo":"%s","type":"any"}`, repoKey)
+	timestampClause := ""
+	if filter != nil {
+		repoClause = fmt.Sprintf(`{"repo":"%s"}`, repoKey)
+		timestampClause = aqlMixedContentTimestampAndCondition(filter)
+	}
+	query := fmt.Sprintf(`items.find({"$and":[{"modified":{"$gte":"%s"}},{"modified":{"$lt":"%s"}},%s%s%s]})`, fromTimestamp, toTimestamp, repoClause, patternOrCondition, timestampClause)
 	query += `.include("repo","path","name","type","modified","size")`
 	return query + generateAqlSortingPart(paginationOffset, disabledDistinctiveAql)
 }
 
 // generateDockerManifestAqlQueryWithPatterns generates a Docker manifest AQL query with pattern filtering.
-func generateDockerManifestAqlQueryWithPatterns(repoKey, fromTimestamp, toTimestamp string, patterns []string, paginationOffset int, disabledDistinctiveAql bool) string {
+func generateDockerManifestAqlQueryWithPatterns(repoKey, fromTimestamp, toTimestamp string, patterns []string, paginationOffset int, disabledDistinctiveAql bool, filter *timestampFilter) string {
 	patternOrCondition := generatePatternOrConditionForAnd(patterns)
+	timestampClause := aqlInclusiveTimestampAndCondition(filter)
 	query := `items.find({"$and":`
-	query += fmt.Sprintf(`[{"repo":"%s"},{"modified":{"$gte":"%s"}},{"modified":{"$lt":"%s"}},{"$or":[{"name":"manifest.json"},{"name":"list.manifest.json"}]}%s`, repoKey, fromTimestamp, toTimestamp, patternOrCondition)
+	query += fmt.Sprintf(`[{"repo":"%s"},{"modified":{"$gte":"%s"}},{"modified":{"$lt":"%s"}},{"$or":[{"name":"manifest.json"},{"name":"list.manifest.json"}]}%s%s`, repoKey, fromTimestamp, toTimestamp, patternOrCondition, timestampClause)
 	query += `]}).include("repo","path","name","type","modified")`
 	return query + generateAqlSortingPart(paginationOffset, disabledDistinctiveAql)
 }

--- a/artifactory/commands/transferfiles/utils_test.go
+++ b/artifactory/commands/transferfiles/utils_test.go
@@ -715,7 +715,7 @@ func TestGeneratePatternBasedAqlQuery(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			result := generatePatternBasedAqlQuery(testCase.repoKey, testCase.patterns, testCase.paginationOffset, false)
+			result := generatePatternBasedAqlQuery(testCase.repoKey, testCase.patterns, testCase.paginationOffset, false, nil)
 			for _, expected := range testCase.expectedContains {
 				assert.Contains(t, result, expected)
 			}
@@ -759,7 +759,7 @@ func TestGenerateDiffAqlQueryWithPatterns(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			result := generateDiffAqlQueryWithPatterns(testCase.repoKey, fromTimestamp, toTimestamp, testCase.patterns, 0, false)
+			result := generateDiffAqlQueryWithPatterns(testCase.repoKey, fromTimestamp, toTimestamp, testCase.patterns, 0, false, nil)
 			for _, expected := range testCase.expectedContains {
 				assert.Contains(t, result, expected)
 			}
@@ -793,10 +793,114 @@ func TestGenerateDockerManifestAqlQueryWithPatterns(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			result := generateDockerManifestAqlQueryWithPatterns(testCase.repoKey, fromTimestamp, toTimestamp, testCase.patterns, 0, false)
+			result := generateDockerManifestAqlQueryWithPatterns(testCase.repoKey, fromTimestamp, toTimestamp, testCase.patterns, 0, false, nil)
 			for _, expected := range testCase.expectedContains {
 				assert.Contains(t, result, expected)
 			}
 		})
 	}
+}
+
+func TestGenerateDiffAndDockerAqlWithPatternsAndTimestampFilter(t *testing.T) {
+	fromTimestamp := "2024-01-01T00:00:00Z"
+	toTimestamp := "2024-01-02T00:00:00Z"
+	filter := &timestampFilter{field: createdFilterField, timestamp: "2025-01-01T00:00:00.000Z"}
+
+	t.Run("diff with patterns and created filter", func(t *testing.T) {
+		query := generateDiffAqlQueryWithPatterns("test-repo", fromTimestamp, toTimestamp, []string{"org/company/*"}, 0, false, filter)
+		assert.Contains(t, query, `"modified":{"$gte":"2024-01-01T00:00:00Z"}`)
+		assert.Contains(t, query, `{"$or":[{"path":{"$match":"*org/company*"}}]}`)
+		assert.Contains(t, query, `,{"$or":[{"type":"folder"},{"$and":[{"type":"file"},{"created":{"$gte":"2025-01-01T00:00:00.000Z"}}]}]}`)
+		assert.NotContains(t, query, `"type":"any"`)
+	})
+
+	t.Run("docker manifest with patterns and created filter", func(t *testing.T) {
+		query := generateDockerManifestAqlQueryWithPatterns("docker-repo", fromTimestamp, toTimestamp, []string{"myapp/*"}, 0, false, filter)
+		assert.Contains(t, query, `"name":"manifest.json"`)
+		assert.Contains(t, query, `{"$or":[{"path":{"$match":"*myapp*"}}]}`)
+		assert.Contains(t, query, `"created":{"$gte":"2025-01-01T00:00:00.000Z"}`)
+	})
+}
+
+func TestAqlTimestampFilterHelpers(t *testing.T) {
+	createdFilter := &timestampFilter{field: createdFilterField, timestamp: "2025-01-01T00:00:00.000Z"}
+	downloadedFilter := &timestampFilter{field: downloadedFilterField, timestamp: "2024-06-15T12:30:45.123Z"}
+
+	t.Run("nil filter returns empty helpers", func(t *testing.T) {
+		assert.Empty(t, aqlInclusiveTimestampCondition(nil))
+		assert.Empty(t, aqlInclusiveTimestampAndCondition(nil))
+		assert.Empty(t, aqlFileOnlyTimestampAndCondition(nil))
+		assert.Empty(t, aqlMixedContentTimestampAndCondition(nil))
+	})
+
+	t.Run("created inclusive condition", func(t *testing.T) {
+		assert.Equal(t, `{"created":{"$gte":"2025-01-01T00:00:00.000Z"}}`, aqlInclusiveTimestampCondition(createdFilter))
+	})
+
+	t.Run("downloaded inclusive condition", func(t *testing.T) {
+		assert.Equal(t, `{"stat.downloaded":{"$gte":"2024-06-15T12:30:45.123Z"}}`, aqlInclusiveTimestampCondition(downloadedFilter))
+	})
+
+	t.Run("inclusive and-condition", func(t *testing.T) {
+		assert.Equal(t, `,{"created":{"$gte":"2025-01-01T00:00:00.000Z"}}`, aqlInclusiveTimestampAndCondition(createdFilter))
+		assert.Equal(t, `,{"stat.downloaded":{"$gte":"2024-06-15T12:30:45.123Z"}}`, aqlInclusiveTimestampAndCondition(downloadedFilter))
+	})
+
+	t.Run("file-only and-condition", func(t *testing.T) {
+		assert.Equal(t, `,"created":{"$gte":"2025-01-01T00:00:00.000Z"}`, aqlFileOnlyTimestampAndCondition(createdFilter))
+		assert.Equal(t, `,"stat.downloaded":{"$gte":"2024-06-15T12:30:45.123Z"}`, aqlFileOnlyTimestampAndCondition(downloadedFilter))
+	})
+
+	t.Run("mixed content preserves folders", func(t *testing.T) {
+		mixed := aqlMixedContentTimestampAndCondition(createdFilter)
+		assert.Equal(t,
+			`,{"$or":[{"type":"folder"},{"$and":[{"type":"file"},{"created":{"$gte":"2025-01-01T00:00:00.000Z"}}]}]}`,
+			mixed)
+		assert.Contains(t, mixed, `"type":"folder"`)
+		assert.Contains(t, mixed, `"type":"file"`)
+	})
+}
+
+func TestGenerateFolderContentAqlQueryWithTimestampFilter(t *testing.T) {
+	const noFilterExpected = `items.find({"type":"any","$or":[{"$and":[{"repo":"repo1","path":{"$match":"."},"name":{"$match":"*"}}]}]}).include("repo","path","name","type","size").sort({"$asc":["name"]}).offset(0).limit(10000)`
+
+	t.Run("no filter unchanged", func(t *testing.T) {
+		assert.Equal(t, noFilterExpected, generateFolderContentAqlQuery("repo1", ".", 0, false, nil))
+	})
+
+	t.Run("created after filters files and keeps folders", func(t *testing.T) {
+		filter := &timestampFilter{field: createdFilterField, timestamp: "2025-01-01T00:00:00.000Z"}
+		query := generateFolderContentAqlQuery("repo1", ".", 0, false, filter)
+		assert.Contains(t, query, `"$or":[{"type":"folder"},{"$and":[{"type":"file"},{"created":{"$gte":"2025-01-01T00:00:00.000Z"}}]}]`)
+		assert.Contains(t, query, `"repo":"repo1"`)
+		assert.Contains(t, query, `"path":{"$match":"."}`)
+	})
+
+	t.Run("downloaded after uses stat.downloaded", func(t *testing.T) {
+		filter := &timestampFilter{field: downloadedFilterField, timestamp: "2025-01-01T00:00:00.000Z"}
+		query := generateFolderContentAqlQuery("repo1", "path/to", 0, false, filter)
+		assert.Contains(t, query, `{"stat.downloaded":{"$gte":"2025-01-01T00:00:00.000Z"}}`)
+		assert.Contains(t, query, `"type":"folder"`)
+	})
+}
+
+func TestGeneratePatternBasedAqlQueryWithTimestampFilter(t *testing.T) {
+	t.Run("no filter unchanged semantics", func(t *testing.T) {
+		without := generatePatternBasedAqlQuery("test-repo", []string{"org/company/*"}, 0, false, nil)
+		assert.Contains(t, without, `"type":"file","repo":"test-repo"`)
+		assert.NotContains(t, without, `"$gte"`)
+	})
+
+	t.Run("created after appended to file query", func(t *testing.T) {
+		filter := &timestampFilter{field: createdFilterField, timestamp: "2025-01-01T00:00:00.000Z"}
+		query := generatePatternBasedAqlQuery("test-repo", []string{"org/company/*"}, 0, false, filter)
+		assert.Contains(t, query, `"type":"file","repo":"test-repo","created":{"$gte":"2025-01-01T00:00:00.000Z"}`)
+		assert.Contains(t, query, `"$or":[{"path":{"$match":"*org/company*"}}]`)
+	})
+
+	t.Run("downloaded after appended to file query", func(t *testing.T) {
+		filter := &timestampFilter{field: downloadedFilterField, timestamp: "2024-06-15T12:30:45.123Z"}
+		query := generatePatternBasedAqlQuery("test-repo", []string{"org/company/*"}, 0, false, filter)
+		assert.Contains(t, query, `"stat.downloaded":{"$gte":"2024-06-15T12:30:45.123Z"}`)
+	})
 }


### PR DESCRIPTION
## Summary

Adds optional timestamp filtering support to the `transfer-files` command core:

- `--created-after` transfers files created at or after an exact UTC-millisecond timestamp.
- `--downloaded-after` transfers files last downloaded at or after the timestamp; never-downloaded files are excluded.
- When both filters are provided, `--created-after` takes precedence and a warning is emitted.
- Filters use inclusive `$gte` semantics and are validated before transfer state is locked.

## Implementation

- Propagates the resolved timestamp filter through all transfer phases.
- Applies filtering to Phase 1 and Phase 2 AQL queries, including `--include-files` flows.
- Preserves folders during mixed-content traversal so newer files beneath older parent folders remain discoverable.
- For Docker repositories, applies filtering to manifest selection while retaining directory-content expansion behavior.
- Warns once when resumed state skips completed folders while a timestamp filter is active.
- Leaves existing behavior unchanged when no timestamp filter is supplied.

## Validation

- Added unit coverage for validation, precedence, inclusive boundaries, AQL generation, folder preservation, Docker manifests, and resume warnings.
- `go test ./artifactory/commands/transferfiles/ -count=1` passes.
- Clean live validation against local source and target Artifactory instances passes for created/downloaded filtering, precedence, inclusive boundaries, files under old parents, no-filter, and `--include-files` scenarios.

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
