### PR TITLE
feat: add JFROG_CLI_CERTS_DIR env support

### DIFF
--- a/utils/coreutils/coreconsts.go
+++ b/utils/coreutils/coreconsts.go
@@ -74,6 +74,7 @@ var (
 	ApplicationKey = "JFROG_CLI_APPLICATION_KEY"
 	SigningKey     = "JFROG_CLI_SIGNING_KEY"
 	KeyAlias       = "JFROG_CLI_KEY_ALIAS"
+	CertsDir       = "JFROG_CLI_CERTS_DIR"
 	//#nosec G101
 	EncryptionKey = "JFROG_CLI_ENCRYPTION_KEY"
 	// For CI runs

--- a/utils/coreutils/utils.go
+++ b/utils/coreutils/utils.go
@@ -342,8 +342,15 @@ func GetJfrogSecurityDir() (string, error) {
 
 func GetJfrogCertsDir() (string, error) {
 	if dir := os.Getenv(CertsDir); dir != "" {
-    return dir, nil
-}
+		dir = filepath.Clean(dir)
+
+		absoluteDir, err := filepath.Abs(dir)
+		if err != nil {
+			return "", errorutils.CheckError(err)
+		}
+
+		return absoluteDir, nil
+	}
 
 	securityDir, err := GetJfrogSecurityDir()
 	if err != nil {

--- a/utils/coreutils/utils.go
+++ b/utils/coreutils/utils.go
@@ -341,6 +341,10 @@ func GetJfrogSecurityDir() (string, error) {
 }
 
 func GetJfrogCertsDir() (string, error) {
+	if os.Getenv(CertsDir) != "" {
+		return os.Getenv(CertsDir), nil
+	}
+
 	securityDir, err := GetJfrogSecurityDir()
 	if err != nil {
 		return "", err

--- a/utils/coreutils/utils.go
+++ b/utils/coreutils/utils.go
@@ -341,9 +341,9 @@ func GetJfrogSecurityDir() (string, error) {
 }
 
 func GetJfrogCertsDir() (string, error) {
-	if os.Getenv(CertsDir) != "" {
-		return os.Getenv(CertsDir), nil
-	}
+	if dir := os.Getenv(CertsDir); dir != "" {
+    return dir, nil
+}
 
 	securityDir, err := GetJfrogSecurityDir()
 	if err != nil {

--- a/utils/coreutils/utils_test.go
+++ b/utils/coreutils/utils_test.go
@@ -297,3 +297,18 @@ func TestGetJfrogCertsDirFallsBackToHomeDir(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "/tmp/jfrog/security/certs", certsDir)
 }
+
+func TestGetJfrogCertsDirNormalizesPath(t *testing.T) {
+	t.Setenv(CertsDir, filepath.Join("test", "..", "custom", "certs"))
+	defer func() {
+		assert.NoError(t, os.Unsetenv(CertsDir))
+	}()
+
+	expectedDir, err := filepath.Abs(filepath.Join("custom", "certs"))
+	assert.NoError(t, err)
+
+	certsDir, err := GetJfrogCertsDir()
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedDir, certsDir)
+}

--- a/utils/coreutils/utils_test.go
+++ b/utils/coreutils/utils_test.go
@@ -281,21 +281,33 @@ func TestGetMaskedCommandString(t *testing.T) {
 }
 
 func TestGetJfrogCertsDirFromEnv(t *testing.T) {
-	t.Setenv("JFROG_CLI_CERTS_DIR", "/custom/certs")
+	certsDirPath, err := filepath.Abs(filepath.Join("/", "custom", "certs"))
+	assert.NoError(t, err)
+
+	t.Setenv(CertsDir, certsDirPath)
+	defer func() {
+		assert.NoError(t, os.Unsetenv(CertsDir))
+	}()
 
 	certsDir, err := GetJfrogCertsDir()
 
 	assert.NoError(t, err)
-	assert.Equal(t, "/custom/certs", certsDir)
+	assert.Equal(t, certsDirPath, certsDir)
 }
 
 func TestGetJfrogCertsDirFallsBackToHomeDir(t *testing.T) {
-	t.Setenv("JFROG_CLI_HOME_DIR", "/tmp/jfrog")
+	certsDirPath, err := filepath.Abs(filepath.Join("tmp", "jfrog"))
+	assert.NoError(t, err)
+
+	t.Setenv(HomeDir, certsDirPath)
+	defer func() {
+		assert.NoError(t, os.Unsetenv(HomeDir))
+	}()
 
 	certsDir, err := GetJfrogCertsDir()
 
 	assert.NoError(t, err)
-	assert.Equal(t, "/tmp/jfrog/security/certs", certsDir)
+	assert.Equal(t, filepath.Join(certsDirPath, JfrogSecurityDirName, JfrogCertsDirName), certsDir)
 }
 
 func TestGetJfrogCertsDirNormalizesPath(t *testing.T) {

--- a/utils/coreutils/utils_test.go
+++ b/utils/coreutils/utils_test.go
@@ -279,3 +279,21 @@ func TestGetMaskedCommandString(t *testing.T) {
 		"pip -i ***@someurl.com/repo --access-token=***",
 		GetMaskedCommandString(exec.Command("pip", "-i", "https://user:pass@someurl.com/repo", "--access-token=123")))
 }
+
+func TestGetJfrogCertsDirFromEnv(t *testing.T) {
+	t.Setenv("JFROG_CLI_CERTS_DIR", "/custom/certs")
+
+	certsDir, err := GetJfrogCertsDir()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "/custom/certs", certsDir)
+}
+
+func TestGetJfrogCertsDirFallsBackToHomeDir(t *testing.T) {
+	t.Setenv("JFROG_CLI_HOME_DIR", "/tmp/jfrog")
+
+	certsDir, err := GetJfrogCertsDir()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "/tmp/jfrog/security/certs", certsDir)
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the master branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

This PR introduces the env variable `JFROG_CLI_CERTS_DIR` for overriding the certificates directory.
More information about the feature can be found here https://github.com/jfrog/jfrog-cli/issues/3661