### PR TITLE
Add legacy flag to preserve per-service URL config for Artifactory v6.x

### DIFF
--- a/common/commands/config.go
+++ b/common/commands/config.go
@@ -62,6 +62,9 @@ type ConfigCommand struct {
 	serverId         string
 	// Preselected web login authentication method, supported on an interactive command only.
 	useWebLogin bool
+	// Preserve per-service URL prompts (Artifactory/Distribution/Xray/Mission Control/Pipelines),
+	// for Artifactory v6.x self-hosted customers where these products don't share a single platform URL.
+	legacy bool
 	// Forcibly make the configured server default.
 	makeDefault bool
 	// For unit tests
@@ -91,6 +94,11 @@ func (cc *ConfigCommand) SetUseBasicAuthOnly(useBasicAuthOnly bool) *ConfigComma
 
 func (cc *ConfigCommand) SetUseWebLogin(useWebLogin bool) *ConfigCommand {
 	cc.useWebLogin = useWebLogin
+	return cc
+}
+
+func (cc *ConfigCommand) SetLegacy(legacy bool) *ConfigCommand {
+	cc.legacy = legacy
 	return cc
 }
 
@@ -385,8 +393,10 @@ func (cc *ConfigCommand) getConfigurationFromUser() (err error) {
 	}
 
 	disallowUsingSavedPassword := cc.fillSpecificUrlsFromPlatform()
-	if err = cc.promptUrls(&disallowUsingSavedPassword); err != nil {
-		return
+	if cc.legacy {
+		if err = cc.promptUrls(&disallowUsingSavedPassword); err != nil {
+			return
+		}
 	}
 
 	if cc.details.Password == "" && cc.details.AccessToken == "" {
@@ -896,6 +906,7 @@ type ConfigCommandConfiguration struct {
 	Interactive   bool
 	EncPassword   bool
 	BasicAuthOnly bool
+	Legacy        bool
 }
 
 func GetAllServerIds() []string {

--- a/general/login/login.go
+++ b/general/login/login.go
@@ -17,6 +17,9 @@ const (
 type LoginCommand struct {
 	serverId            string
 	disableTokenRefresh *bool
+	// When true, preserve per-service URL prompts (Artifactory/Distribution/Xray/Mission Control/Pipelines)
+	// and skip the browser-based web login, for Artifactory v6.x self-hosted customers.
+	legacy bool
 }
 
 func NewLoginCommand() *LoginCommand {
@@ -35,27 +38,32 @@ func (lc *LoginCommand) SetDisableTokenRefresh(disableTokenRefresh *bool) *Login
 	return lc
 }
 
+func (lc *LoginCommand) SetLegacy(legacy bool) *LoginCommand {
+	lc.legacy = legacy
+	return lc
+}
+
 func (lc *LoginCommand) Run() error {
 	if lc.serverId != "" {
-		return existingServerLogin(lc.serverId, lc.disableTokenRefresh)
+		return existingServerLogin(lc.serverId, lc.disableTokenRefresh, lc.legacy)
 	}
 	configurations, err := config.GetAllServersConfigs()
 	if err != nil {
 		return err
 	}
 	if len(configurations) == 0 {
-		return newConfLogin(lc.disableTokenRefresh)
+		return newConfLogin(lc.disableTokenRefresh, lc.legacy)
 	}
-	return existingConfLogin(configurations, lc.disableTokenRefresh)
+	return existingConfLogin(configurations, lc.disableTokenRefresh, lc.legacy)
 }
 
-func newConfLogin(disableTokenRefresh *bool) error {
+func newConfLogin(disableTokenRefresh *bool, legacy bool) error {
 	platformUrl := promptPlatformUrl()
 	newServer := config.ServerDetails{Url: platformUrl}
 	if disableTokenRefresh != nil {
 		newServer.DisableTokenRefresh = *disableTokenRefresh
 	}
-	return general.ConfigServerWithDeducedId(&newServer, true, true)
+	return general.ConfigServerWithDeducedId(&newServer, true, !legacy, legacy)
 }
 
 func promptPlatformUrl() string {
@@ -71,30 +79,30 @@ func promptPlatformUrl() string {
 	return platformUrl
 }
 
-func existingConfLogin(configurations []*config.ServerDetails, disableTokenRefresh *bool) error {
+func existingConfLogin(configurations []*config.ServerDetails, disableTokenRefresh *bool, legacy bool) error {
 	selectedChoice, err := promptAddOrEdit(configurations)
 	if err != nil {
 		return err
 	}
 	if selectedChoice == newSeverPlaceholder {
-		return selectedNewServer(disableTokenRefresh)
+		return selectedNewServer(disableTokenRefresh, legacy)
 	}
-	return existingServerLogin(selectedChoice, disableTokenRefresh)
+	return existingServerLogin(selectedChoice, disableTokenRefresh, legacy)
 }
 
 // When configurations exist and the user chose to log in with a new server we direct him to a clean config process,
 // where he will be prompted for server ID and URL.
-func selectedNewServer(disableTokenRefresh *bool) error {
+func selectedNewServer(disableTokenRefresh *bool, legacy bool) error {
 	var newServer *config.ServerDetails
 	if disableTokenRefresh != nil {
 		newServer = &config.ServerDetails{DisableTokenRefresh: *disableTokenRefresh}
 	}
-	return general.ConfigServerAsDefault(newServer, "", true, true)
+	return general.ConfigServerAsDefault(newServer, "", true, !legacy, legacy)
 }
 
 // When a user chose to log in to an existing server,
 // we run a config process while keeping all his current server details except credentials.
-func existingServerLogin(serverId string, disableTokenRefresh *bool) error {
+func existingServerLogin(serverId string, disableTokenRefresh *bool, legacy bool) error {
 	serverDetails, err := commands.GetConfig(serverId, true)
 	if err != nil {
 		return err
@@ -102,7 +110,7 @@ func existingServerLogin(serverId string, disableTokenRefresh *bool) error {
 	if serverDetails.Url == "" {
 		serverDetails = &config.ServerDetails{ServerId: serverDetails.ServerId}
 	} else {
-		if fileutils.IsSshUrl(serverDetails.Url) {
+		if !legacy && fileutils.IsSshUrl(serverDetails.Url) {
 			return errorutils.CheckErrorf("web login cannot be performed via SSH. Please try again with different server configuration or configure a new one")
 		}
 		serverDetails.User = ""
@@ -113,7 +121,7 @@ func existingServerLogin(serverId string, disableTokenRefresh *bool) error {
 	if disableTokenRefresh != nil {
 		serverDetails.DisableTokenRefresh = *disableTokenRefresh
 	}
-	return general.ConfigServerAsDefault(serverDetails, serverId, true, true)
+	return general.ConfigServerAsDefault(serverDetails, serverId, true, !legacy, legacy)
 }
 
 // Prompt a list of all server IDs and an option for a new server, and let the user choose to which to log in.

--- a/general/login/login_test.go
+++ b/general/login/login_test.go
@@ -31,6 +31,14 @@ func TestSetDisableTokenRefresh(t *testing.T) {
 	assert.Nil(t, lc.disableTokenRefresh)
 }
 
+func TestSetLegacy(t *testing.T) {
+	lc := NewLoginCommand()
+	result := lc.SetLegacy(true)
+	assert.True(t, lc.legacy)
+	// Verify fluent API returns the same instance
+	assert.Same(t, lc, result)
+}
+
 func TestRunWithNonExistentServerId(t *testing.T) {
 	cleanUp, err := utilsTests.SetJfrogHome()
 	require.NoError(t, err)

--- a/general/utils.go
+++ b/general/utils.go
@@ -12,12 +12,12 @@ import (
 const defaultServerId = "default-server"
 
 // Deduce the server ID from the URL and add server details to config.
-func ConfigServerWithDeducedId(server *config.ServerDetails, interactive, webLogin bool) error {
+func ConfigServerWithDeducedId(server *config.ServerDetails, interactive, webLogin, legacy bool) error {
 	serverId, err := deduceServerId(server.Url)
 	if err != nil {
 		return err
 	}
-	return ConfigServerAsDefault(server, serverId, interactive, webLogin)
+	return ConfigServerAsDefault(server, serverId, interactive, webLogin, legacy)
 }
 
 func deduceServerId(platformUrl string) (string, error) {
@@ -36,8 +36,8 @@ func deduceServerId(platformUrl string) (string, error) {
 }
 
 // Add the given server details to the CLI's config by running a 'jf config' command, and make it the default server.
-func ConfigServerAsDefault(server *config.ServerDetails, serverId string, interactive, webLogin bool) error {
+func ConfigServerAsDefault(server *config.ServerDetails, serverId string, interactive, webLogin, legacy bool) error {
 	return commands.NewConfigCommand(commands.AddOrEdit, serverId).
-		SetInteractive(interactive).SetUseWebLogin(webLogin).
+		SetInteractive(interactive).SetUseWebLogin(webLogin).SetLegacy(legacy).
 		SetDetails(server).SetMakeDefault(true).Run()
 }


### PR DESCRIPTION
Simplify `jf login` / `jf c add` to always use a single JFrog Platform URL by default, dropping the interactive per-service URL prompts (Artifactory/Distribution/Xray/Mission Control/Pipelines). A new `legacy` option on `ConfigCommand` / `LoginCommand` restores that prompting (and, for login, skips the browser-based web login) for Artifactory v6.x self-hosted setups where these products don't share one platform URL.

Companion PR in jfrog-cli (wires up the `--legacy` CLI flag): https://github.com/jfrog/jfrog-cli/pull/new/JGC-487-simplify-login

- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
