### PR TITLE
Add priority field to distribution rules

### DIFF
--- a/common/spec/distributionrules.go
+++ b/common/spec/distributionrules.go
@@ -16,6 +16,7 @@ type DistributionRule struct {
 	SiteName     string   `json:"site_name,omitempty"`
 	CityName     string   `json:"city_name,omitempty"`
 	CountryCodes []string `json:"country_codes,omitempty"`
+	Priority     string   `json:"priority,omitempty"`
 }
 
 func (distributionRules *DistributionRules) Get(index int) *DistributionRule {
@@ -30,6 +31,7 @@ func (distributionRule *DistributionRule) ToDistributionCommonParams() *distribu
 		SiteName:     distributionRule.SiteName,
 		CityName:     distributionRule.CityName,
 		CountryCodes: distributionRule.CountryCodes,
+		Priority:     distributionRule.Priority,
 	}
 }
 

--- a/common/spec/distributionrules_test.go
+++ b/common/spec/distributionrules_test.go
@@ -1,0 +1,47 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToDistributionCommonParamsIncludesPriority(t *testing.T) {
+	rule := DistributionRule{
+		SiteName:     "edge1",
+		CityName:     "Tel Aviv",
+		CountryCodes: []string{"IL"},
+		Priority:     "high",
+	}
+
+	params := rule.ToDistributionCommonParams()
+	require.NotNil(t, params)
+	assert.Equal(t, "edge1", params.SiteName)
+	assert.Equal(t, "Tel Aviv", params.CityName)
+	assert.Equal(t, []string{"IL"}, params.CountryCodes)
+	assert.Equal(t, "high", params.Priority)
+}
+
+func TestCreateDistributionRulesFromFileParsesPriority(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rules.json")
+	content := `{
+  "distribution_rules": [
+    {
+      "site_name": "edge*",
+      "priority": "medium"
+    }
+  ]
+}`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	rules, err := CreateDistributionRulesFromFile(path)
+	require.NoError(t, err)
+	require.Len(t, rules.DistributionRules, 1)
+	assert.Equal(t, "edge*", rules.DistributionRules[0].SiteName)
+	assert.Equal(t, "medium", rules.DistributionRules[0].Priority)
+	assert.Equal(t, "medium", rules.DistributionRules[0].ToDistributionCommonParams().Priority)
+}

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,9 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
+// TODO: remove this replace before merge (after jfrog/jfrog-client-go#1379 is merged)
+replace github.com/jfrog/jfrog-client-go => github.com/mnsboev/jfrog-client-go v0.0.0-20260818132447-d5b984492757
+
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go master
 
 //replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105064157-73c3f6f22ba2

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.8.3
 	github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295
 	github.com/jfrog/gofrog v1.7.6
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260813100550-0f2168d02558
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260827094947-e7a90ebc8049
 	github.com/magiconair/properties v1.18.11
 	github.com/manifoldco/promptui v0.9.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
@@ -92,9 +92,6 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
-
-// TODO: remove this replace before merge (after jfrog/jfrog-client-go#1379 is merged)
-replace github.com/jfrog/jfrog-client-go => github.com/mnsboev/jfrog-client-go v0.0.0-20260818132447-d5b984492757
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go master
 

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,6 @@ github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295 h1:EH0h86Kw
 github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260813100550-0f2168d02558 h1:/4ayHXxzgyZ9f66EqImCyZr2SKUpygU1P36sDVAlskM=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260813100550-0f2168d02558/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=
 github.com/kevinburke/ssh_config v1.6.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -142,6 +140,8 @@ github.com/mattn/go-tty v0.0.8 h1:yxtc0Ye17/1ne/bjy993YUoyP8bJJFa9n5M9XTdwoZQ=
 github.com/mattn/go-tty v0.0.8/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
+github.com/mnsboev/jfrog-client-go v0.0.0-20260818132447-d5b984492757 h1:MkOsT6sKyjvU5XNix8vzTKEXaki83cytE4/XFcMLaa0=
+github.com/mnsboev/jfrog-client-go v0.0.0-20260818132447-d5b984492757/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
 github.com/nwaples/rardecode/v2 v2.2.3 h1:qaVuy3ChZDbAQZshPLjHeNJKF3Cru8uo9jmgveKIy2A=
 github.com/nwaples/rardecode/v2 v2.2.3/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsRNb6IbvGVHRmw=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295 h1:EH0h86Kw
 github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295/go.mod h1:+OCtMb22/D+u7Wne5lzkjJjaWr0LRZcHlDwTH86Mpwo=
 github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260827094947-e7a90ebc8049 h1:eogwWAzZFir1suYEgZ4ZrYrch8fhWs7ma2dxv06p/z8=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260827094947-e7a90ebc8049/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=
 github.com/kevinburke/ssh_config v1.6.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -140,8 +142,6 @@ github.com/mattn/go-tty v0.0.8 h1:yxtc0Ye17/1ne/bjy993YUoyP8bJJFa9n5M9XTdwoZQ=
 github.com/mattn/go-tty v0.0.8/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
-github.com/mnsboev/jfrog-client-go v0.0.0-20260818132447-d5b984492757 h1:MkOsT6sKyjvU5XNix8vzTKEXaki83cytE4/XFcMLaa0=
-github.com/mnsboev/jfrog-client-go v0.0.0-20260818132447-d5b984492757/go.mod h1:7B7eMRKuMhZ0rOdMItbJVpWjRUe1L//J3Jq+PgjiNxI=
 github.com/nwaples/rardecode/v2 v2.2.3 h1:qaVuy3ChZDbAQZshPLjHeNJKF3Cru8uo9jmgveKIy2A=
 github.com/nwaples/rardecode/v2 v2.2.3/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsRNb6IbvGVHRmw=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=


### PR DESCRIPTION
## Summary
- Add optional `priority` on distribution rules (JSON + `ToDistributionCommonParams`)
- Temporary `replace` to `mnsboev/jfrog-client-go` for unmerged client-go priority support — remove before merge after https://github.com/jfrog/jfrog-client-go/pull/1379
