### PR TITLE
Use proportional refresh threshold for platform access tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go master
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.55.1-0.20260806075556-215ab6eec524
 
 //replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105064157-73c3f6f22ba2
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.8.3
 	github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295
 	github.com/jfrog/gofrog v1.7.6
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260811135712-2010f5075cc6
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260813100550-0f2168d02558
 	github.com/magiconair/properties v1.18.11
 	github.com/manifoldco/promptui v0.9.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
@@ -93,7 +93,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.55.1-0.20260806075556-215ab6eec524
+// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go master
 
 //replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105064157-73c3f6f22ba2
 

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295 h1:EH0h86Kw
 github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260806075556-215ab6eec524 h1:IGQI/9RSl2XD1ZvnZ8hgTwa6urxOC62kPEltoXNAjI4=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260806075556-215ab6eec524/go.mod h1:FHpjN1nTDoj96xd6obe27EOgGErqzU0rQgC96L3Ch9E=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260811135712-2010f5075cc6 h1:NWwtreeZW34czMVDdQHZeLg+fxc9j4oZLRhLt4vXZbA=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260811135712-2010f5075cc6/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=

--- a/go.sum
+++ b/go.sum
@@ -101,10 +101,8 @@ github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295 h1:EH0h86Kw
 github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260806075556-215ab6eec524 h1:IGQI/9RSl2XD1ZvnZ8hgTwa6urxOC62kPEltoXNAjI4=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260806075556-215ab6eec524/go.mod h1:FHpjN1nTDoj96xd6obe27EOgGErqzU0rQgC96L3Ch9E=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260811135712-2010f5075cc6 h1:NWwtreeZW34czMVDdQHZeLg+fxc9j4oZLRhLt4vXZbA=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260811135712-2010f5075cc6/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260813100550-0f2168d02558 h1:/4ayHXxzgyZ9f66EqImCyZr2SKUpygU1P36sDVAlskM=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260813100550-0f2168d02558/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=
 github.com/kevinburke/ssh_config v1.6.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=

--- a/utils/config/tokenrefresh.go
+++ b/utils/config/tokenrefresh.go
@@ -33,16 +33,21 @@ const (
 type TokenType string
 
 func AccessTokenRefreshPreRequestInterceptor(fields *auth.CommonConfigFields, httpClientDetails *httputils.HttpClientDetails) (err error) {
-	return tokenRefreshPreRequestInterceptor(fields, httpClientDetails, AccessToken, auth.RefreshPlatformTokenBeforeExpiryMinutes)
+	return tokenRefreshPreRequestInterceptor(fields, httpClientDetails, AccessToken)
 }
 
 func ArtifactoryTokenRefreshPreRequestInterceptor(fields *auth.CommonConfigFields, httpClientDetails *httputils.HttpClientDetails) (err error) {
-	return tokenRefreshPreRequestInterceptor(fields, httpClientDetails, ArtifactoryToken, auth.RefreshArtifactoryTokenBeforeExpiryMinutes)
+	return tokenRefreshPreRequestInterceptor(fields, httpClientDetails, ArtifactoryToken)
 }
 
-func tokenRefreshPreRequestInterceptor(fields *auth.CommonConfigFields, httpClientDetails *httputils.HttpClientDetails, tokenType TokenType, refreshBeforeExpiryMinutes int64) (err error) {
+func tokenRefreshPreRequestInterceptor(fields *auth.CommonConfigFields, httpClientDetails *httputils.HttpClientDetails, tokenType TokenType) (err error) {
 	if fields.GetAccessToken() == "" || httpClientDetails.AccessToken == "" {
 		return nil
+	}
+
+	refreshBeforeExpiryMinutes, err := refreshThresholdForTokenType(httpClientDetails.AccessToken, tokenType)
+	if err != nil {
+		return err
 	}
 
 	timeLeft, err := auth.GetTokenMinutesLeft(httpClientDetails.AccessToken)
@@ -65,6 +70,17 @@ func tokenRefreshPreRequestInterceptor(fields *auth.CommonConfigFields, httpClie
 	// Copy new token from the mutual struct CommonConfigFields to the private struct in httpClientDetails
 	httpClientDetails.AccessToken = fields.AccessToken
 	return nil
+}
+
+// refreshThresholdForTokenType returns, in minutes, how long before expiry a token of the given type
+// should be refreshed. Artifactory refresh tokens use a fixed threshold (60-minute lifetime). Platform
+// access tokens use a threshold proportional to their own lifetime, since they aren't always issued
+// with the historical 1-year expiry.
+func refreshThresholdForTokenType(token string, tokenType TokenType) (int64, error) {
+	if tokenType == ArtifactoryToken {
+		return auth.RefreshArtifactoryTokenBeforeExpiryMinutes, nil
+	}
+	return auth.GetPlatformTokenRefreshThreshold(token)
 }
 
 func tokenRefreshHandler(currentAccessToken string, tokenType TokenType) (newAccessToken string, err error) {

--- a/utils/config/tokenrefresh_test.go
+++ b/utils/config/tokenrefresh_test.go
@@ -8,6 +8,7 @@ import (
 	configtests "github.com/jfrog/jfrog-cli-core/v2/utils/config/tests"
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRefreshThresholdForTokenType(t *testing.T) {
@@ -18,14 +19,14 @@ func TestRefreshThresholdForTokenType(t *testing.T) {
 	})
 
 	t.Run("short-lived platform token uses proportional threshold", func(t *testing.T) {
-		token := buildTestAccessToken(1000, 1000+7*24*60*60) // 7-day lifetime
+		token := buildTestAccessToken(t, 1000, 1000+7*24*60*60) // 7-day lifetime
 		threshold, err := refreshThresholdForTokenType(token, AccessToken)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1008), threshold) // 10% of 7 days, in minutes
 	})
 
 	t.Run("1-year platform token is capped at the historical threshold", func(t *testing.T) {
-		token := buildTestAccessToken(1000, 1000+365*24*60*60) // 1-year lifetime
+		token := buildTestAccessToken(t, 1000, 1000+365*24*60*60) // 1-year lifetime
 		threshold, err := refreshThresholdForTokenType(token, AccessToken)
 		assert.NoError(t, err)
 		assert.Equal(t, auth.RefreshPlatformTokenBeforeExpiryMinutes, threshold)
@@ -33,8 +34,9 @@ func TestRefreshThresholdForTokenType(t *testing.T) {
 }
 
 // buildTestAccessToken builds an unsigned JWT-shaped token with the given iat/exp claims.
-func buildTestAccessToken(iat, exp int64) string {
-	payload, _ := json.Marshal(map[string]int64{"iat": iat, "exp": exp})
+func buildTestAccessToken(t *testing.T, iat, exp int64) string {
+	payload, err := json.Marshal(map[string]int64{"iat": iat, "exp": exp})
+	require.NoError(t, err)
 	encodedPayload := base64.RawStdEncoding.EncodeToString(payload)
 	return "header." + encodedPayload + ".signature"
 }

--- a/utils/config/tokenrefresh_test.go
+++ b/utils/config/tokenrefresh_test.go
@@ -1,11 +1,43 @@
 package config
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	configtests "github.com/jfrog/jfrog-cli-core/v2/utils/config/tests"
+	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestRefreshThresholdForTokenType(t *testing.T) {
+	t.Run("artifactory token uses fixed threshold", func(t *testing.T) {
+		threshold, err := refreshThresholdForTokenType("irrelevant-token", ArtifactoryToken)
+		assert.NoError(t, err)
+		assert.Equal(t, auth.RefreshArtifactoryTokenBeforeExpiryMinutes, threshold)
+	})
+
+	t.Run("short-lived platform token uses proportional threshold", func(t *testing.T) {
+		token := buildTestAccessToken(1000, 1000+7*24*60*60) // 7-day lifetime
+		threshold, err := refreshThresholdForTokenType(token, AccessToken)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1008), threshold) // 10% of 7 days, in minutes
+	})
+
+	t.Run("1-year platform token is capped at the historical threshold", func(t *testing.T) {
+		token := buildTestAccessToken(1000, 1000+365*24*60*60) // 1-year lifetime
+		threshold, err := refreshThresholdForTokenType(token, AccessToken)
+		assert.NoError(t, err)
+		assert.Equal(t, auth.RefreshPlatformTokenBeforeExpiryMinutes, threshold)
+	})
+}
+
+// buildTestAccessToken builds an unsigned JWT-shaped token with the given iat/exp claims.
+func buildTestAccessToken(iat, exp int64) string {
+	payload, _ := json.Marshal(map[string]int64{"iat": iat, "exp": exp})
+	encodedPayload := base64.RawStdEncoding.EncodeToString(payload)
+	return "header." + encodedPayload + ".signature"
+}
 
 func TestCreateInitialRefreshableTokensIfNeededEarlyReturns(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Wires jfrog-client-go's new proportional refresh threshold into tokenRefreshPreRequestInterceptor: the static per-call threshold parameter is replaced with refreshThresholdForTokenType, which keeps the fixed threshold for ArtifactoryToken (unchanged) and uses the new proportional calculation for AccessToken (platform tokens).
- Fixes CLI commands entering the token-refresh path on every single call when a platform access token is issued with a short lifetime (e.g. 7 days) instead of the historical 1-year default.

## Scope
- Related to JGC-519.
- Depends on jfrog/jfrog-client-go#1373 (feature/JGC-519). go.mod currently has an active replace directive pinning jfrog-client-go to that branch — this must be swapped to a released version once #1373 merges, before this PR can merge.

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
