### PR TITLE
Allow unsafe PR checkout in build-gate-approved workflows

### DIFF
--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Python3
         uses: actions/setup-python@v6


### PR DESCRIPTION
Same root cause as jfrog-cli: `actions/checkout@v7`'s default fork-checkout refusal under `pull_request_target` broke `frogbot-scan-pull-request.yml` and `test.yml`. Both are only reachable through `build-gate.yml`'s approval gate, so adding `allow-unsafe-pr-checkout: true` there is safe — a maintainer already reviews the diff before approving. `dependabot-auto-merge.yml`'s checkout is left untouched since it isn't behind that gate.

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
