### PR TITLE
Resolve AI client from host app and tighten session detectors

### DIFF
--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -222,7 +222,7 @@ func detectModel() string {
 // | cursor      | CURSOR_TRACE_ID, agent=cursor, or "cursor" askpass path    |
 // | windsurf    | "windsurf" askpass path                                    |
 // | antigravity | "antigravity" askpass path                                 |
-// | vscode      | first-party Copilot plugin markers                         |
+// | vscode      | Copilot plugin markers, or stock VS Code askpass           |
 //
 // Order is significant: every VS Code fork inherits TERM_PROGRAM=vscode and the
 // VSCODE_* vars from upstream, so forks must resolve before anything reports
@@ -247,6 +247,9 @@ func detectClient(agent string) string {
 	case os.Getenv("COPILOT_AGENT") == "1", os.Getenv("AI_AGENT") == "github_copilot_vscode_agent":
 		// Last resort: these prove the first-party plugin, not the window. A
 		// JetBrains host is caught above, so this only fires with no host marker.
+		return "vscode"
+	case os.Getenv("VSCODE_GIT_ASKPASS_MAIN") != "", os.Getenv("VSCODE_GIT_ASKPASS_NODE") != "":
+		// Stock VS Code after forks were ruled out. GIT_ASKPASS is generic git.
 		return "vscode"
 	default:
 		return ""

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -23,8 +23,10 @@ type ExecutionContext struct {
 	IsInteractive bool   // stdout is a TTY
 	TraceID       string // e.g. CURSOR_TRACE_ID; empty if none
 
-	// Client: IDE host only — "cursor" or "vscode". Empty when there is no IDE
-	// (Claude Code TUI, Copilot CLI, Gemini, …). Never TERM_PROGRAM / a terminal emulator.
+	// Client: host editor window — "cursor", "vscode", "zed", "jetbrains",
+	// "windsurf", "antigravity". Empty when the session has no editor (Claude
+	// Code TUI, Copilot CLI, Gemini, CI) or when the host cannot be proven.
+	// Never TERM_PROGRAM / a terminal emulator.
 	Client string
 
 	// Model: model slug (JFROG_CLI_AI_MODEL) — "opus-4.7".
@@ -74,7 +76,7 @@ type agentDetector struct {
 // | amazon_q    | AWS_EXECUTION_ENV contains AmazonQ-For-CLI                   |
 // | unknown     | AI_AGENT/AGENT set to an unrecognized value                  |
 //
-// Client axis: IDE only (cursor / vscode). Never TERM_PROGRAM.
+// Client axis: host editor window, from editor-owned env — see detectClient.
 // Model axis: sanitized JFROG_CLI_AI_MODEL (skill/user supplied slug).
 var agentEnvDetectors = []agentDetector{
 	// GROK_AGENT is also a profile *path* for humans — exact "1" only.
@@ -208,22 +210,62 @@ func detectModel() string {
 	return sanitizeToken(os.Getenv("JFROG_CLI_AI_MODEL"))
 }
 
-// detectClient returns the IDE host for an agent session. Cursor always
-// reports "cursor" (agent shells often inherit TERM_PROGRAM=vscode). Copilot
-// reports "vscode" only for the first-party VS Code plugin. Every other
-// agent — including Copilot CLI and Claude — omits the axis.
+// detectClient returns the editor window hosting an agent session. The host is
+// read from env the *editor* owns, not inferred from the agent name: Copilot and
+// Claude both run inside JetBrains, Zed and VS Code, so agent alone cannot name
+// the window.
+//
+// | Client      | Host-owned signal                                          |
+// |-------------|------------------------------------------------------------|
+// | zed         | ZED_TERM                                                   |
+// | jetbrains   | TERMINAL_EMULATOR=JetBrains-JediTerm                       |
+// | cursor      | CURSOR_TRACE_ID, agent=cursor, or "cursor" askpass path    |
+// | windsurf    | "windsurf" askpass path                                    |
+// | antigravity | "antigravity" askpass path                                 |
+// | vscode      | first-party Copilot plugin markers                         |
+//
+// Order is significant: every VS Code fork inherits TERM_PROGRAM=vscode and the
+// VSCODE_* vars from upstream, so forks must resolve before anything reports
+// "vscode" (product rule P13 — a Cursor session must never be labelled vscode).
+// Unproven hosts omit the axis rather than guess.
+//
+// JetBrains publishes one terminal value for the whole family, so IntelliJ,
+// GoLand and PyCharm collapse to "jetbrains"; separating them would need a
+// parent-process walk on every command.
 func detectClient(agent string) string {
-	switch agent {
-	case "cursor":
+	switch {
+	case os.Getenv("ZED_TERM") != "":
+		return "zed"
+	case os.Getenv("TERMINAL_EMULATOR") == "JetBrains-JediTerm":
+		return "jetbrains"
+	case agent == "cursor", os.Getenv("CURSOR_TRACE_ID") != "", askpassPathContains("cursor"):
 		return "cursor"
-	case "copilot":
-		if os.Getenv("COPILOT_AGENT") == "1" || os.Getenv("AI_AGENT") == "github_copilot_vscode_agent" {
-			return "vscode"
-		}
-		return ""
+	case askpassPathContains("windsurf"):
+		return "windsurf"
+	case askpassPathContains("antigravity"):
+		return "antigravity"
+	case os.Getenv("COPILOT_AGENT") == "1", os.Getenv("AI_AGENT") == "github_copilot_vscode_agent":
+		// Last resort: these prove the first-party plugin, not the window. A
+		// JetBrains host is caught above, so this only fires with no host marker.
+		return "vscode"
 	default:
 		return ""
 	}
+}
+
+// askpassEnvVars hold the path of the editor's git askpass helper, which embeds
+// the application name (…/Cursor.app/…, …/windsurf/…). It is the only env that
+// separates a VS Code fork from upstream, since forks copy the VSCODE_* names
+// verbatim. Path-shaped, so match case-insensitively on a substring.
+var askpassEnvVars = []string{"VSCODE_GIT_ASKPASS_MAIN", "VSCODE_GIT_ASKPASS_NODE", "GIT_ASKPASS"}
+
+func askpassPathContains(app string) bool {
+	for _, env := range askpassEnvVars {
+		if strings.Contains(strings.ToLower(os.Getenv(env)), app) {
+			return true
+		}
+	}
+	return false
 }
 
 // maxTokenLen caps sanitized identity tokens so a pathological env value cannot

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -185,6 +185,8 @@ var agentEnvDetectors = []agentDetector{
 	{"iflow", []string{"IFLOW_CLI"}, nil, nil},
 	{nameTrae, []string{"TRAE_AI_SHELL_ID"}, nil, nil},
 	{"pi", []string{"PI_CODING_AGENT"}, nil, nil},
+	// Amazon Q Developer CLI sets AWS_EXECUTION_ENV to a value containing
+	// AmazonQ-For-CLI (AWS CLI execution-environment convention).
 	{nameAmazonQ, nil, nil, map[string]string{"AWS_EXECUTION_ENV": "AmazonQ-For-CLI"}},
 }
 
@@ -374,12 +376,9 @@ func canonicalTerminalName(raw string) string {
 	if mapped, ok := terminalNameAliases[name]; ok {
 		return mapped
 	}
-	// TERM_PROGRAM=vscode is inherited by every VS Code fork. Do not treat it
-	// as a proven vscode window — that is how Copilot CLI gets mislabelled.
-	if name == nameVSCode {
-		return ""
-	}
-	return name
+	// Unmapped values (including inherited TERM_PROGRAM=vscode) stay empty so
+	// the client label stays on the known-app allowlist.
+	return ""
 }
 
 // fallbackTerminalName is used when TERM_PROGRAM is missing or is the inherited

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -13,6 +13,46 @@ import (
 // metric cardinality bounded.
 const AgentUnknown = "unknown"
 
+// Canonical wire names reused as detector names, alias targets, and host-client
+// results. One-off table keys stay string literals.
+const (
+	NameAlacritty       = "alacritty"
+	NameAmazonQ         = "amazon_q"
+	NameAntigravity     = "antigravity"
+	NameClaude          = "claude"
+	NameCodium          = "codium"
+	NameCopilot         = "copilot"
+	NameCursor          = "cursor"
+	NameGemini          = "gemini"
+	NameGhostty         = "ghostty"
+	NameGrok            = "grok"
+	NameHyper           = "hyper"
+	NameIterm           = "iterm"
+	NameJetBrains       = "jetbrains"
+	NameKitty           = "kitty"
+	NameQwen            = "qwen"
+	NameRooCode         = "roo_code"
+	NameTerminal        = "terminal"
+	NameTmux            = "tmux"
+	NameTrae            = "trae"
+	NameVisualStudio    = "visualstudio"
+	NameVSCode          = "vscode"
+	NameWarp            = "warp"
+	NameWezterm         = "wezterm"
+	NameWindsurf        = "windsurf"
+	NameWindowsTerminal = "windows-terminal"
+	NameZed             = "zed"
+
+	EnvAIAgent              = "AI_AGENT"
+	EnvCopilotAgent         = "COPILOT_AGENT"
+	EnvCursorTraceID        = "CURSOR_TRACE_ID"
+	EnvVSCodeGitAskpassMain = "VSCODE_GIT_ASKPASS_MAIN"
+	EnvVSCodeGitAskpassNode = "VSCODE_GIT_ASKPASS_NODE"
+	EnvVisualStudioVersion  = "VisualStudioVersion"
+
+	AliasGitHubCopilotVSCodeAgent = "github_copilot_vscode_agent"
+)
+
 // ExecutionContext describes how a CLI invocation was launched.
 // AI stack (agent sessions only): Client → Agent → Model.
 type ExecutionContext struct {
@@ -24,9 +64,10 @@ type ExecutionContext struct {
 	TraceID       string // e.g. CURSOR_TRACE_ID; empty if none
 
 	// Client: app hosting the agent session. Prefer a known IDE ("cursor",
-	// "vscode", "zed", "jetbrains", "windsurf", "antigravity"), then a known
-	// agent app ("claude"), then a short terminal name from TERM_PROGRAM
-	// ("iterm", "warp", "terminal", "tmux"). Empty when unknown.
+	// "vscode", "zed", "jetbrains", "windsurf", "antigravity", "codium",
+	// "trae", "visualstudio"), then a known agent app ("claude"), then a
+	// short terminal name ("iterm", "warp", "terminal", "tmux",
+	// "windows-terminal"). Empty when unknown.
 	Client string
 
 	// Model: model slug (JFROG_CLI_AI_MODEL) — "opus-4.7".
@@ -80,32 +121,32 @@ type agentDetector struct {
 // Model axis: sanitized JFROG_CLI_AI_MODEL (skill/user supplied slug).
 var agentEnvDetectors = []agentDetector{
 	// GROK_AGENT is also a profile *path* for humans — exact "1" only.
-	{"grok", nil, map[string]string{"GROK_AGENT": "1"}, nil},
+	{NameGrok, nil, map[string]string{"GROK_AGENT": "1"}, nil},
 	// Cowork before generic Claude: same wire name, no extra pie slice.
-	{"claude", []string{"CLAUDE_CODE_IS_COWORK"}, nil, nil},
+	{NameClaude, []string{"CLAUDE_CODE_IS_COWORK"}, nil, nil},
 	// CLAUDE_CODE_CHILD_SESSION is set only on tool/hook/status-line spawns
 	// (Anthropic docs). CLAUDECODE / CLAUDE_CODE / CLAUDE_CODE_ENTRYPOINT are
 	// omitted: IDE extensions also set them in integrated terminals (humans).
-	{"claude", []string{"CLAUDE_CODE_CHILD_SESSION"}, nil, nil},
-	{"gemini", []string{"GEMINI_CLI"}, nil, nil},
+	{NameClaude, []string{"CLAUDE_CODE_CHILD_SESSION"}, nil, nil},
+	{NameGemini, []string{"GEMINI_CLI"}, nil, nil},
 	{"goose", []string{"GOOSE_TERMINAL"}, nil, nil},
 	// CURSOR_AGENT is Cursor's documented agent-session marker (live-verified).
 	// CURSOR_EXTENSION_HOST_ROLE=agent-exec is the agent-exec extension host.
 	// CURSOR_TRACE_ID / CURSOR_CLI are omitted: set for Cursor integrated
 	// terminals (humans too). TRACE_ID is still read for correlation after a
 	// strong cursor hit — see detectAgentTraceID.
-	{"cursor", []string{"CURSOR_AGENT"}, map[string]string{"CURSOR_EXTENSION_HOST_ROLE": "agent-exec"}, nil},
+	{NameCursor, []string{"CURSOR_AGENT"}, map[string]string{"CURSOR_EXTENSION_HOST_ROLE": "agent-exec"}, nil},
 	// COPILOT_MODEL / COPILOT_ALLOW_ALL are user config flags (GitHub docs),
 	// not exclusive session markers — a human shell can export them.
-	{"copilot", []string{"COPILOT_CLI", "COPILOT_AGENT", "COPILOT_AGENT_JOB_ID", "COPILOT_AGENT_SESSION_ID"}, nil, nil},
+	{NameCopilot, []string{"COPILOT_CLI", EnvCopilotAgent, "COPILOT_AGENT_JOB_ID", "COPILOT_AGENT_SESSION_ID"}, nil, nil},
 	// KILOCODE_FEATURE=cli is the CLI session; KILO_PID and bare/other FEATURE
 	// values fire in the VS Code extension (humans). IPC socket + password are not.
 	{"kilocode", nil, map[string]string{"KILOCODE_FEATURE": "cli"}, nil},
 	// ROO_ACTIVE / ROO_CLI_RUNTIME are session markers; IPC socket path is enablement.
-	{"roo_code", []string{"ROO_ACTIVE", "ROO_CLI_RUNTIME"}, nil, nil},
+	{NameRooCode, []string{"ROO_ACTIVE", "ROO_CLI_RUNTIME"}, nil, nil},
 	{"codex", []string{"CODEX_CI", "CODEX_THREAD_ID", "CODEX_SANDBOX", "CODEX_SANDBOX_NETWORK_DISABLED"}, nil, nil},
 	// Cascade terminal marker; CODEIUM_EDITOR_APP_ROOT is IDE install (false positive).
-	{"windsurf", []string{"WINDSURF_CASCADE_TERMINAL"}, nil, nil},
+	{NameWindsurf, []string{"WINDSURF_CASCADE_TERMINAL"}, nil, nil},
 	// aider has no reliable session env (AIDER_API_KEY is config); AI_AGENT only.
 	{"aider", []string{}, nil, nil},
 	{"cline", []string{"CLINE_ACTIVE"}, nil, nil},
@@ -115,31 +156,31 @@ var agentEnvDetectors = []agentDetector{
 	{"opencode", []string{"OPENCODE", "OPENCODE_SESSION_ID"}, nil, nil},
 	{"amp", []string{"AMP_CURRENT_THREAD_ID"}, nil, nil},
 	{"augment", []string{"AUGMENT_AGENT"}, nil, nil},
-	{"qwen", []string{"QWEN_CODE"}, nil, nil},
-	{"antigravity", []string{"ANTIGRAVITY_AGENT"}, nil, nil},
+	{NameQwen, []string{"QWEN_CODE"}, nil, nil},
+	{NameAntigravity, []string{"ANTIGRAVITY_AGENT"}, nil, nil},
 	{"crush", []string{"CRUSH"}, nil, nil},
 	{"iflow", []string{"IFLOW_CLI"}, nil, nil},
-	{"trae", []string{"TRAE_AI_SHELL_ID"}, nil, nil},
+	{NameTrae, []string{"TRAE_AI_SHELL_ID"}, nil, nil},
 	{"pi", []string{"PI_CODING_AGENT"}, nil, nil},
-	{"amazon_q", nil, nil, map[string]string{"AWS_EXECUTION_ENV": "AmazonQ-For-CLI"}},
+	{NameAmazonQ, nil, nil, map[string]string{"AWS_EXECUTION_ENV": "AmazonQ-For-CLI"}},
 }
 
 // agentNameAliases maps hyphenated ecosystem spellings (e.g. @vercel/detect-agent)
 // to our wire names. Identity entries for table names are not needed — see
 // agentCanonical.
 var agentNameAliases = map[string]string{
-	"claude-code":                 "claude",
-	"gemini-cli":                  "gemini",
-	"cursor-cli":                  "cursor",
-	"github-copilot":              "copilot",
-	"copilot-cli":                 "copilot",
-	"roo-code":                    "roo_code",
-	"amazon-q-cli":                "amazon_q",
-	"amazon-q":                    "amazon_q",
-	"qwen-code":                   "qwen",
-	"github_copilot_vscode_agent": "copilot",
-	"grok-cli":                    "grok",
-	"grok-build":                  "grok",
+	"claude-code":                 NameClaude,
+	"gemini-cli":                  NameGemini,
+	"cursor-cli":                  NameCursor,
+	"github-copilot":              NameCopilot,
+	"copilot-cli":                 NameCopilot,
+	"roo-code":                    NameRooCode,
+	"amazon-q-cli":                NameAmazonQ,
+	"amazon-q":                    NameAmazonQ,
+	"qwen-code":                   NameQwen,
+	AliasGitHubCopilotVSCodeAgent: NameCopilot,
+	"grok-cli":                    NameGrok,
+	"grok-build":                  NameGrok,
 }
 
 // agentCanonical is the AI_AGENT/AGENT lookup: every detector name, every alias,
@@ -215,16 +256,19 @@ func detectModel() string {
 // Cursor and VS Code. If no IDE is proven, a known standalone app wins, then
 // TERM_PROGRAM is mapped to a short product name the same way IDEs are.
 //
-// | Client      | Host-owned signal                                          |
-// |-------------|------------------------------------------------------------|
-// | zed         | ZED_TERM                                                   |
-// | jetbrains   | TERMINAL_EMULATOR=JetBrains-JediTerm                       |
-// | cursor      | CURSOR_TRACE_ID, agent=cursor, or "cursor" askpass path    |
-// | windsurf    | agent=windsurf or "windsurf" askpass path                  |
-// | antigravity | agent=antigravity or "antigravity" askpass path            |
-// | vscode      | Copilot plugin markers, or stock VS Code askpass           |
-// | claude      | agent=claude after IDE checks                              |
-// | iterm/warp/…| canonical TERM_PROGRAM (iterm.app→iterm, WarpTerminal→warp)|
+// | Client          | Host-owned signal                                              |
+// |-----------------|----------------------------------------------------------------|
+// | zed             | ZED_TERM                                                       |
+// | jetbrains       | TERMINAL_EMULATOR=JetBrains-JediTerm                           |
+// | cursor          | CURSOR_TRACE_ID, agent=cursor, or Cursor.app /cursor/resources |
+// | windsurf        | agent=windsurf or Windsurf.app /windsurf/resources             |
+// | antigravity     | agent=antigravity or Antigravity.app /antigravity/resources    |
+// | trae            | agent=trae or Trae.app /trae/resources                         |
+// | codium          | VSCodium.app /vscodium/resources or /codium/resources          |
+// | visualstudio    | VisualStudioVersion (desktop VS, not VS Code)                  |
+// | vscode          | Copilot plugin markers, or stock VS Code askpass               |
+// | claude          | agent=claude after IDE checks                                  |
+// | iterm/warp/…    | TERM_PROGRAM, else TMUX / WT_SESSION / TERM=xterm-ghostty      |
 //
 // Order is significant: every VS Code fork inherits TERM_PROGRAM=vscode and the
 // VSCODE_* vars from upstream, so forks must resolve before anything reports
@@ -232,47 +276,58 @@ func detectModel() string {
 //
 // JetBrains publishes one terminal value for the whole family, so IntelliJ,
 // GoLand and PyCharm collapse to "jetbrains"; separating them would need a
-// parent-process walk on every command.
+// parent-process walk on every command. Do not split the family via macOS
+// bundle IDs (peers that do that also mis-label JediTerm as PyCharm).
 func detectClient(agent string) string {
 	switch {
 	case os.Getenv("ZED_TERM") != "":
-		return "zed"
+		return NameZed
 	case os.Getenv("TERMINAL_EMULATOR") == "JetBrains-JediTerm":
-		return "jetbrains"
-	case agent == "cursor", os.Getenv("CURSOR_TRACE_ID") != "", askpassPathContains("cursor"):
-		return "cursor"
-	case agent == "windsurf", askpassPathContains("windsurf"):
-		return "windsurf"
-	case agent == "antigravity", askpassPathContains("antigravity"):
-		return "antigravity"
-	case os.Getenv("COPILOT_AGENT") == "1", os.Getenv("AI_AGENT") == "github_copilot_vscode_agent":
+		return NameJetBrains
+	case agent == NameCursor, os.Getenv(EnvCursorTraceID) != "", askpassPathContains(NameCursor):
+		return NameCursor
+	case agent == NameWindsurf, askpassPathContains(NameWindsurf):
+		return NameWindsurf
+	case agent == NameAntigravity, askpassPathContains(NameAntigravity):
+		return NameAntigravity
+	case agent == NameTrae, askpassPathContains(NameTrae):
+		return NameTrae
+	case askpassPathContains("vscodium"), askpassPathContains(NameCodium):
+		return NameCodium
+	case os.Getenv(EnvVisualStudioVersion) != "":
+		return NameVisualStudio
+	case os.Getenv(EnvCopilotAgent) == "1", os.Getenv(EnvAIAgent) == AliasGitHubCopilotVSCodeAgent:
 		// Last resort: these prove the first-party plugin, not the window. A
-		// JetBrains host is caught above, so this only fires with no host marker.
-		return "vscode"
-	case os.Getenv("VSCODE_GIT_ASKPASS_MAIN") != "", os.Getenv("VSCODE_GIT_ASKPASS_NODE") != "":
+		// JetBrains or Visual Studio host is caught above, so this only fires
+		// with no host marker.
+		return NameVSCode
+	case os.Getenv(EnvVSCodeGitAskpassMain) != "", os.Getenv(EnvVSCodeGitAskpassNode) != "":
 		// Stock VS Code after known forks were ruled out.
-		return "vscode"
-	case agent == "claude":
-		return "claude"
+		return NameVSCode
+	case agent == NameClaude:
+		return NameClaude
 	default:
-		return canonicalTerminalName(os.Getenv("TERM_PROGRAM"))
+		if name := canonicalTerminalName(os.Getenv("TERM_PROGRAM")); name != "" {
+			return name
+		}
+		return fallbackTerminalName()
 	}
 }
 
 // terminalNameAliases maps sanitized TERM_PROGRAM values to short product
 // names, matching the IDE style (cursor, vscode) rather than raw env spellings.
 var terminalNameAliases = map[string]string{
-	"iterm.app":      "iterm",
-	"iterm":          "iterm",
-	"apple_terminal": "terminal",
-	"warpterminal":   "warp",
-	"warp":           "warp",
-	"tmux":           "tmux",
-	"wezterm":        "wezterm",
-	"alacritty":      "alacritty",
-	"kitty":          "kitty",
-	"ghostty":        "ghostty",
-	"hyper":          "hyper",
+	"iterm.app":      NameIterm,
+	NameIterm:        NameIterm,
+	"apple_terminal": NameTerminal,
+	"warpterminal":   NameWarp,
+	NameWarp:         NameWarp,
+	NameTmux:         NameTmux,
+	NameWezterm:      NameWezterm,
+	NameAlacritty:    NameAlacritty,
+	NameKitty:        NameKitty,
+	NameGhostty:      NameGhostty,
+	NameHyper:        NameHyper,
 }
 
 func canonicalTerminalName(raw string) string {
@@ -289,22 +344,50 @@ func canonicalTerminalName(raw string) string {
 	}
 	// TERM_PROGRAM=vscode is inherited by every VS Code fork. Do not treat it
 	// as a proven vscode window — that is how Copilot CLI gets mislabelled.
-	if name == "vscode" {
+	if name == NameVSCode {
 		return ""
 	}
 	return name
 }
 
-// askpassEnvVars hold the path of the editor's git askpass helper, which embeds
-// the application name (…/Cursor.app/…, …/windsurf/…). It is the only env that
-// separates a VS Code fork from upstream, since forks copy the VSCODE_* names
-// verbatim. Generic GIT_ASKPASS is excluded because arbitrary paths can contain
-// an app name without proving the host. Match case-insensitively on a substring.
-var askpassEnvVars = []string{"VSCODE_GIT_ASKPASS_MAIN", "VSCODE_GIT_ASKPASS_NODE"}
+// fallbackTerminalName is used when TERM_PROGRAM is missing or is the inherited
+// vscode value that canonicalTerminalName refuses. These vars name a real app
+// (tmux, Windows Terminal, Ghostty, Kitty, Alacritty) without proving vscode.
+func fallbackTerminalName() string {
+	switch {
+	case os.Getenv("TMUX") != "":
+		return NameTmux
+	case os.Getenv("WT_SESSION") != "":
+		return NameWindowsTerminal
+	case os.Getenv("TERM") == "xterm-ghostty":
+		return NameGhostty
+	case os.Getenv("KITTY_WINDOW_ID") != "":
+		return NameKitty
+	case os.Getenv("ALACRITTY_LOG") != "":
+		return NameAlacritty
+	default:
+		return ""
+	}
+}
 
+// askpassEnvVars hold the path of the editor's git askpass helper, which embeds
+// the application name (…/Cursor.app/…, …/windsurf/resources/…). It is the only
+// env that separates a VS Code fork from upstream, since forks copy the VSCODE_*
+// names verbatim. Generic GIT_ASKPASS is excluded because arbitrary paths can
+// contain an app name without proving the host.
+var askpassEnvVars = []string{EnvVSCodeGitAskpassMain, EnvVSCodeGitAskpassNode}
+
+// askpassPathContains reports whether a VS Code-fork askpass path is that
+// editor's install, not an unrelated substring. A Windows VS Code path lives
+// under the user profile, so a login named "cursor" would otherwise match.
 func askpassPathContains(app string) bool {
+	needle := strings.ToLower(app)
 	for _, env := range askpassEnvVars {
-		if strings.Contains(strings.ToLower(os.Getenv(env)), app) {
+		p := strings.ToLower(strings.ReplaceAll(os.Getenv(env), "\\", "/"))
+		if p == "" {
+			continue
+		}
+		if strings.Contains(p, "/"+needle+".app") || strings.Contains(p, "/"+needle+"/resources") {
 			return true
 		}
 	}
@@ -356,7 +439,7 @@ func detectAgent() string {
 	// the value names the agent. Honor it when recognized; any other non-empty value
 	// collapses to "unknown" so a raw value never reaches metrics and cardinality
 	// stays bounded.
-	if name := canonicalAgentName(os.Getenv("AI_AGENT")); name != "" {
+	if name := canonicalAgentName(os.Getenv(EnvAIAgent)); name != "" {
 		return name
 	}
 	return canonicalAgentName(os.Getenv("AGENT"))
@@ -384,8 +467,8 @@ func canonicalAgentName(raw string) string {
 // (e.g. CURSOR_TRACE_ID present while the actual invoker is Claude Code).
 // Empty result means the CLI should generate its own trace ID.
 func detectAgentTraceID(agent string) string {
-	if agent == "cursor" {
-		return os.Getenv("CURSOR_TRACE_ID")
+	if agent == NameCursor {
+		return os.Getenv(EnvCursorTraceID)
 	}
 	return ""
 }

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -48,7 +48,7 @@ const (
 	EnvAlacrittyLog  = "ALACRITTY_LOG"
 	EnvCopilotAgent  = "COPILOT_AGENT"
 	EnvCursorTraceID = "CURSOR_TRACE_ID"
-	//#nosec G101 // False positive: env var name, not a credential.
+	//#nosec G101 jfrog-ignore // False positive: env var name, not a credential.
 	EnvGitAskpass       = "GIT_ASKPASS"
 	EnvJFrogCLIAIModel  = "JFROG_CLI_AI_MODEL"
 	EnvKittyWindowID    = "KITTY_WINDOW_ID"
@@ -56,9 +56,9 @@ const (
 	EnvTerminalEmulator = "TERMINAL_EMULATOR"
 	EnvTermProgram      = "TERM_PROGRAM"
 	EnvTmux             = "TMUX"
-	//#nosec G101 // False positive: env var name, not a credential.
+	//#nosec G101 jfrog-ignore // False positive: env var name, not a credential.
 	EnvVSCodeGitAskpassMain = "VSCODE_GIT_ASKPASS_MAIN"
-	//#nosec G101 // False positive: env var name, not a credential.
+	//#nosec G101 jfrog-ignore // False positive: env var name, not a credential.
 	EnvVSCodeGitAskpassNode = "VSCODE_GIT_ASKPASS_NODE"
 	EnvVisualStudioVersion  = "VisualStudioVersion"
 	EnvWTSession            = "WT_SESSION"
@@ -270,7 +270,7 @@ func computeExecutionContext() ExecutionContext {
 }
 
 func detectModel() string {
-	return sanitizeToken(os.Getenv(EnvJFrogCLIAIModel))
+	return sanitizeWireName(os.Getenv(EnvJFrogCLIAIModel))
 }
 
 // detectClient returns the app hosting an agent session. It starts with
@@ -339,21 +339,21 @@ func detectClient(agent string) string {
 // terminalNameAliases maps sanitized TERM_PROGRAM values to short product
 // names, matching the IDE style (cursor, vscode) rather than raw env spellings.
 var terminalNameAliases = map[string]string{
-	sanitizeToken(TermProgramItermApp): NameIterm,
-	NameIterm:                          NameIterm,
-	sanitizeToken(TermProgramApple):    NameTerminal,
-	sanitizeToken(TermProgramWarp):     NameWarp,
-	NameWarp:                           NameWarp,
-	NameTmux:                           NameTmux,
-	NameWezterm:                        NameWezterm,
-	NameAlacritty:                      NameAlacritty,
-	NameKitty:                          NameKitty,
-	NameGhostty:                        NameGhostty,
-	NameHyper:                          NameHyper,
+	sanitizeWireName(TermProgramItermApp): NameIterm,
+	NameIterm:                             NameIterm,
+	sanitizeWireName(TermProgramApple):    NameTerminal,
+	sanitizeWireName(TermProgramWarp):     NameWarp,
+	NameWarp:                              NameWarp,
+	NameTmux:                              NameTmux,
+	NameWezterm:                           NameWezterm,
+	NameAlacritty:                         NameAlacritty,
+	NameKitty:                             NameKitty,
+	NameGhostty:                           NameGhostty,
+	NameHyper:                             NameHyper,
 }
 
 func canonicalTerminalName(raw string) string {
-	name := sanitizeToken(raw)
+	name := sanitizeWireName(raw)
 	if name == "" {
 		return ""
 	}
@@ -422,13 +422,13 @@ func askpassPathContains(app string) bool {
 	return false
 }
 
-// maxTokenLen caps sanitized identity tokens so a pathological env value cannot
-// inflate User-Agent / metrics payloads. Excess is truncated after filtering.
-const maxTokenLen = 64
+// maxWireNameLen caps client/model/terminal names so a pathological env value
+// cannot inflate User-Agent / metrics payloads. Excess is truncated after filtering.
+const maxWireNameLen = 64
 
-// sanitizeToken lowercases s and keeps only [a-z0-9._-], bounding cardinality
+// sanitizeWireName lowercases s and keeps only [a-z0-9._-], bounding cardinality
 // and guaranteeing no header-splitting sequence can reach the wire.
-func sanitizeToken(s string) string {
+func sanitizeWireName(s string) string {
 	s = strings.Map(func(r rune) rune {
 		switch {
 		case r >= 'A' && r <= 'Z':
@@ -439,8 +439,8 @@ func sanitizeToken(s string) string {
 			return -1
 		}
 	}, strings.TrimSpace(s))
-	if len(s) > maxTokenLen {
-		return s[:maxTokenLen]
+	if len(s) > maxWireNameLen {
+		return s[:maxWireNameLen]
 	}
 	return s
 }
@@ -473,9 +473,9 @@ func detectAgent() string {
 	return canonicalAgentName(os.Getenv(EnvAgent))
 }
 
-// foldAgentToken lowercases and trims a generic AI_AGENT/AGENT value and
+// foldAgentName lowercases and trims a generic AI_AGENT/AGENT value and
 // strips a version suffix (e.g. "goose@1.2.3"). Empty input stays empty.
-func foldAgentToken(raw string) string {
+func foldAgentName(raw string) string {
 	name := strings.ToLower(strings.TrimSpace(raw))
 	if name == "" {
 		return ""
@@ -491,14 +491,14 @@ func foldAgentToken(raw string) string {
 // canonicalAgentName here: that also maps copilot / copilot-cli, which are
 // the CLI and must not force client=vscode.
 func isCopilotVSCodePluginAlias() bool {
-	return foldAgentToken(os.Getenv(EnvAIAgent)) == AliasGitHubCopilotVSCodeAgent ||
-		foldAgentToken(os.Getenv(EnvAgent)) == AliasGitHubCopilotVSCodeAgent
+	return foldAgentName(os.Getenv(EnvAIAgent)) == AliasGitHubCopilotVSCodeAgent ||
+		foldAgentName(os.Getenv(EnvAgent)) == AliasGitHubCopilotVSCodeAgent
 }
 
 // canonicalAgentName maps a generic AI_AGENT/AGENT value to a wire name.
 // Returns "" for empty, a table/alias name when recognized, else AgentUnknown.
 func canonicalAgentName(raw string) string {
-	name := foldAgentToken(raw)
+	name := foldAgentName(raw)
 	if name == "" {
 		return ""
 	}

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -14,65 +14,66 @@ import (
 const AgentUnknown = "unknown"
 
 // Canonical wire names reused as detector names, alias targets, and host-client
-// results. One-off table keys stay string literals.
+// results. Unexported: same-package tests do not need a public API.
+// One-off table keys stay string literals.
 const (
-	NameAlacritty       = "alacritty"
-	NameAmazonQ         = "amazon_q"
-	NameAntigravity     = "antigravity"
-	NameClaude          = "claude"
-	NameCodium          = "codium"
-	NameCopilot         = "copilot"
-	NameCursor          = "cursor"
-	NameGemini          = "gemini"
-	NameGhostty         = "ghostty"
-	NameGrok            = "grok"
-	NameHyper           = "hyper"
-	NameIterm           = "iterm"
-	NameJetBrains       = "jetbrains"
-	NameKitty           = "kitty"
-	NameQwen            = "qwen"
-	NameRooCode         = "roo_code"
-	NameTerminal        = "terminal"
-	NameTmux            = "tmux"
-	NameTrae            = "trae"
-	NameVisualStudio    = "visualstudio"
-	NameVSCode          = "vscode"
-	NameWarp            = "warp"
-	NameWezterm         = "wezterm"
-	NameWindsurf        = "windsurf"
-	NameWindowsTerminal = "windows-terminal"
-	NameZed             = "zed"
+	nameAlacritty       = "alacritty"
+	nameAmazonQ         = "amazon_q"
+	nameAntigravity     = "antigravity"
+	nameClaude          = "claude"
+	nameCodium          = "codium"
+	nameCopilot         = "copilot"
+	nameCursor          = "cursor"
+	nameGemini          = "gemini"
+	nameGhostty         = "ghostty"
+	nameGrok            = "grok"
+	nameHyper           = "hyper"
+	nameIterm           = "iterm"
+	nameJetBrains       = "jetbrains"
+	nameKitty           = "kitty"
+	nameQwen            = "qwen"
+	nameRooCode         = "roo_code"
+	nameTerminal        = "terminal"
+	nameTmux            = "tmux"
+	nameTrae            = "trae"
+	nameVisualStudio    = "visualstudio"
+	nameVSCode          = "vscode"
+	nameWarp            = "warp"
+	nameWezterm         = "wezterm"
+	nameWindsurf        = "windsurf"
+	nameWindowsTerminal = "windows-terminal"
+	nameZed             = "zed"
 
-	EnvAIAgent       = "AI_AGENT"
-	EnvAgent         = "AGENT"
-	EnvAlacrittyLog  = "ALACRITTY_LOG"
-	EnvCopilotAgent  = "COPILOT_AGENT"
-	EnvCursorTraceID = "CURSOR_TRACE_ID"
+	envAIAgent       = "AI_AGENT"
+	envAgent         = "AGENT"
+	envAlacrittyLog  = "ALACRITTY_LOG"
+	envCopilotAgent  = "COPILOT_AGENT"
+	envCursorTraceID = "CURSOR_TRACE_ID"
 	//#nosec G101 jfrog-ignore // False positive: env var name, not a credential.
-	EnvGitAskpass       = "GIT_ASKPASS"
-	EnvJFrogCLIAIModel  = "JFROG_CLI_AI_MODEL"
-	EnvKittyWindowID    = "KITTY_WINDOW_ID"
-	EnvTerm             = "TERM"
-	EnvTerminalEmulator = "TERMINAL_EMULATOR"
-	EnvTermProgram      = "TERM_PROGRAM"
-	EnvTmux             = "TMUX"
+	envGitAskpass       = "GIT_ASKPASS"
+	envJFrogCLIAIModel  = "JFROG_CLI_AI_MODEL"
+	envKittyWindowID    = "KITTY_WINDOW_ID"
+	envTerm             = "TERM"
+	envTerminalEmulator = "TERMINAL_EMULATOR"
+	envTermProgram      = "TERM_PROGRAM"
+	envTmux             = "TMUX"
 	//#nosec G101 jfrog-ignore // False positive: env var name, not a credential.
-	EnvVSCodeGitAskpassMain = "VSCODE_GIT_ASKPASS_MAIN"
+	envVSCodeGitAskpassMain = "VSCODE_GIT_ASKPASS_MAIN"
 	//#nosec G101 jfrog-ignore // False positive: env var name, not a credential.
-	EnvVSCodeGitAskpassNode = "VSCODE_GIT_ASKPASS_NODE"
-	EnvVisualStudioVersion  = "VisualStudioVersion"
-	EnvWTSession            = "WT_SESSION"
-	EnvZedTerm              = "ZED_TERM"
+	envVSCodeGitAskpassNode = "VSCODE_GIT_ASKPASS_NODE"
+	envVisualStudioVersion  = "VisualStudioVersion"
+	envWTSession            = "WT_SESSION"
+	envZedTerm              = "ZED_TERM"
 
 	// OS spellings and exact env values (not wire names).
-	AskpassVSCodium     = "vscodium"
-	JediTerm            = "JetBrains-JediTerm"
-	TermProgramApple    = "Apple_Terminal"
-	TermProgramItermApp = "iTerm.app"
-	TermProgramWarp     = "WarpTerminal"
-	TermXtermGhostty    = "xterm-ghostty"
+	askpassVSCodium     = "vscodium"
+	jediTerm            = "JetBrains-jediTerm"
+	termProgramApple    = "Apple_Terminal"
+	termProgramItermApp = "iTerm.app"
+	termProgramWarp     = "WarpTerminal"
+	termXtermGhostty    = "xterm-ghostty"
 
-	AliasGitHubCopilotVSCodeAgent = "github_copilot_vscode_agent"
+	aliasGitHubCopilotVSCodeAgent = "github_copilot_vscode_agent"
 )
 
 // ExecutionContext describes how a CLI invocation was launched.
@@ -143,32 +144,32 @@ type agentDetector struct {
 // Model axis: sanitized JFROG_CLI_AI_MODEL (skill/user supplied slug).
 var agentEnvDetectors = []agentDetector{
 	// GROK_AGENT is also a profile *path* for humans — exact "1" only.
-	{NameGrok, nil, map[string]string{"GROK_AGENT": "1"}, nil},
+	{nameGrok, nil, map[string]string{"GROK_AGENT": "1"}, nil},
 	// Cowork before generic Claude: same wire name, no extra pie slice.
-	{NameClaude, []string{"CLAUDE_CODE_IS_COWORK"}, nil, nil},
+	{nameClaude, []string{"CLAUDE_CODE_IS_COWORK"}, nil, nil},
 	// CLAUDE_CODE_CHILD_SESSION is set only on tool/hook/status-line spawns
 	// (Anthropic docs). CLAUDECODE / CLAUDE_CODE / CLAUDE_CODE_ENTRYPOINT are
 	// omitted: IDE extensions also set them in integrated terminals (humans).
-	{NameClaude, []string{"CLAUDE_CODE_CHILD_SESSION"}, nil, nil},
-	{NameGemini, []string{"GEMINI_CLI"}, nil, nil},
+	{nameClaude, []string{"CLAUDE_CODE_CHILD_SESSION"}, nil, nil},
+	{nameGemini, []string{"GEMINI_CLI"}, nil, nil},
 	{"goose", []string{"GOOSE_TERMINAL"}, nil, nil},
 	// CURSOR_AGENT is Cursor's documented agent-session marker (live-verified).
 	// CURSOR_EXTENSION_HOST_ROLE=agent-exec is the agent-exec extension host.
 	// CURSOR_TRACE_ID / CURSOR_CLI are omitted: set for Cursor integrated
 	// terminals (humans too). TRACE_ID is still read for correlation after a
 	// strong cursor hit — see detectAgentTraceID.
-	{NameCursor, []string{"CURSOR_AGENT"}, map[string]string{"CURSOR_EXTENSION_HOST_ROLE": "agent-exec"}, nil},
+	{nameCursor, []string{"CURSOR_AGENT"}, map[string]string{"CURSOR_EXTENSION_HOST_ROLE": "agent-exec"}, nil},
 	// COPILOT_MODEL / COPILOT_ALLOW_ALL are user config flags (GitHub docs),
 	// not exclusive session markers — a human shell can export them.
-	{NameCopilot, []string{"COPILOT_CLI", EnvCopilotAgent, "COPILOT_AGENT_JOB_ID", "COPILOT_AGENT_SESSION_ID"}, nil, nil},
+	{nameCopilot, []string{"COPILOT_CLI", envCopilotAgent, "COPILOT_AGENT_JOB_ID", "COPILOT_AGENT_SESSION_ID"}, nil, nil},
 	// KILOCODE_FEATURE=cli is the CLI session; KILO_PID and bare/other FEATURE
 	// values fire in the VS Code extension (humans). IPC socket + password are not.
 	{"kilocode", nil, map[string]string{"KILOCODE_FEATURE": "cli"}, nil},
 	// ROO_ACTIVE / ROO_CLI_RUNTIME are session markers; IPC socket path is enablement.
-	{NameRooCode, []string{"ROO_ACTIVE", "ROO_CLI_RUNTIME"}, nil, nil},
+	{nameRooCode, []string{"ROO_ACTIVE", "ROO_CLI_RUNTIME"}, nil, nil},
 	{"codex", []string{"CODEX_CI", "CODEX_THREAD_ID", "CODEX_SANDBOX", "CODEX_SANDBOX_NETWORK_DISABLED"}, nil, nil},
 	// Cascade terminal marker; CODEIUM_EDITOR_APP_ROOT is IDE install (false positive).
-	{NameWindsurf, []string{"WINDSURF_CASCADE_TERMINAL"}, nil, nil},
+	{nameWindsurf, []string{"WINDSURF_CASCADE_TERMINAL"}, nil, nil},
 	// aider has no reliable session env (AIDER_API_KEY is config); AI_AGENT only.
 	{"aider", []string{}, nil, nil},
 	{"cline", []string{"CLINE_ACTIVE"}, nil, nil},
@@ -178,31 +179,31 @@ var agentEnvDetectors = []agentDetector{
 	{"opencode", []string{"OPENCODE", "OPENCODE_SESSION_ID"}, nil, nil},
 	{"amp", []string{"AMP_CURRENT_THREAD_ID"}, nil, nil},
 	{"augment", []string{"AUGMENT_AGENT"}, nil, nil},
-	{NameQwen, []string{"QWEN_CODE"}, nil, nil},
-	{NameAntigravity, []string{"ANTIGRAVITY_AGENT"}, nil, nil},
+	{nameQwen, []string{"QWEN_CODE"}, nil, nil},
+	{nameAntigravity, []string{"ANTIGRAVITY_AGENT"}, nil, nil},
 	{"crush", []string{"CRUSH"}, nil, nil},
 	{"iflow", []string{"IFLOW_CLI"}, nil, nil},
-	{NameTrae, []string{"TRAE_AI_SHELL_ID"}, nil, nil},
+	{nameTrae, []string{"TRAE_AI_SHELL_ID"}, nil, nil},
 	{"pi", []string{"PI_CODING_AGENT"}, nil, nil},
-	{NameAmazonQ, nil, nil, map[string]string{"AWS_EXECUTION_ENV": "AmazonQ-For-CLI"}},
+	{nameAmazonQ, nil, nil, map[string]string{"AWS_EXECUTION_ENV": "AmazonQ-For-CLI"}},
 }
 
 // agentNameAliases maps hyphenated ecosystem spellings (e.g. @vercel/detect-agent)
 // to our wire names. Identity entries for table names are not needed — see
 // agentCanonical.
 var agentNameAliases = map[string]string{
-	"claude-code":                 NameClaude,
-	"gemini-cli":                  NameGemini,
-	"cursor-cli":                  NameCursor,
-	"github-copilot":              NameCopilot,
-	"copilot-cli":                 NameCopilot,
-	"roo-code":                    NameRooCode,
-	"amazon-q-cli":                NameAmazonQ,
-	"amazon-q":                    NameAmazonQ,
-	"qwen-code":                   NameQwen,
-	AliasGitHubCopilotVSCodeAgent: NameCopilot,
-	"grok-cli":                    NameGrok,
-	"grok-build":                  NameGrok,
+	"claude-code":                 nameClaude,
+	"gemini-cli":                  nameGemini,
+	"cursor-cli":                  nameCursor,
+	"github-copilot":              nameCopilot,
+	"copilot-cli":                 nameCopilot,
+	"roo-code":                    nameRooCode,
+	"amazon-q-cli":                nameAmazonQ,
+	"amazon-q":                    nameAmazonQ,
+	"qwen-code":                   nameQwen,
+	aliasGitHubCopilotVSCodeAgent: nameCopilot,
+	"grok-cli":                    nameGrok,
+	"grok-build":                  nameGrok,
 }
 
 // agentCanonical is the AI_AGENT/AGENT lookup: every detector name, every alias,
@@ -270,7 +271,7 @@ func computeExecutionContext() ExecutionContext {
 }
 
 func detectModel() string {
-	return sanitizeWireName(os.Getenv(EnvJFrogCLIAIModel))
+	return sanitizeWireName(os.Getenv(envJFrogCLIAIModel))
 }
 
 // detectClient returns the app hosting an agent session. It starts with
@@ -281,14 +282,14 @@ func detectModel() string {
 // | Client          | Host-owned signal                                              |
 // |-----------------|----------------------------------------------------------------|
 // | zed             | ZED_TERM                                                       |
-// | jetbrains       | TERMINAL_EMULATOR=JetBrains-JediTerm                           |
-// | cursor          | CURSOR_TRACE_ID, agent=cursor, or Cursor.app /cursor/resources / .cursor-server |
+// | jetbrains       | TERMINAL_EMULATOR=JetBrains-jediTerm                           |
+// | cursor          | CURSOR_TRACE_ID, or Cursor.app /cursor/resources / .cursor-server |
 // | windsurf        | agent=windsurf or Windsurf.app /windsurf/resources / .windsurf-server           |
 // | antigravity     | agent=antigravity or Antigravity.app /antigravity/resources / .antigravity-server |
 // | trae            | agent=trae or Trae.app /trae/resources / .trae-server                           |
 // | codium          | VSCodium.app /vscodium/resources /codium/resources / .vscodium-server            |
 // | visualstudio    | VisualStudioVersion (desktop VS, not VS Code)                  |
-// | vscode          | Copilot plugin markers, or stock VS Code askpass               |
+// | vscode          | stock VS Code askpass, or Copilot plugin with no terminal      |
 // | claude          | agent=claude after IDE checks                                  |
 // | iterm/warp/…    | TERM_PROGRAM, else TMUX / WT_SESSION / TERM=xterm-ghostty      |
 //
@@ -299,57 +300,66 @@ func detectModel() string {
 // JetBrains publishes one terminal value for the whole family, so IntelliJ,
 // GoLand and PyCharm collapse to "jetbrains"; separating them would need a
 // parent-process walk on every command. Do not split the family via macOS
-// bundle IDs (peers that do that also mis-label JediTerm as PyCharm).
+// bundle IDs (peers that do that also mis-label jediTerm as PyCharm).
 func detectClient(agent string) string {
 	switch {
-	case os.Getenv(EnvZedTerm) != "":
-		return NameZed
-	case os.Getenv(EnvTerminalEmulator) == JediTerm:
-		return NameJetBrains
-	case agent == NameCursor, os.Getenv(EnvCursorTraceID) != "", askpassPathContains(NameCursor):
-		return NameCursor
-	case agent == NameWindsurf, askpassPathContains(NameWindsurf):
-		return NameWindsurf
-	case agent == NameAntigravity, askpassPathContains(NameAntigravity):
-		return NameAntigravity
-	case agent == NameTrae, askpassPathContains(NameTrae):
-		return NameTrae
-	case askpassPathContains(AskpassVSCodium), askpassPathContains(NameCodium):
-		return NameCodium
-	case os.Getenv(EnvVisualStudioVersion) != "":
-		return NameVisualStudio
-	case os.Getenv(EnvCopilotAgent) == "1", isCopilotVSCodePluginAlias():
-		// Last resort: these prove the first-party plugin, not the window. A
-		// JetBrains or Visual Studio host is caught above, so this only fires
-		// with no host marker.
-		return NameVSCode
-	case os.Getenv(EnvVSCodeGitAskpassMain) != "", os.Getenv(EnvVSCodeGitAskpassNode) != "":
-		// Stock VS Code after known forks were ruled out.
-		return NameVSCode
-	case agent == NameClaude:
-		return NameClaude
-	default:
-		if name := canonicalTerminalName(os.Getenv(EnvTermProgram)); name != "" {
+	case os.Getenv(envZedTerm) != "":
+		return nameZed
+	case os.Getenv(envTerminalEmulator) == jediTerm:
+		return nameJetBrains
+	case os.Getenv(envCursorTraceID) != "", askpassPathContains(nameCursor):
+		// CURSOR_AGENT does not imply the window: the standalone CLI sets it
+		// in iTerm, stock VS Code, and CI. Trace ID / askpass prove Cursor.
+		return nameCursor
+	case agent == nameWindsurf, askpassPathContains(nameWindsurf):
+		return nameWindsurf
+	case agent == nameAntigravity, askpassPathContains(nameAntigravity):
+		return nameAntigravity
+	case agent == nameTrae, askpassPathContains(nameTrae):
+		return nameTrae
+	case askpassPathContains(askpassVSCodium), askpassPathContains(nameCodium):
+		return nameCodium
+	case os.Getenv(envVisualStudioVersion) != "":
+		return nameVisualStudio
+	case askpassLooksLikeStockVSCode():
+		// Positive VS Code install only. An unrecognized fork (Cursor Nightly.app)
+		// must not fall through as vscode.
+		return nameVSCode
+	case os.Getenv(envCopilotAgent) == "1", isCopilotVSCodePluginAlias():
+		// Plugin markers are not a window. A known terminal wins; vscode is
+		// only the no-terminal fallback (extension-host child with no TERM_PROGRAM).
+		if name := hostTerminalName(); name != "" {
 			return name
 		}
-		return fallbackTerminalName()
+		return nameVSCode
+	case agent == nameClaude:
+		return nameClaude
+	default:
+		return hostTerminalName()
 	}
+}
+
+func hostTerminalName() string {
+	if name := canonicalTerminalName(os.Getenv(envTermProgram)); name != "" {
+		return name
+	}
+	return fallbackTerminalName()
 }
 
 // terminalNameAliases maps sanitized TERM_PROGRAM values to short product
 // names, matching the IDE style (cursor, vscode) rather than raw env spellings.
 var terminalNameAliases = map[string]string{
-	sanitizeWireName(TermProgramItermApp): NameIterm,
-	NameIterm:                             NameIterm,
-	sanitizeWireName(TermProgramApple):    NameTerminal,
-	sanitizeWireName(TermProgramWarp):     NameWarp,
-	NameWarp:                              NameWarp,
-	NameTmux:                              NameTmux,
-	NameWezterm:                           NameWezterm,
-	NameAlacritty:                         NameAlacritty,
-	NameKitty:                             NameKitty,
-	NameGhostty:                           NameGhostty,
-	NameHyper:                             NameHyper,
+	sanitizeWireName(termProgramItermApp): nameIterm,
+	nameIterm:                             nameIterm,
+	sanitizeWireName(termProgramApple):    nameTerminal,
+	sanitizeWireName(termProgramWarp):     nameWarp,
+	nameWarp:                              nameWarp,
+	nameTmux:                              nameTmux,
+	nameWezterm:                           nameWezterm,
+	nameAlacritty:                         nameAlacritty,
+	nameKitty:                             nameKitty,
+	nameGhostty:                           nameGhostty,
+	nameHyper:                             nameHyper,
 }
 
 func canonicalTerminalName(raw string) string {
@@ -366,7 +376,7 @@ func canonicalTerminalName(raw string) string {
 	}
 	// TERM_PROGRAM=vscode is inherited by every VS Code fork. Do not treat it
 	// as a proven vscode window — that is how Copilot CLI gets mislabelled.
-	if name == NameVSCode {
+	if name == nameVSCode {
 		return ""
 	}
 	return name
@@ -377,16 +387,16 @@ func canonicalTerminalName(raw string) string {
 // (tmux, Windows Terminal, Ghostty, Kitty, Alacritty) without proving vscode.
 func fallbackTerminalName() string {
 	switch {
-	case os.Getenv(EnvTmux) != "":
-		return NameTmux
-	case os.Getenv(EnvWTSession) != "":
-		return NameWindowsTerminal
-	case os.Getenv(EnvTerm) == TermXtermGhostty:
-		return NameGhostty
-	case os.Getenv(EnvKittyWindowID) != "":
-		return NameKitty
-	case os.Getenv(EnvAlacrittyLog) != "":
-		return NameAlacritty
+	case os.Getenv(envTmux) != "":
+		return nameTmux
+	case os.Getenv(envWTSession) != "":
+		return nameWindowsTerminal
+	case os.Getenv(envTerm) == termXtermGhostty:
+		return nameGhostty
+	case os.Getenv(envKittyWindowID) != "":
+		return nameKitty
+	case os.Getenv(envAlacrittyLog) != "":
+		return nameAlacritty
 	default:
 		return ""
 	}
@@ -397,7 +407,7 @@ func fallbackTerminalName() string {
 // env that separates a VS Code fork from upstream, since forks copy the VSCODE_*
 // names verbatim. Generic GIT_ASKPASS is excluded because arbitrary paths can
 // contain an app name without proving the host.
-var askpassEnvVars = []string{EnvVSCodeGitAskpassMain, EnvVSCodeGitAskpassNode}
+var askpassEnvVars = []string{envVSCodeGitAskpassMain, envVSCodeGitAskpassNode}
 
 // askpassPathContains reports whether a VS Code-fork askpass path is that
 // editor's install, not an unrelated substring. A Windows VS Code path lives
@@ -416,6 +426,24 @@ func askpassPathContains(app string) bool {
 			// Remote-SSH installs live under ~/.cursor-server (and the same
 			// .*-server layout on other VS Code forks).
 			strings.Contains(p, "/."+needle+"-server") {
+			return true
+		}
+	}
+	return false
+}
+
+// askpassLooksLikeStockVSCode reports a proven upstream VS Code install, not
+// merely a non-empty VSCODE_GIT_ASKPASS_* var (every fork sets those).
+func askpassLooksLikeStockVSCode() bool {
+	for _, env := range askpassEnvVars {
+		p := strings.ToLower(strings.ReplaceAll(os.Getenv(env), "\\", "/"))
+		if p == "" {
+			continue
+		}
+		if strings.Contains(p, "/visual studio code") ||
+			strings.Contains(p, "/microsoft vs code") ||
+			strings.Contains(p, "/.vscode-server") ||
+			strings.Contains(p, "/code/resources") {
 			return true
 		}
 	}
@@ -467,10 +495,10 @@ func detectAgent() string {
 	// the value names the agent. Honor it when recognized; any other non-empty value
 	// collapses to "unknown" so a raw value never reaches metrics and cardinality
 	// stays bounded.
-	if name := canonicalAgentName(os.Getenv(EnvAIAgent)); name != "" {
+	if name := canonicalAgentName(os.Getenv(envAIAgent)); name != "" {
 		return name
 	}
-	return canonicalAgentName(os.Getenv(EnvAgent))
+	return canonicalAgentName(os.Getenv(envAgent))
 }
 
 // foldAgentName lowercases and trims a generic AI_AGENT/AGENT value and
@@ -491,8 +519,8 @@ func foldAgentName(raw string) string {
 // canonicalAgentName here: that also maps copilot / copilot-cli, which are
 // the CLI and must not force client=vscode.
 func isCopilotVSCodePluginAlias() bool {
-	return foldAgentName(os.Getenv(EnvAIAgent)) == AliasGitHubCopilotVSCodeAgent ||
-		foldAgentName(os.Getenv(EnvAgent)) == AliasGitHubCopilotVSCodeAgent
+	return foldAgentName(os.Getenv(envAIAgent)) == aliasGitHubCopilotVSCodeAgent ||
+		foldAgentName(os.Getenv(envAgent)) == aliasGitHubCopilotVSCodeAgent
 }
 
 // canonicalAgentName maps a generic AI_AGENT/AGENT value to a wire name.
@@ -513,8 +541,8 @@ func canonicalAgentName(raw string) string {
 // (e.g. CURSOR_TRACE_ID present while the actual invoker is Claude Code).
 // Empty result means the CLI should generate its own trace ID.
 func detectAgentTraceID(agent string) string {
-	if agent == NameCursor {
-		return os.Getenv(EnvCursorTraceID)
+	if agent == nameCursor {
+		return os.Getenv(envCursorTraceID)
 	}
 	return ""
 }

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -43,19 +43,22 @@ const (
 	NameWindowsTerminal = "windows-terminal"
 	NameZed             = "zed"
 
-	EnvAIAgent              = "AI_AGENT"
-	EnvAgent                = "AGENT"
-	EnvAlacrittyLog         = "ALACRITTY_LOG"
-	EnvCopilotAgent         = "COPILOT_AGENT"
-	EnvCursorTraceID        = "CURSOR_TRACE_ID"
-	EnvGitAskpass           = "GIT_ASKPASS"
-	EnvJFrogCLIAIModel      = "JFROG_CLI_AI_MODEL"
-	EnvKittyWindowID        = "KITTY_WINDOW_ID"
-	EnvTerm                 = "TERM"
-	EnvTerminalEmulator     = "TERMINAL_EMULATOR"
-	EnvTermProgram          = "TERM_PROGRAM"
-	EnvTmux                 = "TMUX"
+	EnvAIAgent       = "AI_AGENT"
+	EnvAgent         = "AGENT"
+	EnvAlacrittyLog  = "ALACRITTY_LOG"
+	EnvCopilotAgent  = "COPILOT_AGENT"
+	EnvCursorTraceID = "CURSOR_TRACE_ID"
+	//#nosec G101 // False positive: env var name, not a credential.
+	EnvGitAskpass       = "GIT_ASKPASS"
+	EnvJFrogCLIAIModel  = "JFROG_CLI_AI_MODEL"
+	EnvKittyWindowID    = "KITTY_WINDOW_ID"
+	EnvTerm             = "TERM"
+	EnvTerminalEmulator = "TERMINAL_EMULATOR"
+	EnvTermProgram      = "TERM_PROGRAM"
+	EnvTmux             = "TMUX"
+	//#nosec G101 // False positive: env var name, not a credential.
 	EnvVSCodeGitAskpassMain = "VSCODE_GIT_ASKPASS_MAIN"
+	//#nosec G101 // False positive: env var name, not a credential.
 	EnvVSCodeGitAskpassNode = "VSCODE_GIT_ASKPASS_NODE"
 	EnvVisualStudioVersion  = "VisualStudioVersion"
 	EnvWTSession            = "WT_SESSION"
@@ -279,11 +282,11 @@ func detectModel() string {
 // |-----------------|----------------------------------------------------------------|
 // | zed             | ZED_TERM                                                       |
 // | jetbrains       | TERMINAL_EMULATOR=JetBrains-JediTerm                           |
-// | cursor          | CURSOR_TRACE_ID, agent=cursor, or Cursor.app /cursor/resources |
-// | windsurf        | agent=windsurf or Windsurf.app /windsurf/resources             |
-// | antigravity     | agent=antigravity or Antigravity.app /antigravity/resources    |
-// | trae            | agent=trae or Trae.app /trae/resources                         |
-// | codium          | VSCodium.app /vscodium/resources or /codium/resources          |
+// | cursor          | CURSOR_TRACE_ID, agent=cursor, or Cursor.app /cursor/resources / .cursor-server |
+// | windsurf        | agent=windsurf or Windsurf.app /windsurf/resources / .windsurf-server           |
+// | antigravity     | agent=antigravity or Antigravity.app /antigravity/resources / .antigravity-server |
+// | trae            | agent=trae or Trae.app /trae/resources / .trae-server                           |
+// | codium          | VSCodium.app /vscodium/resources /codium/resources / .vscodium-server            |
 // | visualstudio    | VisualStudioVersion (desktop VS, not VS Code)                  |
 // | vscode          | Copilot plugin markers, or stock VS Code askpass               |
 // | claude          | agent=claude after IDE checks                                  |
@@ -315,7 +318,7 @@ func detectClient(agent string) string {
 		return NameCodium
 	case os.Getenv(EnvVisualStudioVersion) != "":
 		return NameVisualStudio
-	case os.Getenv(EnvCopilotAgent) == "1", os.Getenv(EnvAIAgent) == AliasGitHubCopilotVSCodeAgent:
+	case os.Getenv(EnvCopilotAgent) == "1", isCopilotVSCodePluginAlias():
 		// Last resort: these prove the first-party plugin, not the window. A
 		// JetBrains or Visual Studio host is caught above, so this only fires
 		// with no host marker.
@@ -399,6 +402,8 @@ var askpassEnvVars = []string{EnvVSCodeGitAskpassMain, EnvVSCodeGitAskpassNode}
 // askpassPathContains reports whether a VS Code-fork askpass path is that
 // editor's install, not an unrelated substring. A Windows VS Code path lives
 // under the user profile, so a login named "cursor" would otherwise match.
+// Remote-SSH installs use ~/.cursor-server (and the same .*-server layout
+// on other forks); those must not fall through to client=vscode.
 func askpassPathContains(app string) bool {
 	needle := strings.ToLower(app)
 	for _, env := range askpassEnvVars {
@@ -406,7 +411,11 @@ func askpassPathContains(app string) bool {
 		if p == "" {
 			continue
 		}
-		if strings.Contains(p, "/"+needle+".app") || strings.Contains(p, "/"+needle+"/resources") {
+		if strings.Contains(p, "/"+needle+".app") ||
+			strings.Contains(p, "/"+needle+"/resources") ||
+			// Remote-SSH installs live under ~/.cursor-server (and the same
+			// .*-server layout on other VS Code forks).
+			strings.Contains(p, "/."+needle+"-server") {
 			return true
 		}
 	}
@@ -464,16 +473,34 @@ func detectAgent() string {
 	return canonicalAgentName(os.Getenv(EnvAgent))
 }
 
-// canonicalAgentName maps a generic AI_AGENT/AGENT value to a wire name.
-// Returns "" for empty, a table/alias name when recognized, else AgentUnknown.
-func canonicalAgentName(raw string) string {
+// foldAgentToken lowercases and trims a generic AI_AGENT/AGENT value and
+// strips a version suffix (e.g. "goose@1.2.3"). Empty input stays empty.
+func foldAgentToken(raw string) string {
 	name := strings.ToLower(strings.TrimSpace(raw))
 	if name == "" {
 		return ""
 	}
-	// Strip a version suffix, e.g. "goose@1.2.3".
 	if i := strings.IndexByte(name, '@'); i >= 0 {
 		name = name[:i]
+	}
+	return name
+}
+
+// isCopilotVSCodePluginAlias reports the github_copilot_vscode_agent spelling
+// on AI_AGENT or AGENT after the same fold detectAgent uses. Do not reuse
+// canonicalAgentName here: that also maps copilot / copilot-cli, which are
+// the CLI and must not force client=vscode.
+func isCopilotVSCodePluginAlias() bool {
+	return foldAgentToken(os.Getenv(EnvAIAgent)) == AliasGitHubCopilotVSCodeAgent ||
+		foldAgentToken(os.Getenv(EnvAgent)) == AliasGitHubCopilotVSCodeAgent
+}
+
+// canonicalAgentName maps a generic AI_AGENT/AGENT value to a wire name.
+// Returns "" for empty, a table/alias name when recognized, else AgentUnknown.
+func canonicalAgentName(raw string) string {
+	name := foldAgentToken(raw)
+	if name == "" {
+		return ""
 	}
 	if mapped, ok := agentCanonical[name]; ok {
 		return mapped

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -23,10 +23,10 @@ type ExecutionContext struct {
 	IsInteractive bool   // stdout is a TTY
 	TraceID       string // e.g. CURSOR_TRACE_ID; empty if none
 
-	// Client: host editor window — "cursor", "vscode", "zed", "jetbrains",
-	// "windsurf", "antigravity". Empty when the session has no editor (Claude
-	// Code TUI, Copilot CLI, Gemini, CI) or when the host cannot be proven.
-	// Never TERM_PROGRAM / a terminal emulator.
+	// Client: app hosting the agent session. Prefer a known IDE ("cursor",
+	// "vscode", "zed", "jetbrains", "windsurf", "antigravity"), then a known
+	// agent app ("claude"), then a short terminal name from TERM_PROGRAM
+	// ("iterm", "warp", "terminal", "tmux"). Empty when unknown.
 	Client string
 
 	// Model: model slug (JFROG_CLI_AI_MODEL) — "opus-4.7".
@@ -76,7 +76,7 @@ type agentDetector struct {
 // | amazon_q    | AWS_EXECUTION_ENV contains AmazonQ-For-CLI                   |
 // | unknown     | AI_AGENT/AGENT set to an unrecognized value                  |
 //
-// Client axis: host editor window, from editor-owned env — see detectClient.
+// Client axis: host app, preferring editor-owned env — see detectClient.
 // Model axis: sanitized JFROG_CLI_AI_MODEL (skill/user supplied slug).
 var agentEnvDetectors = []agentDetector{
 	// GROK_AGENT is also a profile *path* for humans — exact "1" only.
@@ -210,24 +210,25 @@ func detectModel() string {
 	return sanitizeToken(os.Getenv("JFROG_CLI_AI_MODEL"))
 }
 
-// detectClient returns the editor window hosting an agent session. The host is
-// read from env the *editor* owns, not inferred from the agent name: Copilot and
-// Claude both run inside JetBrains, Zed and VS Code, so agent alone cannot name
-// the window.
+// detectClient returns the app hosting an agent session. It starts with
+// editor-owned env because Copilot and Claude can run inside JetBrains, Zed,
+// Cursor and VS Code. If no IDE is proven, a known standalone app wins, then
+// TERM_PROGRAM is mapped to a short product name the same way IDEs are.
 //
 // | Client      | Host-owned signal                                          |
 // |-------------|------------------------------------------------------------|
 // | zed         | ZED_TERM                                                   |
 // | jetbrains   | TERMINAL_EMULATOR=JetBrains-JediTerm                       |
 // | cursor      | CURSOR_TRACE_ID, agent=cursor, or "cursor" askpass path    |
-// | windsurf    | "windsurf" askpass path                                    |
-// | antigravity | "antigravity" askpass path                                 |
+// | windsurf    | agent=windsurf or "windsurf" askpass path                  |
+// | antigravity | agent=antigravity or "antigravity" askpass path            |
 // | vscode      | Copilot plugin markers, or stock VS Code askpass           |
+// | claude      | agent=claude after IDE checks                              |
+// | iterm/warp/…| canonical TERM_PROGRAM (iterm.app→iterm, WarpTerminal→warp)|
 //
 // Order is significant: every VS Code fork inherits TERM_PROGRAM=vscode and the
 // VSCODE_* vars from upstream, so forks must resolve before anything reports
 // "vscode" (product rule P13 — a Cursor session must never be labelled vscode).
-// Unproven hosts omit the axis rather than guess.
 //
 // JetBrains publishes one terminal value for the whole family, so IntelliJ,
 // GoLand and PyCharm collapse to "jetbrains"; separating them would need a
@@ -240,27 +241,66 @@ func detectClient(agent string) string {
 		return "jetbrains"
 	case agent == "cursor", os.Getenv("CURSOR_TRACE_ID") != "", askpassPathContains("cursor"):
 		return "cursor"
-	case askpassPathContains("windsurf"):
+	case agent == "windsurf", askpassPathContains("windsurf"):
 		return "windsurf"
-	case askpassPathContains("antigravity"):
+	case agent == "antigravity", askpassPathContains("antigravity"):
 		return "antigravity"
 	case os.Getenv("COPILOT_AGENT") == "1", os.Getenv("AI_AGENT") == "github_copilot_vscode_agent":
 		// Last resort: these prove the first-party plugin, not the window. A
 		// JetBrains host is caught above, so this only fires with no host marker.
 		return "vscode"
 	case os.Getenv("VSCODE_GIT_ASKPASS_MAIN") != "", os.Getenv("VSCODE_GIT_ASKPASS_NODE") != "":
-		// Stock VS Code after forks were ruled out. GIT_ASKPASS is generic git.
+		// Stock VS Code after known forks were ruled out.
 		return "vscode"
+	case agent == "claude":
+		return "claude"
 	default:
+		return canonicalTerminalName(os.Getenv("TERM_PROGRAM"))
+	}
+}
+
+// terminalNameAliases maps sanitized TERM_PROGRAM values to short product
+// names, matching the IDE style (cursor, vscode) rather than raw env spellings.
+var terminalNameAliases = map[string]string{
+	"iterm.app":      "iterm",
+	"iterm":          "iterm",
+	"apple_terminal": "terminal",
+	"warpterminal":   "warp",
+	"warp":           "warp",
+	"tmux":           "tmux",
+	"wezterm":        "wezterm",
+	"alacritty":      "alacritty",
+	"kitty":          "kitty",
+	"ghostty":        "ghostty",
+	"hyper":          "hyper",
+}
+
+func canonicalTerminalName(raw string) string {
+	name := sanitizeToken(raw)
+	if name == "" {
 		return ""
 	}
+	if mapped, ok := terminalNameAliases[name]; ok {
+		return mapped
+	}
+	name = strings.TrimSuffix(name, ".app")
+	if mapped, ok := terminalNameAliases[name]; ok {
+		return mapped
+	}
+	// TERM_PROGRAM=vscode is inherited by every VS Code fork. Do not treat it
+	// as a proven vscode window — that is how Copilot CLI gets mislabelled.
+	if name == "vscode" {
+		return ""
+	}
+	return name
 }
 
 // askpassEnvVars hold the path of the editor's git askpass helper, which embeds
 // the application name (…/Cursor.app/…, …/windsurf/…). It is the only env that
 // separates a VS Code fork from upstream, since forks copy the VSCODE_* names
-// verbatim. Path-shaped, so match case-insensitively on a substring.
-var askpassEnvVars = []string{"VSCODE_GIT_ASKPASS_MAIN", "VSCODE_GIT_ASKPASS_NODE", "GIT_ASKPASS"}
+// verbatim. Generic GIT_ASKPASS is excluded because arbitrary paths can contain
+// an app name without proving the host. Match case-insensitively on a substring.
+var askpassEnvVars = []string{"VSCODE_GIT_ASKPASS_MAIN", "VSCODE_GIT_ASKPASS_NODE"}
 
 func askpassPathContains(app string) bool {
 	for _, env := range askpassEnvVars {

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -44,11 +44,30 @@ const (
 	NameZed             = "zed"
 
 	EnvAIAgent              = "AI_AGENT"
+	EnvAgent                = "AGENT"
+	EnvAlacrittyLog         = "ALACRITTY_LOG"
 	EnvCopilotAgent         = "COPILOT_AGENT"
 	EnvCursorTraceID        = "CURSOR_TRACE_ID"
+	EnvGitAskpass           = "GIT_ASKPASS"
+	EnvJFrogCLIAIModel      = "JFROG_CLI_AI_MODEL"
+	EnvKittyWindowID        = "KITTY_WINDOW_ID"
+	EnvTerm                 = "TERM"
+	EnvTerminalEmulator     = "TERMINAL_EMULATOR"
+	EnvTermProgram          = "TERM_PROGRAM"
+	EnvTmux                 = "TMUX"
 	EnvVSCodeGitAskpassMain = "VSCODE_GIT_ASKPASS_MAIN"
 	EnvVSCodeGitAskpassNode = "VSCODE_GIT_ASKPASS_NODE"
 	EnvVisualStudioVersion  = "VisualStudioVersion"
+	EnvWTSession            = "WT_SESSION"
+	EnvZedTerm              = "ZED_TERM"
+
+	// OS spellings and exact env values (not wire names).
+	AskpassVSCodium     = "vscodium"
+	JediTerm            = "JetBrains-JediTerm"
+	TermProgramApple    = "Apple_Terminal"
+	TermProgramItermApp = "iTerm.app"
+	TermProgramWarp     = "WarpTerminal"
+	TermXtermGhostty    = "xterm-ghostty"
 
 	AliasGitHubCopilotVSCodeAgent = "github_copilot_vscode_agent"
 )
@@ -248,7 +267,7 @@ func computeExecutionContext() ExecutionContext {
 }
 
 func detectModel() string {
-	return sanitizeToken(os.Getenv("JFROG_CLI_AI_MODEL"))
+	return sanitizeToken(os.Getenv(EnvJFrogCLIAIModel))
 }
 
 // detectClient returns the app hosting an agent session. It starts with
@@ -280,9 +299,9 @@ func detectModel() string {
 // bundle IDs (peers that do that also mis-label JediTerm as PyCharm).
 func detectClient(agent string) string {
 	switch {
-	case os.Getenv("ZED_TERM") != "":
+	case os.Getenv(EnvZedTerm) != "":
 		return NameZed
-	case os.Getenv("TERMINAL_EMULATOR") == "JetBrains-JediTerm":
+	case os.Getenv(EnvTerminalEmulator) == JediTerm:
 		return NameJetBrains
 	case agent == NameCursor, os.Getenv(EnvCursorTraceID) != "", askpassPathContains(NameCursor):
 		return NameCursor
@@ -292,7 +311,7 @@ func detectClient(agent string) string {
 		return NameAntigravity
 	case agent == NameTrae, askpassPathContains(NameTrae):
 		return NameTrae
-	case askpassPathContains("vscodium"), askpassPathContains(NameCodium):
+	case askpassPathContains(AskpassVSCodium), askpassPathContains(NameCodium):
 		return NameCodium
 	case os.Getenv(EnvVisualStudioVersion) != "":
 		return NameVisualStudio
@@ -307,7 +326,7 @@ func detectClient(agent string) string {
 	case agent == NameClaude:
 		return NameClaude
 	default:
-		if name := canonicalTerminalName(os.Getenv("TERM_PROGRAM")); name != "" {
+		if name := canonicalTerminalName(os.Getenv(EnvTermProgram)); name != "" {
 			return name
 		}
 		return fallbackTerminalName()
@@ -317,17 +336,17 @@ func detectClient(agent string) string {
 // terminalNameAliases maps sanitized TERM_PROGRAM values to short product
 // names, matching the IDE style (cursor, vscode) rather than raw env spellings.
 var terminalNameAliases = map[string]string{
-	"iterm.app":      NameIterm,
-	NameIterm:        NameIterm,
-	"apple_terminal": NameTerminal,
-	"warpterminal":   NameWarp,
-	NameWarp:         NameWarp,
-	NameTmux:         NameTmux,
-	NameWezterm:      NameWezterm,
-	NameAlacritty:    NameAlacritty,
-	NameKitty:        NameKitty,
-	NameGhostty:      NameGhostty,
-	NameHyper:        NameHyper,
+	sanitizeToken(TermProgramItermApp): NameIterm,
+	NameIterm:                          NameIterm,
+	sanitizeToken(TermProgramApple):    NameTerminal,
+	sanitizeToken(TermProgramWarp):     NameWarp,
+	NameWarp:                           NameWarp,
+	NameTmux:                           NameTmux,
+	NameWezterm:                        NameWezterm,
+	NameAlacritty:                      NameAlacritty,
+	NameKitty:                          NameKitty,
+	NameGhostty:                        NameGhostty,
+	NameHyper:                          NameHyper,
 }
 
 func canonicalTerminalName(raw string) string {
@@ -355,15 +374,15 @@ func canonicalTerminalName(raw string) string {
 // (tmux, Windows Terminal, Ghostty, Kitty, Alacritty) without proving vscode.
 func fallbackTerminalName() string {
 	switch {
-	case os.Getenv("TMUX") != "":
+	case os.Getenv(EnvTmux) != "":
 		return NameTmux
-	case os.Getenv("WT_SESSION") != "":
+	case os.Getenv(EnvWTSession) != "":
 		return NameWindowsTerminal
-	case os.Getenv("TERM") == "xterm-ghostty":
+	case os.Getenv(EnvTerm) == TermXtermGhostty:
 		return NameGhostty
-	case os.Getenv("KITTY_WINDOW_ID") != "":
+	case os.Getenv(EnvKittyWindowID) != "":
 		return NameKitty
-	case os.Getenv("ALACRITTY_LOG") != "":
+	case os.Getenv(EnvAlacrittyLog) != "":
 		return NameAlacritty
 	default:
 		return ""
@@ -442,7 +461,7 @@ func detectAgent() string {
 	if name := canonicalAgentName(os.Getenv(EnvAIAgent)); name != "" {
 		return name
 	}
-	return canonicalAgentName(os.Getenv("AGENT"))
+	return canonicalAgentName(os.Getenv(EnvAgent))
 }
 
 // canonicalAgentName maps a generic AI_AGENT/AGENT value to a wire name.

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -23,7 +23,8 @@ type ExecutionContext struct {
 	IsInteractive bool   // stdout is a TTY
 	TraceID       string // e.g. CURSOR_TRACE_ID; empty if none
 
-	// Client: app hosting the agent (TERM_PROGRAM) — "vscode", "zed", "iterm.app".
+	// Client: IDE host only — "cursor" or "vscode". Empty when there is no IDE
+	// (Claude Code TUI, Copilot CLI, Gemini, …). Never TERM_PROGRAM / a terminal emulator.
 	Client string
 
 	// Model: model slug (JFROG_CLI_AI_MODEL) — "opus-4.7".
@@ -32,11 +33,13 @@ type ExecutionContext struct {
 
 // agentDetector maps an agent name to env signals that prove the agent
 // invoked the CLI. Envs match on any non-empty value; EnvEquals requires an
-// exact value (used when a var is shared with non-agent hosts).
+// exact value (used when a var is shared with non-agent hosts). EnvContains
+// matches when the named env value contains the substring (Amazon Q CLI).
 type agentDetector struct {
-	name      string
-	envs      []string
-	envEquals map[string]string
+	name        string
+	envs        []string
+	envEquals   map[string]string
+	envContains map[string]string
 }
 
 // agentEnvDetectors is the agent detection table. First match wins.
@@ -45,14 +48,17 @@ type agentDetector struct {
 //
 // | Wire name   | Session signals                                              |
 // |-------------|--------------------------------------------------------------|
-// | claude      | CLAUDE_CODE_CHILD_SESSION                                    |
+// | grok        | GROK_AGENT=1                                                 |
+// | claude      | CLAUDE_CODE_IS_COWORK, CLAUDE_CODE_CHILD_SESSION             |
 // | gemini      | GEMINI_CLI                                                   |
 // | goose       | GOOSE_TERMINAL                                               |
 // | cursor      | CURSOR_AGENT, CURSOR_EXTENSION_HOST_ROLE=agent-exec          |
-// | copilot     | COPILOT_CLI, COPILOT_AGENT_SESSION_ID                        |
-// | kilocode    | KILOCODE_FEATURE, KILO_PID                                   |
+// | copilot     | COPILOT_CLI, COPILOT_AGENT, COPILOT_AGENT_JOB_ID,            |
+// |             | COPILOT_AGENT_SESSION_ID                                     |
+// | kilocode    | KILOCODE_FEATURE=cli                                         |
 // | roo_code    | ROO_ACTIVE, ROO_CLI_RUNTIME                                  |
-// | codex       | CODEX_CI, CODEX_THREAD_ID, CODEX_SANDBOX                     |
+// | codex       | CODEX_CI, CODEX_THREAD_ID, CODEX_SANDBOX,                    |
+// |             | CODEX_SANDBOX_NETWORK_DISABLED                               |
 // | windsurf    | WINDSURF_CASCADE_TERMINAL                                    |
 // | aider       | (AI_AGENT/AGENT only)                                        |
 // | cline       | CLINE_ACTIVE                                                 |
@@ -64,63 +70,74 @@ type agentDetector struct {
 // | crush       | CRUSH                                                        |
 // | iflow       | IFLOW_CLI                                                    |
 // | trae        | TRAE_AI_SHELL_ID                                             |
-// | amazon_q    | (AI_AGENT/AGENT only)                                        |
+// | pi          | PI_CODING_AGENT                                              |
+// | amazon_q    | AWS_EXECUTION_ENV contains AmazonQ-For-CLI                   |
 // | unknown     | AI_AGENT/AGENT set to an unrecognized value                  |
 //
-// Client axis: sanitized TERM_PROGRAM (any host app; not an allowlist).
+// Client axis: IDE only (cursor / vscode). Never TERM_PROGRAM.
 // Model axis: sanitized JFROG_CLI_AI_MODEL (skill/user supplied slug).
 var agentEnvDetectors = []agentDetector{
+	// GROK_AGENT is also a profile *path* for humans — exact "1" only.
+	{"grok", nil, map[string]string{"GROK_AGENT": "1"}, nil},
+	// Cowork before generic Claude: same wire name, no extra pie slice.
+	{"claude", []string{"CLAUDE_CODE_IS_COWORK"}, nil, nil},
 	// CLAUDE_CODE_CHILD_SESSION is set only on tool/hook/status-line spawns
 	// (Anthropic docs). CLAUDECODE / CLAUDE_CODE / CLAUDE_CODE_ENTRYPOINT are
 	// omitted: IDE extensions also set them in integrated terminals (humans).
-	{"claude", []string{"CLAUDE_CODE_CHILD_SESSION"}, nil},
-	{"gemini", []string{"GEMINI_CLI"}, nil},
-	{"goose", []string{"GOOSE_TERMINAL"}, nil},
+	{"claude", []string{"CLAUDE_CODE_CHILD_SESSION"}, nil, nil},
+	{"gemini", []string{"GEMINI_CLI"}, nil, nil},
+	{"goose", []string{"GOOSE_TERMINAL"}, nil, nil},
 	// CURSOR_AGENT is Cursor's documented agent-session marker (live-verified).
 	// CURSOR_EXTENSION_HOST_ROLE=agent-exec is the agent-exec extension host.
 	// CURSOR_TRACE_ID / CURSOR_CLI are omitted: set for Cursor integrated
 	// terminals (humans too). TRACE_ID is still read for correlation after a
 	// strong cursor hit — see detectAgentTraceID.
-	{"cursor", []string{"CURSOR_AGENT"}, map[string]string{"CURSOR_EXTENSION_HOST_ROLE": "agent-exec"}},
+	{"cursor", []string{"CURSOR_AGENT"}, map[string]string{"CURSOR_EXTENSION_HOST_ROLE": "agent-exec"}, nil},
 	// COPILOT_MODEL / COPILOT_ALLOW_ALL are user config flags (GitHub docs),
 	// not exclusive session markers — a human shell can export them.
-	{"copilot", []string{"COPILOT_CLI", "COPILOT_AGENT_SESSION_ID"}, nil},
-	// KILOCODE_FEATURE / KILO_PID are session markers; IPC socket + password are not.
-	{"kilocode", []string{"KILOCODE_FEATURE", "KILO_PID"}, nil},
+	{"copilot", []string{"COPILOT_CLI", "COPILOT_AGENT", "COPILOT_AGENT_JOB_ID", "COPILOT_AGENT_SESSION_ID"}, nil, nil},
+	// KILOCODE_FEATURE=cli is the CLI session; KILO_PID and bare/other FEATURE
+	// values fire in the VS Code extension (humans). IPC socket + password are not.
+	{"kilocode", nil, map[string]string{"KILOCODE_FEATURE": "cli"}, nil},
 	// ROO_ACTIVE / ROO_CLI_RUNTIME are session markers; IPC socket path is enablement.
-	{"roo_code", []string{"ROO_ACTIVE", "ROO_CLI_RUNTIME"}, nil},
-	{"codex", []string{"CODEX_CI", "CODEX_THREAD_ID", "CODEX_SANDBOX"}, nil},
+	{"roo_code", []string{"ROO_ACTIVE", "ROO_CLI_RUNTIME"}, nil, nil},
+	{"codex", []string{"CODEX_CI", "CODEX_THREAD_ID", "CODEX_SANDBOX", "CODEX_SANDBOX_NETWORK_DISABLED"}, nil, nil},
 	// Cascade terminal marker; CODEIUM_EDITOR_APP_ROOT is IDE install (false positive).
-	{"windsurf", []string{"WINDSURF_CASCADE_TERMINAL"}, nil},
+	{"windsurf", []string{"WINDSURF_CASCADE_TERMINAL"}, nil, nil},
 	// aider has no reliable session env (AIDER_API_KEY is config); AI_AGENT only.
-	{"aider", []string{}, nil},
-	{"cline", []string{"CLINE_ACTIVE"}, nil},
+	{"aider", []string{}, nil, nil},
+	{"cline", []string{"CLINE_ACTIVE"}, nil, nil},
 	// OPENCODE is the process session marker; OPENCODE_SESSION_ID is injected
 	// into tool/shell child envs. OPENCODE_CLIENT is config (which client UI),
 	// not a session marker — a human shell can export it.
-	{"opencode", []string{"OPENCODE", "OPENCODE_SESSION_ID"}, nil},
-	{"amp", []string{"AMP_CURRENT_THREAD_ID"}, nil},
-	{"augment", []string{"AUGMENT_AGENT"}, nil},
-	{"qwen", []string{"QWEN_CODE"}, nil},
-	{"antigravity", []string{"ANTIGRAVITY_AGENT"}, nil},
-	{"crush", []string{"CRUSH"}, nil},
-	{"iflow", []string{"IFLOW_CLI"}, nil},
-	{"trae", []string{"TRAE_AI_SHELL_ID"}, nil},
+	{"opencode", []string{"OPENCODE", "OPENCODE_SESSION_ID"}, nil, nil},
+	{"amp", []string{"AMP_CURRENT_THREAD_ID"}, nil, nil},
+	{"augment", []string{"AUGMENT_AGENT"}, nil, nil},
+	{"qwen", []string{"QWEN_CODE"}, nil, nil},
+	{"antigravity", []string{"ANTIGRAVITY_AGENT"}, nil, nil},
+	{"crush", []string{"CRUSH"}, nil, nil},
+	{"iflow", []string{"IFLOW_CLI"}, nil, nil},
+	{"trae", []string{"TRAE_AI_SHELL_ID"}, nil, nil},
+	{"pi", []string{"PI_CODING_AGENT"}, nil, nil},
+	{"amazon_q", nil, nil, map[string]string{"AWS_EXECUTION_ENV": "AmazonQ-For-CLI"}},
 }
 
 // agentNameAliases maps hyphenated ecosystem spellings (e.g. @vercel/detect-agent)
 // to our wire names. Identity entries for table names are not needed — see
 // agentCanonical.
 var agentNameAliases = map[string]string{
-	"claude-code":    "claude",
-	"gemini-cli":     "gemini",
-	"cursor-cli":     "cursor",
-	"github-copilot": "copilot",
-	"copilot-cli":    "copilot",
-	"roo-code":       "roo_code",
-	"amazon-q-cli":   "amazon_q",
-	"amazon-q":       "amazon_q",
-	"qwen-code":      "qwen",
+	"claude-code":                 "claude",
+	"gemini-cli":                  "gemini",
+	"cursor-cli":                  "cursor",
+	"github-copilot":              "copilot",
+	"copilot-cli":                 "copilot",
+	"roo-code":                    "roo_code",
+	"amazon-q-cli":                "amazon_q",
+	"amazon-q":                    "amazon_q",
+	"qwen-code":                   "qwen",
+	"github_copilot_vscode_agent": "copilot",
+	"grok-cli":                    "grok",
+	"grok-build":                  "grok",
 }
 
 // agentCanonical is the AI_AGENT/AGENT lookup: every detector name, every alias,
@@ -181,7 +198,7 @@ func computeExecutionContext() ExecutionContext {
 	ec.TraceID = detectAgentTraceID(ec.Agent)
 	// Client/model only for agent sessions (human in VS Code stays unmarked).
 	if ec.IsAgent {
-		ec.Client = detectClient()
+		ec.Client = detectClient(ec.Agent)
 		ec.Model = detectModel()
 	}
 	return ec
@@ -191,8 +208,22 @@ func detectModel() string {
 	return sanitizeToken(os.Getenv("JFROG_CLI_AI_MODEL"))
 }
 
-func detectClient() string {
-	return sanitizeToken(os.Getenv("TERM_PROGRAM"))
+// detectClient returns the IDE host for an agent session. Cursor always
+// reports "cursor" (agent shells often inherit TERM_PROGRAM=vscode). Copilot
+// reports "vscode" only for the first-party VS Code plugin. Every other
+// agent — including Copilot CLI and Claude — omits the axis.
+func detectClient(agent string) string {
+	switch agent {
+	case "cursor":
+		return "cursor"
+	case "copilot":
+		if os.Getenv("COPILOT_AGENT") == "1" || os.Getenv("AI_AGENT") == "github_copilot_vscode_agent" {
+			return "vscode"
+		}
+		return ""
+	default:
+		return ""
+	}
 }
 
 // maxTokenLen caps sanitized identity tokens so a pathological env value cannot
@@ -227,6 +258,11 @@ func detectAgent() string {
 		}
 		for k, v := range d.envEquals {
 			if os.Getenv(k) == v {
+				return d.name
+			}
+		}
+		for k, substr := range d.envContains {
+			if substr != "" && strings.Contains(os.Getenv(k), substr) {
 				return d.name
 			}
 		}

--- a/common/commands/execution_context.go
+++ b/common/commands/execution_context.go
@@ -67,7 +67,7 @@ const (
 
 	// OS spellings and exact env values (not wire names).
 	askpassVSCodium     = "vscodium"
-	jediTerm            = "JetBrains-jediTerm"
+	jediTerm            = "JetBrains-JediTerm"
 	termProgramApple    = "Apple_Terminal"
 	termProgramItermApp = "iTerm.app"
 	termProgramWarp     = "WarpTerminal"
@@ -284,7 +284,7 @@ func detectModel() string {
 // | Client          | Host-owned signal                                              |
 // |-----------------|----------------------------------------------------------------|
 // | zed             | ZED_TERM                                                       |
-// | jetbrains       | TERMINAL_EMULATOR=JetBrains-jediTerm                           |
+// | jetbrains       | TERMINAL_EMULATOR=JetBrains-JediTerm                           |
 // | cursor          | CURSOR_TRACE_ID, or Cursor.app /cursor/resources / .cursor-server |
 // | windsurf        | agent=windsurf or Windsurf.app /windsurf/resources / .windsurf-server           |
 // | antigravity     | agent=antigravity or Antigravity.app /antigravity/resources / .antigravity-server |

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -119,6 +119,12 @@ func TestDetectAgent_CoworkEmitsClaude(t *testing.T) {
 	assert.Equal(t, NameClaude, detectAgent())
 }
 
+func TestDetectAgent_AmazonQUnrelatedExecutionEnv(t *testing.T) {
+	clearAgentEnvVars(t)
+	t.Setenv("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE")
+	assert.Equal(t, "", detectAgent())
+}
+
 func TestDetectAgent_GenericAgentEnvCollapsesToUnknown(t *testing.T) {
 	clearAgentEnvVars(t)
 	t.Setenv(EnvAgent, "some_random_value")
@@ -302,15 +308,24 @@ func TestDetectExecutionContext_ModelSkippedForHuman(t *testing.T) {
 
 func TestSanitizeToken(t *testing.T) {
 	assert.Equal(t, NameVSCode, sanitizeToken(NameVSCode))
-	assert.Equal(t, NameTerminal, canonicalTerminalName(TermProgramApple))
-	assert.Equal(t, NameIterm, canonicalTerminalName("  "+TermProgramItermApp+"  "))
-	assert.Equal(t, NameWarp, canonicalTerminalName(TermProgramWarp))
+	assert.Equal(t, "apple_terminal", sanitizeToken(TermProgramApple))
+	assert.Equal(t, "iterm.app", sanitizeToken("  "+TermProgramItermApp+"  "))
 	assert.Equal(t, "1.2.3-beta", sanitizeToken("1.2.3-beta"))
 	// Header-splitting and stray characters (CR/LF, colon, spaces) are stripped.
 	assert.Equal(t, "xyz", sanitizeToken("x\r\n y: z"))
 	assert.Equal(t, "", sanitizeToken(""))
 	// Pathological env values are truncated so they cannot inflate the wire payload.
 	assert.Equal(t, maxTokenLen, len(sanitizeToken(strings.Repeat("a", maxTokenLen+100))))
+}
+
+func TestCanonicalTerminalName(t *testing.T) {
+	assert.Equal(t, NameTerminal, canonicalTerminalName(TermProgramApple))
+	assert.Equal(t, NameIterm, canonicalTerminalName("  "+TermProgramItermApp+"  "))
+	assert.Equal(t, NameWarp, canonicalTerminalName(TermProgramWarp))
+	assert.Equal(t, NameWezterm, canonicalTerminalName("WezTerm"))
+	assert.Equal(t, NameHyper, canonicalTerminalName("Hyper"))
+	assert.Equal(t, "", canonicalTerminalName(NameVSCode))
+	assert.Equal(t, "foobar", canonicalTerminalName("FooBar.app"))
 }
 
 func TestDetectExecutionContext_ClientCursorIgnoresTermProgram(t *testing.T) {
@@ -367,6 +382,29 @@ func TestDetectExecutionContext_ClientCopilotViaAIAgentAlias(t *testing.T) {
 	assert.Equal(t, NameVSCode, ec.Client)
 }
 
+func TestDetectExecutionContext_ClientCopilotAliasFoldsLikeSession(t *testing.T) {
+	testCases := []struct {
+		name string
+		key  string
+		val  string
+	}{
+		{"AI_AGENT uppercase", EnvAIAgent, "GITHUB_COPILOT_VSCODE_AGENT"},
+		{"AI_AGENT padded versioned", EnvAIAgent, "  github_copilot_vscode_agent@1.2.3  "},
+		{"AGENT lowercase", EnvAgent, AliasGitHubCopilotVSCodeAgent},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resetExecutionContextForTest(t)
+			clearAgentEnvVars(t)
+			t.Setenv(testCase.key, testCase.val)
+
+			ec := DetectExecutionContext()
+			assert.Equal(t, NameCopilot, ec.Agent)
+			assert.Equal(t, NameVSCode, ec.Client)
+		})
+	}
+}
+
 func TestDetectExecutionContext_ClientSkippedForHuman(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
@@ -384,7 +422,7 @@ func TestDetectExecutionContext_ClientSkippedForHuman(t *testing.T) {
 // different window depending on where the user opened it.
 func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 	askpass := func(app string) map[string]string {
-		return map[string]string{EnvVSCodeGitAskpassMain: "/Applications/" + app + "/out/askpass-main.js"}
+		return map[string]string{EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/" + app + "/out")}
 	}
 	testCases := []struct {
 		name     string
@@ -403,7 +441,7 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 		{"claude in cursor via trace id", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvCursorTraceID: "abc"}, NameCursor},
 		// Claude Code is itself the app when no IDE is proven.
 		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvTermProgram: TermProgramItermApp}, NameClaude},
-		{"claude in vscode via askpass", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvVSCodeGitAskpassMain: "/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass-main.js"}, NameVSCode},
+		{"claude in vscode via askpass", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, NameVSCode},
 		{"windsurf agent without askpass", map[string]string{"WINDSURF_CASCADE_TERMINAL": "1", EnvTermProgram: NameVSCode}, NameWindsurf},
 		{"antigravity agent without askpass", map[string]string{"ANTIGRAVITY_AGENT": "1", EnvTermProgram: NameVSCode}, NameAntigravity},
 		// Other CLI agents fall back to the terminal app.
@@ -411,15 +449,19 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 		{"gemini in warp", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramWarp}, NameWarp},
 		{"gemini in apple terminal", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramApple}, NameTerminal},
 		{"gemini in tmux", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: NameTmux}, NameTmux},
-		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramItermApp, EnvGitAskpass: "/Users/cursor/bin/git-helper"}, NameIterm}, // #nosec G101 -- fixture path, not a credential
+		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramItermApp, EnvGitAskpass: "/Users/cursor/bin/git-helper"}, NameIterm},
 		// A VS Code install under a login named "cursor" must not become client=cursor.
-		{"vscode askpass under cursor home is vscode", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: "/Users/cursor/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/git/dist/askpass-main.js"}, NameVSCode},
-		{"windows cursor install is cursor", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: `C:\Users\bob\AppData\Local\Programs\cursor\resources\app\extensions\git\dist\askpass-main.js`}, NameCursor},
+		{"vscode askpass under cursor home is vscode", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/Users/cursor/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/git/dist")}, NameVSCode},
+		{"windows cursor install is cursor", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPathWin(`C:\Users\bob\AppData\Local\Programs\cursor\resources\app\extensions\git\dist`)}, NameCursor},
+		{"cursor remote server askpass is cursor", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/home/ubuntu/.cursor-server/bin")}, NameCursor},
+		{"windsurf remote server askpass is windsurf", map[string]string{"CLINE_ACTIVE": "1", EnvVSCodeGitAskpassNode: vscodeGitHelperPath("/home/ubuntu/.windsurf-server/bin")}, NameWindsurf},
+		{"stock vscode remote server is vscode", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/home/ubuntu/.vscode-server/bin")}, NameVSCode},
+		{"stock vscode via askpass node only", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassNode: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, NameVSCode},
 		// Inherited TERM_PROGRAM=vscode is not a vscode window (P13). Askpass of
 		// stock VS Code is stronger and does prove the host.
 		{"gemini with inherited vscode term", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: NameVSCode}, ""},
 		{"copilot cli with inherited vscode term", map[string]string{"COPILOT_CLI": "1", EnvTermProgram: NameVSCode}, ""},
-		{"copilot cli in stock vscode via askpass", map[string]string{"COPILOT_CLI": "1", EnvVSCodeGitAskpassMain: "/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass-main.js"}, NameVSCode},
+		{"copilot cli in stock vscode via askpass", map[string]string{"COPILOT_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, NameVSCode},
 		{"gemini in unknown terminal app", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: "FooBar.app"}, "foobar"},
 		{"gemini in vscodium via askpass", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("VSCodium.app")), NameCodium},
 		{"trae agent is not vscode", map[string]string{"TRAE_AI_SHELL_ID": "1", EnvTermProgram: NameVSCode}, NameTrae},
@@ -444,6 +486,17 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 			assert.Equal(t, testCase.expected, ec.Client)
 		})
 	}
+}
+
+// vscodeGitHelperPath builds a VS Code-family git-askpass fixture. The
+// filename is isolated here so gosec G101 does not treat every table row
+// as a hardcoded credential.
+func vscodeGitHelperPath(dir string) string {
+	return dir + "/askpass-main.js" // #nosec G101 -- fixture path, not a credential
+}
+
+func vscodeGitHelperPathWin(dir string) string {
+	return dir + `\askpass-main.js` // #nosec G101 -- fixture path, not a credential
 }
 
 func mergeEnv(envs ...map[string]string) map[string]string {

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -404,7 +404,7 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 		{"gemini in warp", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "WarpTerminal"}, "warp"},
 		{"gemini in apple terminal", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "Apple_Terminal"}, "terminal"},
 		{"gemini in tmux", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "tmux"}, "tmux"},
-		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "iTerm.app", "GIT_ASKPASS": "/Users/cursor/bin/askpass"}, "iterm"},
+		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "iTerm.app", "GIT_ASKPASS": "/Users/cursor/bin/git-helper"}, "iterm"}, // #nosec G101 -- fixture path, not a credential
 		// Inherited TERM_PROGRAM=vscode is not a vscode window (P13).
 		{"gemini with inherited vscode term", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "vscode"}, ""},
 		{"copilot cli with inherited vscode term", map[string]string{"COPILOT_CLI": "1", "TERM_PROGRAM": "vscode"}, ""},

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -265,6 +265,13 @@ func clearAgentEnvVars(t *testing.T) {
 	t.Setenv("JFROG_CLI_AI_MODEL", "")
 	t.Setenv("COPILOT_AGENT", "")
 	t.Setenv("COPILOT_AGENT_JOB_ID", "")
+	// Host-window signals: a developer running these tests from a Zed, JetBrains
+	// or Cursor terminal must not have their editor leak into client assertions.
+	t.Setenv("ZED_TERM", "")
+	t.Setenv("TERMINAL_EMULATOR", "")
+	for _, env := range askpassEnvVars {
+		t.Setenv(env, "")
+	}
 }
 
 func TestDetectExecutionContext_ModelAgentOnly(t *testing.T) {
@@ -355,10 +362,61 @@ func TestDetectExecutionContext_ClientCopilotViaAIAgentAlias(t *testing.T) {
 func TestDetectExecutionContext_ClientSkippedForHuman(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
-	// No agent signal: a human in a VS Code terminal must not be recorded.
+	// No agent signal: a human in a VS Code or Zed terminal must not be recorded,
+	// however loudly the editor announces itself.
 	t.Setenv("TERM_PROGRAM", "vscode")
+	t.Setenv("ZED_TERM", "true")
 
 	ec := DetectExecutionContext()
 	assert.False(t, ec.IsAgent)
 	assert.Equal(t, "", ec.Client)
+}
+
+// The host axis must follow the editor, not the agent: the same agent reports a
+// different window depending on where the user opened it.
+func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
+	askpass := func(app string) map[string]string {
+		return map[string]string{"VSCODE_GIT_ASKPASS_MAIN": "/Applications/" + app + "/out/askpass-main.js"}
+	}
+	testCases := []struct {
+		name     string
+		env      map[string]string
+		expected string
+	}{
+		{"copilot in jetbrains", map[string]string{"COPILOT_AGENT": "1", "TERMINAL_EMULATOR": "JetBrains-JediTerm"}, "jetbrains"},
+		{"claude in jetbrains", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERMINAL_EMULATOR": "JetBrains-JediTerm"}, "jetbrains"},
+		{"claude in zed", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "ZED_TERM": "true"}, "zed"},
+		{"claude in cursor", mergeEnv(map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1"}, askpass("Cursor.app")), "cursor"},
+		{"cline in windsurf", mergeEnv(map[string]string{"CLINE_ACTIVE": "1"}, askpass("Windsurf.app")), "windsurf"},
+		{"gemini in antigravity", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("Antigravity.app")), "antigravity"},
+		// A fork inherits the upstream Copilot marker; the fork must still win.
+		{"copilot in windsurf", mergeEnv(map[string]string{"COPILOT_AGENT": "1"}, askpass("Windsurf.app")), "windsurf"},
+		// Cursor keeps its identity when the window is proven by trace ID alone.
+		{"claude in cursor via trace id", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "CURSOR_TRACE_ID": "abc"}, "cursor"},
+		// Terminal-only agents have no window to report.
+		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERM_PROGRAM": "iTerm.app"}, ""},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resetExecutionContextForTest(t)
+			clearAgentEnvVars(t)
+			for key, value := range testCase.env {
+				t.Setenv(key, value)
+			}
+
+			ec := DetectExecutionContext()
+			assert.True(t, ec.IsAgent)
+			assert.Equal(t, testCase.expected, ec.Client)
+		})
+	}
+}
+
+func mergeEnv(envs ...map[string]string) map[string]string {
+	merged := map[string]string{}
+	for _, env := range envs {
+		for key, value := range env {
+			merged[key] = value
+		}
+	}
+	return merged
 }

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -269,6 +269,7 @@ func clearAgentEnvVars(t *testing.T) {
 	// or Cursor terminal must not have their editor leak into client assertions.
 	t.Setenv("ZED_TERM", "")
 	t.Setenv("TERMINAL_EMULATOR", "")
+	t.Setenv("GIT_ASKPASS", "")
 	for _, env := range askpassEnvVars {
 		t.Setenv(env, "")
 	}
@@ -316,15 +317,15 @@ func TestDetectExecutionContext_ClientCursorIgnoresTermProgram(t *testing.T) {
 	assert.Equal(t, "cursor", ec.Client)
 }
 
-func TestDetectExecutionContext_ClientOmittedForClaude(t *testing.T) {
+func TestDetectExecutionContext_ClientClaudeAppWithoutKnownIDE(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "1")
-	t.Setenv("TERM_PROGRAM", "vscode")
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
 
 	ec := DetectExecutionContext()
 	assert.Equal(t, "claude", ec.Agent)
-	assert.Equal(t, "", ec.Client)
+	assert.Equal(t, "claude", ec.Client)
 }
 
 func TestDetectExecutionContext_ClientCopilotVscodePlugin(t *testing.T) {
@@ -338,15 +339,15 @@ func TestDetectExecutionContext_ClientCopilotVscodePlugin(t *testing.T) {
 	assert.Equal(t, "vscode", ec.Client)
 }
 
-func TestDetectExecutionContext_ClientOmittedForCopilotCLI(t *testing.T) {
+func TestDetectExecutionContext_ClientCopilotCLIFallsBackToTerminalApp(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("COPILOT_CLI", "1")
-	t.Setenv("TERM_PROGRAM", "vscode")
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
 
 	ec := DetectExecutionContext()
 	assert.Equal(t, "copilot", ec.Agent)
-	assert.Equal(t, "", ec.Client)
+	assert.Equal(t, "iterm", ec.Client)
 }
 
 func TestDetectExecutionContext_ClientCopilotViaAIAgentAlias(t *testing.T) {
@@ -393,9 +394,20 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 		{"copilot in windsurf", mergeEnv(map[string]string{"COPILOT_AGENT": "1"}, askpass("Windsurf.app")), "windsurf"},
 		// Cursor keeps its identity when the window is proven by trace ID alone.
 		{"claude in cursor via trace id", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "CURSOR_TRACE_ID": "abc"}, "cursor"},
-		// Terminal-only agents have no window to report.
-		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERM_PROGRAM": "iTerm.app"}, ""},
+		// Claude Code is itself the app when no IDE is proven.
+		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERM_PROGRAM": "iTerm.app"}, "claude"},
 		{"claude in vscode via askpass", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "VSCODE_GIT_ASKPASS_MAIN": "/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass-main.js"}, "vscode"},
+		{"windsurf agent without askpass", map[string]string{"WINDSURF_CASCADE_TERMINAL": "1", "TERM_PROGRAM": "vscode"}, "windsurf"},
+		{"antigravity agent without askpass", map[string]string{"ANTIGRAVITY_AGENT": "1", "TERM_PROGRAM": "vscode"}, "antigravity"},
+		// Other CLI agents fall back to the terminal app.
+		{"gemini in iterm", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "iTerm.app"}, "iterm"},
+		{"gemini in warp", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "WarpTerminal"}, "warp"},
+		{"gemini in apple terminal", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "Apple_Terminal"}, "terminal"},
+		{"gemini in tmux", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "tmux"}, "tmux"},
+		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "iTerm.app", "GIT_ASKPASS": "/Users/cursor/bin/askpass"}, "iterm"},
+		// Inherited TERM_PROGRAM=vscode is not a vscode window (P13).
+		{"gemini with inherited vscode term", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "vscode"}, ""},
+		{"copilot cli with inherited vscode term", map[string]string{"COPILOT_CLI": "1", "TERM_PROGRAM": "vscode"}, ""},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -50,7 +50,7 @@ func TestDetectAgent_CursorCLINotASessionMarker(t *testing.T) {
 func TestDetectAgent_CursorTraceIDNotASessionMarker(t *testing.T) {
 	// CURSOR_TRACE_ID is also set for regular Cursor integrated terminals.
 	clearAgentEnvVars(t)
-	t.Setenv("CURSOR_TRACE_ID", "trace-123")
+	t.Setenv(EnvCursorTraceID, "trace-123")
 	assert.Equal(t, "", detectAgent())
 }
 
@@ -116,7 +116,7 @@ func TestDetectAgent_GrokAgentPathIsNotASessionMarker(t *testing.T) {
 func TestDetectAgent_CoworkEmitsClaude(t *testing.T) {
 	clearAgentEnvVars(t)
 	t.Setenv("CLAUDE_CODE_IS_COWORK", "1")
-	assert.Equal(t, "claude", detectAgent())
+	assert.Equal(t, NameClaude, detectAgent())
 }
 
 func TestDetectAgent_GenericAgentEnvCollapsesToUnknown(t *testing.T) {
@@ -127,26 +127,26 @@ func TestDetectAgent_GenericAgentEnvCollapsesToUnknown(t *testing.T) {
 
 func TestDetectAgent_GenericValueMapsToKnownAgent(t *testing.T) {
 	cases := map[string]string{
-		"claude-code":                 "claude",
-		"gemini-cli":                  "gemini",
-		"github-copilot":              "copilot",
-		"roo-code":                    "roo_code",
-		"roo_code":                    "roo_code", // canonical form round-trips
-		"qwen":                        "qwen",
-		"amazon-q-cli":                "amazon_q",
-		"amazon_q":                    "amazon_q",
+		"claude-code":                 NameClaude,
+		"gemini-cli":                  NameGemini,
+		"github-copilot":              NameCopilot,
+		"roo-code":                    NameRooCode,
+		NameRooCode:                   NameRooCode, // canonical form round-trips
+		NameQwen:                      NameQwen,
+		"amazon-q-cli":                NameAmazonQ,
+		NameAmazonQ:                   NameAmazonQ,
 		"aider":                       "aider",
 		"goose@1.2.3":                 "goose",
-		"CURSOR":                      "cursor",
-		"github_copilot_vscode_agent": "copilot",
-		"grok-cli":                    "grok",
-		"grok-build":                  "grok",
+		"CURSOR":                      NameCursor,
+		AliasGitHubCopilotVSCodeAgent: NameCopilot,
+		"grok-cli":                    NameGrok,
+		"grok-build":                  NameGrok,
 		"totally-made-up":             AgentUnknown,
 	}
 	for value, want := range cases {
 		t.Run(value, func(t *testing.T) {
 			clearAgentEnvVars(t)
-			t.Setenv("AI_AGENT", value)
+			t.Setenv(EnvAIAgent, value)
 			assert.Equal(t, want, detectAgent())
 		})
 	}
@@ -159,14 +159,14 @@ func TestDetectAgent_TableOrderGeminiBeforeCursor(t *testing.T) {
 	clearAgentEnvVars(t)
 	t.Setenv("GEMINI_CLI", "1")
 	t.Setenv("CURSOR_AGENT", "1")
-	assert.Equal(t, "gemini", detectAgent())
+	assert.Equal(t, NameGemini, detectAgent())
 }
 
 func TestDetectAgent_TableWinsOverGenericValue(t *testing.T) {
 	clearAgentEnvVars(t)
 	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "1")
-	t.Setenv("AI_AGENT", "cursor")
-	assert.Equal(t, "claude", detectAgent())
+	t.Setenv(EnvAIAgent, NameCursor)
+	assert.Equal(t, NameClaude, detectAgent())
 }
 
 func TestDetectAgent_None(t *testing.T) {
@@ -175,11 +175,11 @@ func TestDetectAgent_None(t *testing.T) {
 }
 
 func TestDetectAgentTraceID(t *testing.T) {
-	t.Setenv("CURSOR_TRACE_ID", "trace-abc")
-	assert.Equal(t, "trace-abc", detectAgentTraceID("cursor"))
+	t.Setenv(EnvCursorTraceID, "trace-abc")
+	assert.Equal(t, "trace-abc", detectAgentTraceID(NameCursor))
 	// Trace ID gated on agent identity: a leaked CURSOR_TRACE_ID from an outer
 	// shell must not be reused when the real invoker is a different agent.
-	assert.Equal(t, "", detectAgentTraceID("claude"))
+	assert.Equal(t, "", detectAgentTraceID(NameClaude))
 	assert.Equal(t, "", detectAgentTraceID(""))
 }
 
@@ -190,7 +190,7 @@ func TestDetectExecutionContext_Agent(t *testing.T) {
 
 	ec := DetectExecutionContext()
 	assert.True(t, ec.IsAgent)
-	assert.Equal(t, "claude", ec.Agent)
+	assert.Equal(t, NameClaude, ec.Agent)
 }
 
 func TestDetectExecutionContext_NoEnv(t *testing.T) {
@@ -215,7 +215,7 @@ func TestDetectExecutionContext_IsMemoized(t *testing.T) {
 	second := DetectExecutionContext()
 
 	assert.Equal(t, first, second)
-	assert.Equal(t, "claude", second.Agent)
+	assert.Equal(t, NameClaude, second.Agent)
 }
 
 // resetExecutionContextForTest forces the next DetectExecutionContext call to
@@ -245,10 +245,10 @@ func clearAgentEnvVars(t *testing.T) {
 		}
 	}
 	t.Setenv("AGENT", "")
-	t.Setenv("AI_AGENT", "")
+	t.Setenv(EnvAIAgent, "")
 	// Cleared even though no longer detectors — leftover process env must not
 	// bleed into tests that assert human / strong-signal behaviour.
-	t.Setenv("CURSOR_TRACE_ID", "")
+	t.Setenv(EnvCursorTraceID, "")
 	t.Setenv("CURSOR_CLI", "")
 	t.Setenv("CLAUDECODE", "")
 	t.Setenv("CLAUDE_CODE", "")
@@ -262,9 +262,15 @@ func clearAgentEnvVars(t *testing.T) {
 	t.Setenv("KILO_PID", "")
 	t.Setenv("KILOCODE_FEATURE", "")
 	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("TERM", "")
+	t.Setenv("TMUX", "")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("KITTY_WINDOW_ID", "")
+	t.Setenv("ALACRITTY_LOG", "")
 	t.Setenv("JFROG_CLI_AI_MODEL", "")
-	t.Setenv("COPILOT_AGENT", "")
+	t.Setenv(EnvCopilotAgent, "")
 	t.Setenv("COPILOT_AGENT_JOB_ID", "")
+	t.Setenv(EnvVisualStudioVersion, "")
 	// Host-window signals: a developer running these tests from a Zed, JetBrains
 	// or Cursor terminal must not have their editor leak into client assertions.
 	t.Setenv("ZED_TERM", "")
@@ -295,7 +301,7 @@ func TestDetectExecutionContext_ModelSkippedForHuman(t *testing.T) {
 }
 
 func TestSanitizeToken(t *testing.T) {
-	assert.Equal(t, "vscode", sanitizeToken("vscode"))
+	assert.Equal(t, NameVSCode, sanitizeToken(NameVSCode))
 	assert.Equal(t, "apple_terminal", sanitizeToken("Apple_Terminal"))
 	assert.Equal(t, "iterm.app", sanitizeToken("  iTerm.app  "))
 	assert.Equal(t, "1.2.3-beta", sanitizeToken("1.2.3-beta"))
@@ -310,11 +316,11 @@ func TestDetectExecutionContext_ClientCursorIgnoresTermProgram(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("CURSOR_AGENT", "1")
-	t.Setenv("TERM_PROGRAM", "vscode")
+	t.Setenv("TERM_PROGRAM", NameVSCode)
 
 	ec := DetectExecutionContext()
-	assert.Equal(t, "cursor", ec.Agent)
-	assert.Equal(t, "cursor", ec.Client)
+	assert.Equal(t, NameCursor, ec.Agent)
+	assert.Equal(t, NameCursor, ec.Client)
 }
 
 func TestDetectExecutionContext_ClientClaudeAppWithoutKnownIDE(t *testing.T) {
@@ -324,19 +330,19 @@ func TestDetectExecutionContext_ClientClaudeAppWithoutKnownIDE(t *testing.T) {
 	t.Setenv("TERM_PROGRAM", "iTerm.app")
 
 	ec := DetectExecutionContext()
-	assert.Equal(t, "claude", ec.Agent)
-	assert.Equal(t, "claude", ec.Client)
+	assert.Equal(t, NameClaude, ec.Agent)
+	assert.Equal(t, NameClaude, ec.Client)
 }
 
 func TestDetectExecutionContext_ClientCopilotVscodePlugin(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
-	t.Setenv("COPILOT_AGENT", "1")
+	t.Setenv(EnvCopilotAgent, "1")
 	t.Setenv("TERM_PROGRAM", "iTerm.app")
 
 	ec := DetectExecutionContext()
-	assert.Equal(t, "copilot", ec.Agent)
-	assert.Equal(t, "vscode", ec.Client)
+	assert.Equal(t, NameCopilot, ec.Agent)
+	assert.Equal(t, NameVSCode, ec.Client)
 }
 
 func TestDetectExecutionContext_ClientCopilotCLIFallsBackToTerminalApp(t *testing.T) {
@@ -346,18 +352,18 @@ func TestDetectExecutionContext_ClientCopilotCLIFallsBackToTerminalApp(t *testin
 	t.Setenv("TERM_PROGRAM", "iTerm.app")
 
 	ec := DetectExecutionContext()
-	assert.Equal(t, "copilot", ec.Agent)
-	assert.Equal(t, "iterm", ec.Client)
+	assert.Equal(t, NameCopilot, ec.Agent)
+	assert.Equal(t, NameIterm, ec.Client)
 }
 
 func TestDetectExecutionContext_ClientCopilotViaAIAgentAlias(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
-	t.Setenv("AI_AGENT", "github_copilot_vscode_agent")
+	t.Setenv(EnvAIAgent, AliasGitHubCopilotVSCodeAgent)
 
 	ec := DetectExecutionContext()
-	assert.Equal(t, "copilot", ec.Agent)
-	assert.Equal(t, "vscode", ec.Client)
+	assert.Equal(t, NameCopilot, ec.Agent)
+	assert.Equal(t, NameVSCode, ec.Client)
 }
 
 func TestDetectExecutionContext_ClientSkippedForHuman(t *testing.T) {
@@ -365,7 +371,7 @@ func TestDetectExecutionContext_ClientSkippedForHuman(t *testing.T) {
 	clearAgentEnvVars(t)
 	// No agent signal: a human in a VS Code or Zed terminal must not be recorded,
 	// however loudly the editor announces itself.
-	t.Setenv("TERM_PROGRAM", "vscode")
+	t.Setenv("TERM_PROGRAM", NameVSCode)
 	t.Setenv("ZED_TERM", "true")
 
 	ec := DetectExecutionContext()
@@ -377,37 +383,52 @@ func TestDetectExecutionContext_ClientSkippedForHuman(t *testing.T) {
 // different window depending on where the user opened it.
 func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 	askpass := func(app string) map[string]string {
-		return map[string]string{"VSCODE_GIT_ASKPASS_MAIN": "/Applications/" + app + "/out/askpass-main.js"}
+		return map[string]string{EnvVSCodeGitAskpassMain: "/Applications/" + app + "/out/askpass-main.js"}
 	}
 	testCases := []struct {
 		name     string
 		env      map[string]string
 		expected string
 	}{
-		{"copilot in jetbrains", map[string]string{"COPILOT_AGENT": "1", "TERMINAL_EMULATOR": "JetBrains-JediTerm"}, "jetbrains"},
-		{"claude in jetbrains", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERMINAL_EMULATOR": "JetBrains-JediTerm"}, "jetbrains"},
-		{"claude in zed", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "ZED_TERM": "true"}, "zed"},
-		{"claude in cursor", mergeEnv(map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1"}, askpass("Cursor.app")), "cursor"},
-		{"cline in windsurf", mergeEnv(map[string]string{"CLINE_ACTIVE": "1"}, askpass("Windsurf.app")), "windsurf"},
-		{"gemini in antigravity", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("Antigravity.app")), "antigravity"},
+		{"copilot in jetbrains", map[string]string{EnvCopilotAgent: "1", "TERMINAL_EMULATOR": "JetBrains-JediTerm"}, NameJetBrains},
+		{"claude in jetbrains", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERMINAL_EMULATOR": "JetBrains-JediTerm"}, NameJetBrains},
+		{"claude in zed", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "ZED_TERM": "true"}, NameZed},
+		{"claude in cursor", mergeEnv(map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1"}, askpass("Cursor.app")), NameCursor},
+		{"cline in windsurf", mergeEnv(map[string]string{"CLINE_ACTIVE": "1"}, askpass("Windsurf.app")), NameWindsurf},
+		{"gemini in antigravity", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("Antigravity.app")), NameAntigravity},
 		// A fork inherits the upstream Copilot marker; the fork must still win.
-		{"copilot in windsurf", mergeEnv(map[string]string{"COPILOT_AGENT": "1"}, askpass("Windsurf.app")), "windsurf"},
+		{"copilot in windsurf", mergeEnv(map[string]string{EnvCopilotAgent: "1"}, askpass("Windsurf.app")), NameWindsurf},
 		// Cursor keeps its identity when the window is proven by trace ID alone.
-		{"claude in cursor via trace id", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "CURSOR_TRACE_ID": "abc"}, "cursor"},
+		{"claude in cursor via trace id", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvCursorTraceID: "abc"}, NameCursor},
 		// Claude Code is itself the app when no IDE is proven.
-		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERM_PROGRAM": "iTerm.app"}, "claude"},
-		{"claude in vscode via askpass", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "VSCODE_GIT_ASKPASS_MAIN": "/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass-main.js"}, "vscode"},
-		{"windsurf agent without askpass", map[string]string{"WINDSURF_CASCADE_TERMINAL": "1", "TERM_PROGRAM": "vscode"}, "windsurf"},
-		{"antigravity agent without askpass", map[string]string{"ANTIGRAVITY_AGENT": "1", "TERM_PROGRAM": "vscode"}, "antigravity"},
+		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERM_PROGRAM": "iTerm.app"}, NameClaude},
+		{"claude in vscode via askpass", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvVSCodeGitAskpassMain: "/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass-main.js"}, NameVSCode},
+		{"windsurf agent without askpass", map[string]string{"WINDSURF_CASCADE_TERMINAL": "1", "TERM_PROGRAM": NameVSCode}, NameWindsurf},
+		{"antigravity agent without askpass", map[string]string{"ANTIGRAVITY_AGENT": "1", "TERM_PROGRAM": NameVSCode}, NameAntigravity},
 		// Other CLI agents fall back to the terminal app.
-		{"gemini in iterm", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "iTerm.app"}, "iterm"},
-		{"gemini in warp", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "WarpTerminal"}, "warp"},
-		{"gemini in apple terminal", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "Apple_Terminal"}, "terminal"},
-		{"gemini in tmux", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "tmux"}, "tmux"},
-		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "iTerm.app", "GIT_ASKPASS": "/Users/cursor/bin/git-helper"}, "iterm"}, // #nosec G101 -- fixture path, not a credential
-		// Inherited TERM_PROGRAM=vscode is not a vscode window (P13).
-		{"gemini with inherited vscode term", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "vscode"}, ""},
-		{"copilot cli with inherited vscode term", map[string]string{"COPILOT_CLI": "1", "TERM_PROGRAM": "vscode"}, ""},
+		{"gemini in iterm", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "iTerm.app"}, NameIterm},
+		{"gemini in warp", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "WarpTerminal"}, NameWarp},
+		{"gemini in apple terminal", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "Apple_Terminal"}, NameTerminal},
+		{"gemini in tmux", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": NameTmux}, NameTmux},
+		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "iTerm.app", "GIT_ASKPASS": "/Users/cursor/bin/git-helper"}, NameIterm}, // #nosec G101 -- fixture path, not a credential
+		// A VS Code install under a login named "cursor" must not become client=cursor.
+		{"vscode askpass under cursor home is vscode", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: "/Users/cursor/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/git/dist/askpass-main.js"}, NameVSCode},
+		{"windows cursor install is cursor", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: `C:\Users\bob\AppData\Local\Programs\cursor\resources\app\extensions\git\dist\askpass-main.js`}, NameCursor},
+		// Inherited TERM_PROGRAM=vscode is not a vscode window (P13). Askpass of
+		// stock VS Code is stronger and does prove the host.
+		{"gemini with inherited vscode term", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": NameVSCode}, ""},
+		{"copilot cli with inherited vscode term", map[string]string{"COPILOT_CLI": "1", "TERM_PROGRAM": NameVSCode}, ""},
+		{"copilot cli in stock vscode via askpass", map[string]string{"COPILOT_CLI": "1", EnvVSCodeGitAskpassMain: "/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass-main.js"}, NameVSCode},
+		{"gemini in unknown terminal app", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "FooBar.app"}, "foobar"},
+		{"gemini in vscodium via askpass", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("VSCodium.app")), NameCodium},
+		{"trae agent is not vscode", map[string]string{"TRAE_AI_SHELL_ID": "1", "TERM_PROGRAM": NameVSCode}, NameTrae},
+		{"copilot in visual studio", map[string]string{EnvCopilotAgent: "1", EnvVisualStudioVersion: "17.0"}, NameVisualStudio},
+		{"gemini in tmux via TMUX", map[string]string{"GEMINI_CLI": "1", "TMUX": "1"}, NameTmux},
+		{"gemini in windows terminal", map[string]string{"GEMINI_CLI": "1", "WT_SESSION": "abc"}, NameWindowsTerminal},
+		{"gemini in ghostty via TERM", map[string]string{"GEMINI_CLI": "1", "TERM": "xterm-ghostty"}, NameGhostty},
+		{"gemini in kitty via window id", map[string]string{"GEMINI_CLI": "1", "KITTY_WINDOW_ID": "1"}, NameKitty},
+		{"gemini in alacritty via log", map[string]string{"GEMINI_CLI": "1", "ALACRITTY_LOG": "/tmp/alacritty.log"}, NameAlacritty},
+		{"inherited vscode term plus tmux is tmux", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": NameVSCode, "TMUX": "1"}, NameTmux},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -306,16 +306,16 @@ func TestDetectExecutionContext_ModelSkippedForHuman(t *testing.T) {
 	assert.Equal(t, "", ec.Model)
 }
 
-func TestSanitizeToken(t *testing.T) {
-	assert.Equal(t, NameVSCode, sanitizeToken(NameVSCode))
-	assert.Equal(t, "apple_terminal", sanitizeToken(TermProgramApple))
-	assert.Equal(t, "iterm.app", sanitizeToken("  "+TermProgramItermApp+"  "))
-	assert.Equal(t, "1.2.3-beta", sanitizeToken("1.2.3-beta"))
+func TestSanitizeWireName(t *testing.T) {
+	assert.Equal(t, NameVSCode, sanitizeWireName(NameVSCode))
+	assert.Equal(t, "apple_terminal", sanitizeWireName(TermProgramApple))
+	assert.Equal(t, "iterm.app", sanitizeWireName("  "+TermProgramItermApp+"  "))
+	assert.Equal(t, "1.2.3-beta", sanitizeWireName("1.2.3-beta"))
 	// Header-splitting and stray characters (CR/LF, colon, spaces) are stripped.
-	assert.Equal(t, "xyz", sanitizeToken("x\r\n y: z"))
-	assert.Equal(t, "", sanitizeToken(""))
+	assert.Equal(t, "xyz", sanitizeWireName("x\r\n y: z"))
+	assert.Equal(t, "", sanitizeWireName(""))
 	// Pathological env values are truncated so they cannot inflate the wire payload.
-	assert.Equal(t, maxTokenLen, len(sanitizeToken(strings.Repeat("a", maxTokenLen+100))))
+	assert.Equal(t, maxWireNameLen, len(sanitizeWireName(strings.Repeat("a", maxWireNameLen+100))))
 }
 
 func TestCanonicalTerminalName(t *testing.T) {
@@ -382,7 +382,7 @@ func TestDetectExecutionContext_ClientCopilotViaAIAgentAlias(t *testing.T) {
 	assert.Equal(t, NameVSCode, ec.Client)
 }
 
-func TestDetectExecutionContext_ClientCopilotAliasFoldsLikeSession(t *testing.T) {
+func TestDetectExecutionContext_ClientCopilotAliasMatchesSession(t *testing.T) {
 	testCases := []struct {
 		name string
 		key  string
@@ -449,7 +449,7 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 		{"gemini in warp", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramWarp}, NameWarp},
 		{"gemini in apple terminal", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramApple}, NameTerminal},
 		{"gemini in tmux", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: NameTmux}, NameTmux},
-		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramItermApp, EnvGitAskpass: "/Users/cursor/bin/git-helper"}, NameIterm},
+		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramItermApp, EnvGitAskpass: "/Users/cursor/bin/git-helper"}, NameIterm}, // #nosec G101 jfrog-ignore -- fixture path, not a credential
 		// A VS Code install under a login named "cursor" must not become client=cursor.
 		{"vscode askpass under cursor home is vscode", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/Users/cursor/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/git/dist")}, NameVSCode},
 		{"windows cursor install is cursor", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPathWin(`C:\Users\bob\AppData\Local\Programs\cursor\resources\app\extensions\git\dist`)}, NameCursor},
@@ -492,11 +492,11 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 // filename is isolated here so gosec G101 does not treat every table row
 // as a hardcoded credential.
 func vscodeGitHelperPath(dir string) string {
-	return dir + "/askpass-main.js" // #nosec G101 -- fixture path, not a credential
+	return dir + "/askpass-main.js" // #nosec G101 jfrog-ignore -- fixture path, not a credential
 }
 
 func vscodeGitHelperPathWin(dir string) string {
-	return dir + `\askpass-main.js` // #nosec G101 -- fixture path, not a credential
+	return dir + `\askpass-main.js` // #nosec G101 jfrog-ignore -- fixture path, not a credential
 }
 
 func mergeEnv(envs ...map[string]string) map[string]string {

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -24,6 +24,13 @@ func TestDetectAgent_FromTable(t *testing.T) {
 				assert.Equal(t, d.name, detectAgent())
 			})
 		}
+		for k, substr := range d.envContains {
+			t.Run(k+" contains "+substr, func(t *testing.T) {
+				clearAgentEnvVars(t)
+				t.Setenv(k, "prefix-"+substr+"-suffix")
+				assert.Equal(t, d.name, detectAgent())
+			})
+		}
 	}
 }
 
@@ -87,6 +94,31 @@ func TestDetectAgent_RemovedIPCNotASessionMarker(t *testing.T) {
 	assert.Equal(t, "", detectAgent())
 }
 
+func TestDetectAgent_KiloExtensionNotASessionMarker(t *testing.T) {
+	clearAgentEnvVars(t)
+	t.Setenv("KILO_PID", "12345")
+	t.Setenv("KILOCODE_FEATURE", "vscode-extension")
+	assert.Equal(t, "", detectAgent())
+}
+
+func TestDetectAgent_KiloCLIIsASessionMarker(t *testing.T) {
+	clearAgentEnvVars(t)
+	t.Setenv("KILOCODE_FEATURE", "cli")
+	assert.Equal(t, "kilocode", detectAgent())
+}
+
+func TestDetectAgent_GrokAgentPathIsNotASessionMarker(t *testing.T) {
+	clearAgentEnvVars(t)
+	t.Setenv("GROK_AGENT", "/Users/me/.grok/profile")
+	assert.Equal(t, "", detectAgent())
+}
+
+func TestDetectAgent_CoworkEmitsClaude(t *testing.T) {
+	clearAgentEnvVars(t)
+	t.Setenv("CLAUDE_CODE_IS_COWORK", "1")
+	assert.Equal(t, "claude", detectAgent())
+}
+
 func TestDetectAgent_GenericAgentEnvCollapsesToUnknown(t *testing.T) {
 	clearAgentEnvVars(t)
 	t.Setenv("AGENT", "some_random_value")
@@ -95,18 +127,21 @@ func TestDetectAgent_GenericAgentEnvCollapsesToUnknown(t *testing.T) {
 
 func TestDetectAgent_GenericValueMapsToKnownAgent(t *testing.T) {
 	cases := map[string]string{
-		"claude-code":     "claude",
-		"gemini-cli":      "gemini",
-		"github-copilot":  "copilot",
-		"roo-code":        "roo_code",
-		"roo_code":        "roo_code", // canonical form round-trips
-		"qwen":            "qwen",
-		"amazon-q-cli":    "amazon_q",
-		"amazon_q":        "amazon_q", // alias-only id still round-trips
-		"aider":           "aider",    // table row with no session env
-		"goose@1.2.3":     "goose",    // version suffix stripped
-		"CURSOR":          "cursor",   // case-insensitive
-		"totally-made-up": AgentUnknown,
+		"claude-code":                 "claude",
+		"gemini-cli":                  "gemini",
+		"github-copilot":              "copilot",
+		"roo-code":                    "roo_code",
+		"roo_code":                    "roo_code", // canonical form round-trips
+		"qwen":                        "qwen",
+		"amazon-q-cli":                "amazon_q",
+		"amazon_q":                    "amazon_q",
+		"aider":                       "aider",
+		"goose@1.2.3":                 "goose",
+		"CURSOR":                      "cursor",
+		"github_copilot_vscode_agent": "copilot",
+		"grok-cli":                    "grok",
+		"grok-build":                  "grok",
+		"totally-made-up":             AgentUnknown,
 	}
 	for value, want := range cases {
 		t.Run(value, func(t *testing.T) {
@@ -205,6 +240,9 @@ func clearAgentEnvVars(t *testing.T) {
 		for k := range d.envEquals {
 			t.Setenv(k, "")
 		}
+		for k := range d.envContains {
+			t.Setenv(k, "")
+		}
 	}
 	t.Setenv("AGENT", "")
 	t.Setenv("AI_AGENT", "")
@@ -221,8 +259,12 @@ func clearAgentEnvVars(t *testing.T) {
 	t.Setenv("KILO_IPC_SOCKET_PATH", "")
 	t.Setenv("KILO_SERVER_PASSWORD", "")
 	t.Setenv("ROO_CODE_IPC_SOCKET_PATH", "")
+	t.Setenv("KILO_PID", "")
+	t.Setenv("KILOCODE_FEATURE", "")
 	t.Setenv("TERM_PROGRAM", "")
 	t.Setenv("JFROG_CLI_AI_MODEL", "")
+	t.Setenv("COPILOT_AGENT", "")
+	t.Setenv("COPILOT_AGENT_JOB_ID", "")
 }
 
 func TestDetectExecutionContext_ModelAgentOnly(t *testing.T) {
@@ -256,13 +298,57 @@ func TestSanitizeToken(t *testing.T) {
 	assert.Equal(t, maxTokenLen, len(sanitizeToken(strings.Repeat("a", maxTokenLen+100))))
 }
 
-func TestDetectExecutionContext_ClientAgentOnly(t *testing.T) {
+func TestDetectExecutionContext_ClientCursorIgnoresTermProgram(t *testing.T) {
+	resetExecutionContextForTest(t)
+	clearAgentEnvVars(t)
+	t.Setenv("CURSOR_AGENT", "1")
+	t.Setenv("TERM_PROGRAM", "vscode")
+
+	ec := DetectExecutionContext()
+	assert.Equal(t, "cursor", ec.Agent)
+	assert.Equal(t, "cursor", ec.Client)
+}
+
+func TestDetectExecutionContext_ClientOmittedForClaude(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "1")
 	t.Setenv("TERM_PROGRAM", "vscode")
 
 	ec := DetectExecutionContext()
+	assert.Equal(t, "claude", ec.Agent)
+	assert.Equal(t, "", ec.Client)
+}
+
+func TestDetectExecutionContext_ClientCopilotVscodePlugin(t *testing.T) {
+	resetExecutionContextForTest(t)
+	clearAgentEnvVars(t)
+	t.Setenv("COPILOT_AGENT", "1")
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+
+	ec := DetectExecutionContext()
+	assert.Equal(t, "copilot", ec.Agent)
+	assert.Equal(t, "vscode", ec.Client)
+}
+
+func TestDetectExecutionContext_ClientOmittedForCopilotCLI(t *testing.T) {
+	resetExecutionContextForTest(t)
+	clearAgentEnvVars(t)
+	t.Setenv("COPILOT_CLI", "1")
+	t.Setenv("TERM_PROGRAM", "vscode")
+
+	ec := DetectExecutionContext()
+	assert.Equal(t, "copilot", ec.Agent)
+	assert.Equal(t, "", ec.Client)
+}
+
+func TestDetectExecutionContext_ClientCopilotViaAIAgentAlias(t *testing.T) {
+	resetExecutionContextForTest(t)
+	clearAgentEnvVars(t)
+	t.Setenv("AI_AGENT", "github_copilot_vscode_agent")
+
+	ec := DetectExecutionContext()
+	assert.Equal(t, "copilot", ec.Agent)
 	assert.Equal(t, "vscode", ec.Client)
 }
 

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -125,6 +125,13 @@ func TestDetectAgent_AmazonQUnrelatedExecutionEnv(t *testing.T) {
 	assert.Equal(t, "", detectAgent())
 }
 
+func TestDetectAgent_AmazonQExecutionEnv(t *testing.T) {
+	// Literal is independent of the detector table so a typo there fails this test.
+	clearAgentEnvVars(t)
+	t.Setenv("AWS_EXECUTION_ENV", "AmazonQ-For-CLI")
+	assert.Equal(t, nameAmazonQ, detectAgent())
+}
+
 func TestDetectAgent_GenericAgentEnvCollapsesToUnknown(t *testing.T) {
 	clearAgentEnvVars(t)
 	t.Setenv(envAgent, "some_random_value")
@@ -325,7 +332,7 @@ func TestCanonicalTerminalName(t *testing.T) {
 	assert.Equal(t, nameWezterm, canonicalTerminalName("WezTerm"))
 	assert.Equal(t, nameHyper, canonicalTerminalName("Hyper"))
 	assert.Equal(t, "", canonicalTerminalName(nameVSCode))
-	assert.Equal(t, "foobar", canonicalTerminalName("FooBar.app"))
+	assert.Equal(t, "", canonicalTerminalName("FooBar.app"))
 }
 
 func TestDetectExecutionContext_ClientCursorIgnoresTermProgram(t *testing.T) {
@@ -463,7 +470,7 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 		{"gemini with inherited vscode term", map[string]string{"GEMINI_CLI": "1", envTermProgram: nameVSCode}, ""},
 		{"copilot cli with inherited vscode term", map[string]string{"COPILOT_CLI": "1", envTermProgram: nameVSCode}, ""},
 		{"copilot cli in stock vscode via askpass", map[string]string{"COPILOT_CLI": "1", envVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, nameVSCode},
-		{"gemini in unknown terminal app", map[string]string{"GEMINI_CLI": "1", envTermProgram: "FooBar.app"}, "foobar"},
+		{"gemini in unknown terminal app", map[string]string{"GEMINI_CLI": "1", envTermProgram: "FooBar.app"}, ""},
 		{"gemini in vscodium via askpass", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("VSCodium.app")), nameCodium},
 		{"trae agent is not vscode", map[string]string{"TRAE_AI_SHELL_ID": "1", envTermProgram: nameVSCode}, nameTrae},
 		{"copilot in visual studio", map[string]string{envCopilotAgent: "1", envVisualStudioVersion: "17.0"}, nameVisualStudio},

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -395,6 +395,7 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 		{"claude in cursor via trace id", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "CURSOR_TRACE_ID": "abc"}, "cursor"},
 		// Terminal-only agents have no window to report.
 		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERM_PROGRAM": "iTerm.app"}, ""},
+		{"claude in vscode via askpass", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "VSCODE_GIT_ASKPASS_MAIN": "/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass-main.js"}, "vscode"},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -121,7 +121,7 @@ func TestDetectAgent_CoworkEmitsClaude(t *testing.T) {
 
 func TestDetectAgent_GenericAgentEnvCollapsesToUnknown(t *testing.T) {
 	clearAgentEnvVars(t)
-	t.Setenv("AGENT", "some_random_value")
+	t.Setenv(EnvAgent, "some_random_value")
 	assert.Equal(t, AgentUnknown, detectAgent())
 }
 
@@ -244,7 +244,7 @@ func clearAgentEnvVars(t *testing.T) {
 			t.Setenv(k, "")
 		}
 	}
-	t.Setenv("AGENT", "")
+	t.Setenv(EnvAgent, "")
 	t.Setenv(EnvAIAgent, "")
 	// Cleared even though no longer detectors — leftover process env must not
 	// bleed into tests that assert human / strong-signal behaviour.
@@ -261,21 +261,21 @@ func clearAgentEnvVars(t *testing.T) {
 	t.Setenv("ROO_CODE_IPC_SOCKET_PATH", "")
 	t.Setenv("KILO_PID", "")
 	t.Setenv("KILOCODE_FEATURE", "")
-	t.Setenv("TERM_PROGRAM", "")
-	t.Setenv("TERM", "")
-	t.Setenv("TMUX", "")
-	t.Setenv("WT_SESSION", "")
-	t.Setenv("KITTY_WINDOW_ID", "")
-	t.Setenv("ALACRITTY_LOG", "")
-	t.Setenv("JFROG_CLI_AI_MODEL", "")
+	t.Setenv(EnvTermProgram, "")
+	t.Setenv(EnvTerm, "")
+	t.Setenv(EnvTmux, "")
+	t.Setenv(EnvWTSession, "")
+	t.Setenv(EnvKittyWindowID, "")
+	t.Setenv(EnvAlacrittyLog, "")
+	t.Setenv(EnvJFrogCLIAIModel, "")
 	t.Setenv(EnvCopilotAgent, "")
 	t.Setenv("COPILOT_AGENT_JOB_ID", "")
 	t.Setenv(EnvVisualStudioVersion, "")
 	// Host-window signals: a developer running these tests from a Zed, JetBrains
 	// or Cursor terminal must not have their editor leak into client assertions.
-	t.Setenv("ZED_TERM", "")
-	t.Setenv("TERMINAL_EMULATOR", "")
-	t.Setenv("GIT_ASKPASS", "")
+	t.Setenv(EnvZedTerm, "")
+	t.Setenv(EnvTerminalEmulator, "")
+	t.Setenv(EnvGitAskpass, "")
 	for _, env := range askpassEnvVars {
 		t.Setenv(env, "")
 	}
@@ -285,7 +285,7 @@ func TestDetectExecutionContext_ModelAgentOnly(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "1")
-	t.Setenv("JFROG_CLI_AI_MODEL", "opus-4.7")
+	t.Setenv(EnvJFrogCLIAIModel, "opus-4.7")
 
 	assert.Equal(t, "opus-4.7", DetectExecutionContext().Model)
 }
@@ -293,7 +293,7 @@ func TestDetectExecutionContext_ModelAgentOnly(t *testing.T) {
 func TestDetectExecutionContext_ModelSkippedForHuman(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
-	t.Setenv("JFROG_CLI_AI_MODEL", "opus-4.7")
+	t.Setenv(EnvJFrogCLIAIModel, "opus-4.7")
 
 	ec := DetectExecutionContext()
 	assert.False(t, ec.IsAgent)
@@ -302,8 +302,9 @@ func TestDetectExecutionContext_ModelSkippedForHuman(t *testing.T) {
 
 func TestSanitizeToken(t *testing.T) {
 	assert.Equal(t, NameVSCode, sanitizeToken(NameVSCode))
-	assert.Equal(t, "apple_terminal", sanitizeToken("Apple_Terminal"))
-	assert.Equal(t, "iterm.app", sanitizeToken("  iTerm.app  "))
+	assert.Equal(t, NameTerminal, canonicalTerminalName(TermProgramApple))
+	assert.Equal(t, NameIterm, canonicalTerminalName("  "+TermProgramItermApp+"  "))
+	assert.Equal(t, NameWarp, canonicalTerminalName(TermProgramWarp))
 	assert.Equal(t, "1.2.3-beta", sanitizeToken("1.2.3-beta"))
 	// Header-splitting and stray characters (CR/LF, colon, spaces) are stripped.
 	assert.Equal(t, "xyz", sanitizeToken("x\r\n y: z"))
@@ -316,7 +317,7 @@ func TestDetectExecutionContext_ClientCursorIgnoresTermProgram(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("CURSOR_AGENT", "1")
-	t.Setenv("TERM_PROGRAM", NameVSCode)
+	t.Setenv(EnvTermProgram, NameVSCode)
 
 	ec := DetectExecutionContext()
 	assert.Equal(t, NameCursor, ec.Agent)
@@ -327,7 +328,7 @@ func TestDetectExecutionContext_ClientClaudeAppWithoutKnownIDE(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "1")
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv(EnvTermProgram, TermProgramItermApp)
 
 	ec := DetectExecutionContext()
 	assert.Equal(t, NameClaude, ec.Agent)
@@ -338,7 +339,7 @@ func TestDetectExecutionContext_ClientCopilotVscodePlugin(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv(EnvCopilotAgent, "1")
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv(EnvTermProgram, TermProgramItermApp)
 
 	ec := DetectExecutionContext()
 	assert.Equal(t, NameCopilot, ec.Agent)
@@ -349,7 +350,7 @@ func TestDetectExecutionContext_ClientCopilotCLIFallsBackToTerminalApp(t *testin
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("COPILOT_CLI", "1")
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv(EnvTermProgram, TermProgramItermApp)
 
 	ec := DetectExecutionContext()
 	assert.Equal(t, NameCopilot, ec.Agent)
@@ -371,8 +372,8 @@ func TestDetectExecutionContext_ClientSkippedForHuman(t *testing.T) {
 	clearAgentEnvVars(t)
 	// No agent signal: a human in a VS Code or Zed terminal must not be recorded,
 	// however loudly the editor announces itself.
-	t.Setenv("TERM_PROGRAM", NameVSCode)
-	t.Setenv("ZED_TERM", "true")
+	t.Setenv(EnvTermProgram, NameVSCode)
+	t.Setenv(EnvZedTerm, "true")
 
 	ec := DetectExecutionContext()
 	assert.False(t, ec.IsAgent)
@@ -390,9 +391,9 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 		env      map[string]string
 		expected string
 	}{
-		{"copilot in jetbrains", map[string]string{EnvCopilotAgent: "1", "TERMINAL_EMULATOR": "JetBrains-JediTerm"}, NameJetBrains},
-		{"claude in jetbrains", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERMINAL_EMULATOR": "JetBrains-JediTerm"}, NameJetBrains},
-		{"claude in zed", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "ZED_TERM": "true"}, NameZed},
+		{"copilot in jetbrains", map[string]string{EnvCopilotAgent: "1", EnvTerminalEmulator: JediTerm}, NameJetBrains},
+		{"claude in jetbrains", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvTerminalEmulator: JediTerm}, NameJetBrains},
+		{"claude in zed", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvZedTerm: "true"}, NameZed},
 		{"claude in cursor", mergeEnv(map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1"}, askpass("Cursor.app")), NameCursor},
 		{"cline in windsurf", mergeEnv(map[string]string{"CLINE_ACTIVE": "1"}, askpass("Windsurf.app")), NameWindsurf},
 		{"gemini in antigravity", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("Antigravity.app")), NameAntigravity},
@@ -401,34 +402,34 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 		// Cursor keeps its identity when the window is proven by trace ID alone.
 		{"claude in cursor via trace id", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvCursorTraceID: "abc"}, NameCursor},
 		// Claude Code is itself the app when no IDE is proven.
-		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", "TERM_PROGRAM": "iTerm.app"}, NameClaude},
+		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvTermProgram: TermProgramItermApp}, NameClaude},
 		{"claude in vscode via askpass", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvVSCodeGitAskpassMain: "/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass-main.js"}, NameVSCode},
-		{"windsurf agent without askpass", map[string]string{"WINDSURF_CASCADE_TERMINAL": "1", "TERM_PROGRAM": NameVSCode}, NameWindsurf},
-		{"antigravity agent without askpass", map[string]string{"ANTIGRAVITY_AGENT": "1", "TERM_PROGRAM": NameVSCode}, NameAntigravity},
+		{"windsurf agent without askpass", map[string]string{"WINDSURF_CASCADE_TERMINAL": "1", EnvTermProgram: NameVSCode}, NameWindsurf},
+		{"antigravity agent without askpass", map[string]string{"ANTIGRAVITY_AGENT": "1", EnvTermProgram: NameVSCode}, NameAntigravity},
 		// Other CLI agents fall back to the terminal app.
-		{"gemini in iterm", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "iTerm.app"}, NameIterm},
-		{"gemini in warp", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "WarpTerminal"}, NameWarp},
-		{"gemini in apple terminal", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "Apple_Terminal"}, NameTerminal},
-		{"gemini in tmux", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": NameTmux}, NameTmux},
-		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "iTerm.app", "GIT_ASKPASS": "/Users/cursor/bin/git-helper"}, NameIterm}, // #nosec G101 -- fixture path, not a credential
+		{"gemini in iterm", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramItermApp}, NameIterm},
+		{"gemini in warp", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramWarp}, NameWarp},
+		{"gemini in apple terminal", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramApple}, NameTerminal},
+		{"gemini in tmux", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: NameTmux}, NameTmux},
+		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramItermApp, EnvGitAskpass: "/Users/cursor/bin/git-helper"}, NameIterm}, // #nosec G101 -- fixture path, not a credential
 		// A VS Code install under a login named "cursor" must not become client=cursor.
 		{"vscode askpass under cursor home is vscode", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: "/Users/cursor/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/git/dist/askpass-main.js"}, NameVSCode},
 		{"windows cursor install is cursor", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: `C:\Users\bob\AppData\Local\Programs\cursor\resources\app\extensions\git\dist\askpass-main.js`}, NameCursor},
 		// Inherited TERM_PROGRAM=vscode is not a vscode window (P13). Askpass of
 		// stock VS Code is stronger and does prove the host.
-		{"gemini with inherited vscode term", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": NameVSCode}, ""},
-		{"copilot cli with inherited vscode term", map[string]string{"COPILOT_CLI": "1", "TERM_PROGRAM": NameVSCode}, ""},
+		{"gemini with inherited vscode term", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: NameVSCode}, ""},
+		{"copilot cli with inherited vscode term", map[string]string{"COPILOT_CLI": "1", EnvTermProgram: NameVSCode}, ""},
 		{"copilot cli in stock vscode via askpass", map[string]string{"COPILOT_CLI": "1", EnvVSCodeGitAskpassMain: "/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass-main.js"}, NameVSCode},
-		{"gemini in unknown terminal app", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": "FooBar.app"}, "foobar"},
+		{"gemini in unknown terminal app", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: "FooBar.app"}, "foobar"},
 		{"gemini in vscodium via askpass", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("VSCodium.app")), NameCodium},
-		{"trae agent is not vscode", map[string]string{"TRAE_AI_SHELL_ID": "1", "TERM_PROGRAM": NameVSCode}, NameTrae},
+		{"trae agent is not vscode", map[string]string{"TRAE_AI_SHELL_ID": "1", EnvTermProgram: NameVSCode}, NameTrae},
 		{"copilot in visual studio", map[string]string{EnvCopilotAgent: "1", EnvVisualStudioVersion: "17.0"}, NameVisualStudio},
-		{"gemini in tmux via TMUX", map[string]string{"GEMINI_CLI": "1", "TMUX": "1"}, NameTmux},
-		{"gemini in windows terminal", map[string]string{"GEMINI_CLI": "1", "WT_SESSION": "abc"}, NameWindowsTerminal},
-		{"gemini in ghostty via TERM", map[string]string{"GEMINI_CLI": "1", "TERM": "xterm-ghostty"}, NameGhostty},
-		{"gemini in kitty via window id", map[string]string{"GEMINI_CLI": "1", "KITTY_WINDOW_ID": "1"}, NameKitty},
-		{"gemini in alacritty via log", map[string]string{"GEMINI_CLI": "1", "ALACRITTY_LOG": "/tmp/alacritty.log"}, NameAlacritty},
-		{"inherited vscode term plus tmux is tmux", map[string]string{"GEMINI_CLI": "1", "TERM_PROGRAM": NameVSCode, "TMUX": "1"}, NameTmux},
+		{"gemini in tmux via TMUX", map[string]string{"GEMINI_CLI": "1", EnvTmux: "1"}, NameTmux},
+		{"gemini in windows terminal", map[string]string{"GEMINI_CLI": "1", EnvWTSession: "abc"}, NameWindowsTerminal},
+		{"gemini in ghostty via TERM", map[string]string{"GEMINI_CLI": "1", EnvTerm: TermXtermGhostty}, NameGhostty},
+		{"gemini in kitty via window id", map[string]string{"GEMINI_CLI": "1", EnvKittyWindowID: "1"}, NameKitty},
+		{"gemini in alacritty via log", map[string]string{"GEMINI_CLI": "1", EnvAlacrittyLog: "/tmp/alacritty.log"}, NameAlacritty},
+		{"inherited vscode term plus tmux is tmux", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: NameVSCode, EnvTmux: "1"}, NameTmux},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -132,6 +132,12 @@ func TestDetectAgent_AmazonQExecutionEnv(t *testing.T) {
 	assert.Equal(t, nameAmazonQ, detectAgent())
 }
 
+func TestJediTermMatchesJetBrainsOSValue(t *testing.T) {
+	// JetBrains sets TERMINAL_EMULATOR=JetBrains-JediTerm (capital J).
+	// Assert the literal so a const rename cannot hide a production miss.
+	assert.Equal(t, "JetBrains-JediTerm", jediTerm)
+}
+
 func TestDetectAgent_GenericAgentEnvCollapsesToUnknown(t *testing.T) {
 	clearAgentEnvVars(t)
 	t.Setenv(envAgent, "some_random_value")
@@ -437,8 +443,8 @@ func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 		env      map[string]string
 		expected string
 	}{
-		{"copilot in jetbrains", map[string]string{envCopilotAgent: "1", envTerminalEmulator: jediTerm}, nameJetBrains},
-		{"claude in jetbrains", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", envTerminalEmulator: jediTerm}, nameJetBrains},
+		{"copilot in jetbrains", map[string]string{envCopilotAgent: "1", envTerminalEmulator: "JetBrains-JediTerm"}, nameJetBrains},
+		{"claude in jetbrains", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", envTerminalEmulator: "JetBrains-JediTerm"}, nameJetBrains},
 		{"claude in zed", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", envZedTerm: "true"}, nameZed},
 		{"claude in cursor", mergeEnv(map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1"}, askpass("Cursor.app")), nameCursor},
 		{"cline in windsurf", mergeEnv(map[string]string{"CLINE_ACTIVE": "1"}, askpass("Windsurf.app")), nameWindsurf},

--- a/common/commands/execution_context_test.go
+++ b/common/commands/execution_context_test.go
@@ -50,7 +50,7 @@ func TestDetectAgent_CursorCLINotASessionMarker(t *testing.T) {
 func TestDetectAgent_CursorTraceIDNotASessionMarker(t *testing.T) {
 	// CURSOR_TRACE_ID is also set for regular Cursor integrated terminals.
 	clearAgentEnvVars(t)
-	t.Setenv(EnvCursorTraceID, "trace-123")
+	t.Setenv(envCursorTraceID, "trace-123")
 	assert.Equal(t, "", detectAgent())
 }
 
@@ -116,7 +116,7 @@ func TestDetectAgent_GrokAgentPathIsNotASessionMarker(t *testing.T) {
 func TestDetectAgent_CoworkEmitsClaude(t *testing.T) {
 	clearAgentEnvVars(t)
 	t.Setenv("CLAUDE_CODE_IS_COWORK", "1")
-	assert.Equal(t, NameClaude, detectAgent())
+	assert.Equal(t, nameClaude, detectAgent())
 }
 
 func TestDetectAgent_AmazonQUnrelatedExecutionEnv(t *testing.T) {
@@ -127,32 +127,32 @@ func TestDetectAgent_AmazonQUnrelatedExecutionEnv(t *testing.T) {
 
 func TestDetectAgent_GenericAgentEnvCollapsesToUnknown(t *testing.T) {
 	clearAgentEnvVars(t)
-	t.Setenv(EnvAgent, "some_random_value")
+	t.Setenv(envAgent, "some_random_value")
 	assert.Equal(t, AgentUnknown, detectAgent())
 }
 
 func TestDetectAgent_GenericValueMapsToKnownAgent(t *testing.T) {
 	cases := map[string]string{
-		"claude-code":                 NameClaude,
-		"gemini-cli":                  NameGemini,
-		"github-copilot":              NameCopilot,
-		"roo-code":                    NameRooCode,
-		NameRooCode:                   NameRooCode, // canonical form round-trips
-		NameQwen:                      NameQwen,
-		"amazon-q-cli":                NameAmazonQ,
-		NameAmazonQ:                   NameAmazonQ,
+		"claude-code":                 nameClaude,
+		"gemini-cli":                  nameGemini,
+		"github-copilot":              nameCopilot,
+		"roo-code":                    nameRooCode,
+		nameRooCode:                   nameRooCode, // canonical form round-trips
+		nameQwen:                      nameQwen,
+		"amazon-q-cli":                nameAmazonQ,
+		nameAmazonQ:                   nameAmazonQ,
 		"aider":                       "aider",
 		"goose@1.2.3":                 "goose",
-		"CURSOR":                      NameCursor,
-		AliasGitHubCopilotVSCodeAgent: NameCopilot,
-		"grok-cli":                    NameGrok,
-		"grok-build":                  NameGrok,
+		"CURSOR":                      nameCursor,
+		aliasGitHubCopilotVSCodeAgent: nameCopilot,
+		"grok-cli":                    nameGrok,
+		"grok-build":                  nameGrok,
 		"totally-made-up":             AgentUnknown,
 	}
 	for value, want := range cases {
 		t.Run(value, func(t *testing.T) {
 			clearAgentEnvVars(t)
-			t.Setenv(EnvAIAgent, value)
+			t.Setenv(envAIAgent, value)
 			assert.Equal(t, want, detectAgent())
 		})
 	}
@@ -165,14 +165,14 @@ func TestDetectAgent_TableOrderGeminiBeforeCursor(t *testing.T) {
 	clearAgentEnvVars(t)
 	t.Setenv("GEMINI_CLI", "1")
 	t.Setenv("CURSOR_AGENT", "1")
-	assert.Equal(t, NameGemini, detectAgent())
+	assert.Equal(t, nameGemini, detectAgent())
 }
 
 func TestDetectAgent_TableWinsOverGenericValue(t *testing.T) {
 	clearAgentEnvVars(t)
 	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "1")
-	t.Setenv(EnvAIAgent, NameCursor)
-	assert.Equal(t, NameClaude, detectAgent())
+	t.Setenv(envAIAgent, nameCursor)
+	assert.Equal(t, nameClaude, detectAgent())
 }
 
 func TestDetectAgent_None(t *testing.T) {
@@ -181,11 +181,11 @@ func TestDetectAgent_None(t *testing.T) {
 }
 
 func TestDetectAgentTraceID(t *testing.T) {
-	t.Setenv(EnvCursorTraceID, "trace-abc")
-	assert.Equal(t, "trace-abc", detectAgentTraceID(NameCursor))
+	t.Setenv(envCursorTraceID, "trace-abc")
+	assert.Equal(t, "trace-abc", detectAgentTraceID(nameCursor))
 	// Trace ID gated on agent identity: a leaked CURSOR_TRACE_ID from an outer
 	// shell must not be reused when the real invoker is a different agent.
-	assert.Equal(t, "", detectAgentTraceID(NameClaude))
+	assert.Equal(t, "", detectAgentTraceID(nameClaude))
 	assert.Equal(t, "", detectAgentTraceID(""))
 }
 
@@ -196,7 +196,7 @@ func TestDetectExecutionContext_Agent(t *testing.T) {
 
 	ec := DetectExecutionContext()
 	assert.True(t, ec.IsAgent)
-	assert.Equal(t, NameClaude, ec.Agent)
+	assert.Equal(t, nameClaude, ec.Agent)
 }
 
 func TestDetectExecutionContext_NoEnv(t *testing.T) {
@@ -221,7 +221,7 @@ func TestDetectExecutionContext_IsMemoized(t *testing.T) {
 	second := DetectExecutionContext()
 
 	assert.Equal(t, first, second)
-	assert.Equal(t, NameClaude, second.Agent)
+	assert.Equal(t, nameClaude, second.Agent)
 }
 
 // resetExecutionContextForTest forces the next DetectExecutionContext call to
@@ -250,11 +250,11 @@ func clearAgentEnvVars(t *testing.T) {
 			t.Setenv(k, "")
 		}
 	}
-	t.Setenv(EnvAgent, "")
-	t.Setenv(EnvAIAgent, "")
+	t.Setenv(envAgent, "")
+	t.Setenv(envAIAgent, "")
 	// Cleared even though no longer detectors — leftover process env must not
 	// bleed into tests that assert human / strong-signal behaviour.
-	t.Setenv(EnvCursorTraceID, "")
+	t.Setenv(envCursorTraceID, "")
 	t.Setenv("CURSOR_CLI", "")
 	t.Setenv("CLAUDECODE", "")
 	t.Setenv("CLAUDE_CODE", "")
@@ -267,21 +267,21 @@ func clearAgentEnvVars(t *testing.T) {
 	t.Setenv("ROO_CODE_IPC_SOCKET_PATH", "")
 	t.Setenv("KILO_PID", "")
 	t.Setenv("KILOCODE_FEATURE", "")
-	t.Setenv(EnvTermProgram, "")
-	t.Setenv(EnvTerm, "")
-	t.Setenv(EnvTmux, "")
-	t.Setenv(EnvWTSession, "")
-	t.Setenv(EnvKittyWindowID, "")
-	t.Setenv(EnvAlacrittyLog, "")
-	t.Setenv(EnvJFrogCLIAIModel, "")
-	t.Setenv(EnvCopilotAgent, "")
+	t.Setenv(envTermProgram, "")
+	t.Setenv(envTerm, "")
+	t.Setenv(envTmux, "")
+	t.Setenv(envWTSession, "")
+	t.Setenv(envKittyWindowID, "")
+	t.Setenv(envAlacrittyLog, "")
+	t.Setenv(envJFrogCLIAIModel, "")
+	t.Setenv(envCopilotAgent, "")
 	t.Setenv("COPILOT_AGENT_JOB_ID", "")
-	t.Setenv(EnvVisualStudioVersion, "")
+	t.Setenv(envVisualStudioVersion, "")
 	// Host-window signals: a developer running these tests from a Zed, JetBrains
 	// or Cursor terminal must not have their editor leak into client assertions.
-	t.Setenv(EnvZedTerm, "")
-	t.Setenv(EnvTerminalEmulator, "")
-	t.Setenv(EnvGitAskpass, "")
+	t.Setenv(envZedTerm, "")
+	t.Setenv(envTerminalEmulator, "")
+	t.Setenv(envGitAskpass, "")
 	for _, env := range askpassEnvVars {
 		t.Setenv(env, "")
 	}
@@ -291,7 +291,7 @@ func TestDetectExecutionContext_ModelAgentOnly(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "1")
-	t.Setenv(EnvJFrogCLIAIModel, "opus-4.7")
+	t.Setenv(envJFrogCLIAIModel, "opus-4.7")
 
 	assert.Equal(t, "opus-4.7", DetectExecutionContext().Model)
 }
@@ -299,7 +299,7 @@ func TestDetectExecutionContext_ModelAgentOnly(t *testing.T) {
 func TestDetectExecutionContext_ModelSkippedForHuman(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
-	t.Setenv(EnvJFrogCLIAIModel, "opus-4.7")
+	t.Setenv(envJFrogCLIAIModel, "opus-4.7")
 
 	ec := DetectExecutionContext()
 	assert.False(t, ec.IsAgent)
@@ -307,9 +307,9 @@ func TestDetectExecutionContext_ModelSkippedForHuman(t *testing.T) {
 }
 
 func TestSanitizeWireName(t *testing.T) {
-	assert.Equal(t, NameVSCode, sanitizeWireName(NameVSCode))
-	assert.Equal(t, "apple_terminal", sanitizeWireName(TermProgramApple))
-	assert.Equal(t, "iterm.app", sanitizeWireName("  "+TermProgramItermApp+"  "))
+	assert.Equal(t, nameVSCode, sanitizeWireName(nameVSCode))
+	assert.Equal(t, "apple_terminal", sanitizeWireName(termProgramApple))
+	assert.Equal(t, "iterm.app", sanitizeWireName("  "+termProgramItermApp+"  "))
 	assert.Equal(t, "1.2.3-beta", sanitizeWireName("1.2.3-beta"))
 	// Header-splitting and stray characters (CR/LF, colon, spaces) are stripped.
 	assert.Equal(t, "xyz", sanitizeWireName("x\r\n y: z"))
@@ -319,12 +319,12 @@ func TestSanitizeWireName(t *testing.T) {
 }
 
 func TestCanonicalTerminalName(t *testing.T) {
-	assert.Equal(t, NameTerminal, canonicalTerminalName(TermProgramApple))
-	assert.Equal(t, NameIterm, canonicalTerminalName("  "+TermProgramItermApp+"  "))
-	assert.Equal(t, NameWarp, canonicalTerminalName(TermProgramWarp))
-	assert.Equal(t, NameWezterm, canonicalTerminalName("WezTerm"))
-	assert.Equal(t, NameHyper, canonicalTerminalName("Hyper"))
-	assert.Equal(t, "", canonicalTerminalName(NameVSCode))
+	assert.Equal(t, nameTerminal, canonicalTerminalName(termProgramApple))
+	assert.Equal(t, nameIterm, canonicalTerminalName("  "+termProgramItermApp+"  "))
+	assert.Equal(t, nameWarp, canonicalTerminalName(termProgramWarp))
+	assert.Equal(t, nameWezterm, canonicalTerminalName("WezTerm"))
+	assert.Equal(t, nameHyper, canonicalTerminalName("Hyper"))
+	assert.Equal(t, "", canonicalTerminalName(nameVSCode))
 	assert.Equal(t, "foobar", canonicalTerminalName("FooBar.app"))
 }
 
@@ -332,54 +332,55 @@ func TestDetectExecutionContext_ClientCursorIgnoresTermProgram(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("CURSOR_AGENT", "1")
-	t.Setenv(EnvTermProgram, NameVSCode)
+	t.Setenv(envCursorTraceID, "trace-123")
+	t.Setenv(envTermProgram, nameVSCode)
 
 	ec := DetectExecutionContext()
-	assert.Equal(t, NameCursor, ec.Agent)
-	assert.Equal(t, NameCursor, ec.Client)
+	assert.Equal(t, nameCursor, ec.Agent)
+	assert.Equal(t, nameCursor, ec.Client)
 }
 
 func TestDetectExecutionContext_ClientClaudeAppWithoutKnownIDE(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("CLAUDE_CODE_CHILD_SESSION", "1")
-	t.Setenv(EnvTermProgram, TermProgramItermApp)
+	t.Setenv(envTermProgram, termProgramItermApp)
 
 	ec := DetectExecutionContext()
-	assert.Equal(t, NameClaude, ec.Agent)
-	assert.Equal(t, NameClaude, ec.Client)
+	assert.Equal(t, nameClaude, ec.Agent)
+	assert.Equal(t, nameClaude, ec.Client)
 }
 
 func TestDetectExecutionContext_ClientCopilotVscodePlugin(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
-	t.Setenv(EnvCopilotAgent, "1")
-	t.Setenv(EnvTermProgram, TermProgramItermApp)
+	t.Setenv(envCopilotAgent, "1")
+	t.Setenv(envTermProgram, termProgramItermApp)
 
 	ec := DetectExecutionContext()
-	assert.Equal(t, NameCopilot, ec.Agent)
-	assert.Equal(t, NameVSCode, ec.Client)
+	assert.Equal(t, nameCopilot, ec.Agent)
+	assert.Equal(t, nameIterm, ec.Client)
 }
 
 func TestDetectExecutionContext_ClientCopilotCLIFallsBackToTerminalApp(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
 	t.Setenv("COPILOT_CLI", "1")
-	t.Setenv(EnvTermProgram, TermProgramItermApp)
+	t.Setenv(envTermProgram, termProgramItermApp)
 
 	ec := DetectExecutionContext()
-	assert.Equal(t, NameCopilot, ec.Agent)
-	assert.Equal(t, NameIterm, ec.Client)
+	assert.Equal(t, nameCopilot, ec.Agent)
+	assert.Equal(t, nameIterm, ec.Client)
 }
 
 func TestDetectExecutionContext_ClientCopilotViaAIAgentAlias(t *testing.T) {
 	resetExecutionContextForTest(t)
 	clearAgentEnvVars(t)
-	t.Setenv(EnvAIAgent, AliasGitHubCopilotVSCodeAgent)
+	t.Setenv(envAIAgent, aliasGitHubCopilotVSCodeAgent)
 
 	ec := DetectExecutionContext()
-	assert.Equal(t, NameCopilot, ec.Agent)
-	assert.Equal(t, NameVSCode, ec.Client)
+	assert.Equal(t, nameCopilot, ec.Agent)
+	assert.Equal(t, nameVSCode, ec.Client)
 }
 
 func TestDetectExecutionContext_ClientCopilotAliasMatchesSession(t *testing.T) {
@@ -388,9 +389,9 @@ func TestDetectExecutionContext_ClientCopilotAliasMatchesSession(t *testing.T) {
 		key  string
 		val  string
 	}{
-		{"AI_AGENT uppercase", EnvAIAgent, "GITHUB_COPILOT_VSCODE_AGENT"},
-		{"AI_AGENT padded versioned", EnvAIAgent, "  github_copilot_vscode_agent@1.2.3  "},
-		{"AGENT lowercase", EnvAgent, AliasGitHubCopilotVSCodeAgent},
+		{"AI_AGENT uppercase", envAIAgent, "GITHUB_COPILOT_VSCODE_AGENT"},
+		{"AI_AGENT padded versioned", envAIAgent, "  github_copilot_vscode_agent@1.2.3  "},
+		{"AGENT lowercase", envAgent, aliasGitHubCopilotVSCodeAgent},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -399,8 +400,8 @@ func TestDetectExecutionContext_ClientCopilotAliasMatchesSession(t *testing.T) {
 			t.Setenv(testCase.key, testCase.val)
 
 			ec := DetectExecutionContext()
-			assert.Equal(t, NameCopilot, ec.Agent)
-			assert.Equal(t, NameVSCode, ec.Client)
+			assert.Equal(t, nameCopilot, ec.Agent)
+			assert.Equal(t, nameVSCode, ec.Client)
 		})
 	}
 }
@@ -410,8 +411,8 @@ func TestDetectExecutionContext_ClientSkippedForHuman(t *testing.T) {
 	clearAgentEnvVars(t)
 	// No agent signal: a human in a VS Code or Zed terminal must not be recorded,
 	// however loudly the editor announces itself.
-	t.Setenv(EnvTermProgram, NameVSCode)
-	t.Setenv(EnvZedTerm, "true")
+	t.Setenv(envTermProgram, nameVSCode)
+	t.Setenv(envZedTerm, "true")
 
 	ec := DetectExecutionContext()
 	assert.False(t, ec.IsAgent)
@@ -422,56 +423,60 @@ func TestDetectExecutionContext_ClientSkippedForHuman(t *testing.T) {
 // different window depending on where the user opened it.
 func TestDetectExecutionContext_ClientFollowsHostEditor(t *testing.T) {
 	askpass := func(app string) map[string]string {
-		return map[string]string{EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/" + app + "/out")}
+		return map[string]string{envVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/" + app + "/out")}
 	}
 	testCases := []struct {
 		name     string
 		env      map[string]string
 		expected string
 	}{
-		{"copilot in jetbrains", map[string]string{EnvCopilotAgent: "1", EnvTerminalEmulator: JediTerm}, NameJetBrains},
-		{"claude in jetbrains", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvTerminalEmulator: JediTerm}, NameJetBrains},
-		{"claude in zed", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvZedTerm: "true"}, NameZed},
-		{"claude in cursor", mergeEnv(map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1"}, askpass("Cursor.app")), NameCursor},
-		{"cline in windsurf", mergeEnv(map[string]string{"CLINE_ACTIVE": "1"}, askpass("Windsurf.app")), NameWindsurf},
-		{"gemini in antigravity", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("Antigravity.app")), NameAntigravity},
+		{"copilot in jetbrains", map[string]string{envCopilotAgent: "1", envTerminalEmulator: jediTerm}, nameJetBrains},
+		{"claude in jetbrains", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", envTerminalEmulator: jediTerm}, nameJetBrains},
+		{"claude in zed", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", envZedTerm: "true"}, nameZed},
+		{"claude in cursor", mergeEnv(map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1"}, askpass("Cursor.app")), nameCursor},
+		{"cline in windsurf", mergeEnv(map[string]string{"CLINE_ACTIVE": "1"}, askpass("Windsurf.app")), nameWindsurf},
+		{"gemini in antigravity", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("Antigravity.app")), nameAntigravity},
 		// A fork inherits the upstream Copilot marker; the fork must still win.
-		{"copilot in windsurf", mergeEnv(map[string]string{EnvCopilotAgent: "1"}, askpass("Windsurf.app")), NameWindsurf},
+		{"copilot in windsurf", mergeEnv(map[string]string{envCopilotAgent: "1"}, askpass("Windsurf.app")), nameWindsurf},
 		// Cursor keeps its identity when the window is proven by trace ID alone.
-		{"claude in cursor via trace id", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvCursorTraceID: "abc"}, NameCursor},
+		{"claude in cursor via trace id", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", envCursorTraceID: "abc"}, nameCursor},
 		// Claude Code is itself the app when no IDE is proven.
-		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvTermProgram: TermProgramItermApp}, NameClaude},
-		{"claude in vscode via askpass", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, NameVSCode},
-		{"windsurf agent without askpass", map[string]string{"WINDSURF_CASCADE_TERMINAL": "1", EnvTermProgram: NameVSCode}, NameWindsurf},
-		{"antigravity agent without askpass", map[string]string{"ANTIGRAVITY_AGENT": "1", EnvTermProgram: NameVSCode}, NameAntigravity},
+		{"claude in a plain terminal", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", envTermProgram: termProgramItermApp}, nameClaude},
+		{"claude in vscode via askpass", map[string]string{"CLAUDE_CODE_CHILD_SESSION": "1", envVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, nameVSCode},
+		{"windsurf agent without askpass", map[string]string{"WINDSURF_CASCADE_TERMINAL": "1", envTermProgram: nameVSCode}, nameWindsurf},
+		{"antigravity agent without askpass", map[string]string{"ANTIGRAVITY_AGENT": "1", envTermProgram: nameVSCode}, nameAntigravity},
 		// Other CLI agents fall back to the terminal app.
-		{"gemini in iterm", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramItermApp}, NameIterm},
-		{"gemini in warp", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramWarp}, NameWarp},
-		{"gemini in apple terminal", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramApple}, NameTerminal},
-		{"gemini in tmux", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: NameTmux}, NameTmux},
-		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: TermProgramItermApp, EnvGitAskpass: "/Users/cursor/bin/git-helper"}, NameIterm}, // #nosec G101 jfrog-ignore -- fixture path, not a credential
+		{"gemini in iterm", map[string]string{"GEMINI_CLI": "1", envTermProgram: termProgramItermApp}, nameIterm},
+		{"gemini in warp", map[string]string{"GEMINI_CLI": "1", envTermProgram: termProgramWarp}, nameWarp},
+		{"gemini in apple terminal", map[string]string{"GEMINI_CLI": "1", envTermProgram: termProgramApple}, nameTerminal},
+		{"gemini in tmux", map[string]string{"GEMINI_CLI": "1", envTermProgram: nameTmux}, nameTmux},
+		{"generic git askpass does not claim cursor", map[string]string{"GEMINI_CLI": "1", envTermProgram: termProgramItermApp, envGitAskpass: "/Users/cursor/bin/git-helper"}, nameIterm}, // #nosec G101 jfrog-ignore -- fixture path, not a credential
 		// A VS Code install under a login named "cursor" must not become client=cursor.
-		{"vscode askpass under cursor home is vscode", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/Users/cursor/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/git/dist")}, NameVSCode},
-		{"windows cursor install is cursor", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPathWin(`C:\Users\bob\AppData\Local\Programs\cursor\resources\app\extensions\git\dist`)}, NameCursor},
-		{"cursor remote server askpass is cursor", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/home/ubuntu/.cursor-server/bin")}, NameCursor},
-		{"windsurf remote server askpass is windsurf", map[string]string{"CLINE_ACTIVE": "1", EnvVSCodeGitAskpassNode: vscodeGitHelperPath("/home/ubuntu/.windsurf-server/bin")}, NameWindsurf},
-		{"stock vscode remote server is vscode", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/home/ubuntu/.vscode-server/bin")}, NameVSCode},
-		{"stock vscode via askpass node only", map[string]string{"GEMINI_CLI": "1", EnvVSCodeGitAskpassNode: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, NameVSCode},
+		{"vscode askpass under cursor home is vscode", map[string]string{"GEMINI_CLI": "1", envVSCodeGitAskpassMain: vscodeGitHelperPath("/Users/cursor/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/git/dist")}, nameVSCode},
+		{"windows cursor install is cursor", map[string]string{"GEMINI_CLI": "1", envVSCodeGitAskpassMain: vscodeGitHelperPathWin(`C:\Users\bob\AppData\Local\Programs\cursor\resources\app\extensions\git\dist`)}, nameCursor},
+		{"cursor remote server askpass is cursor", map[string]string{"GEMINI_CLI": "1", envVSCodeGitAskpassMain: vscodeGitHelperPath("/home/ubuntu/.cursor-server/bin")}, nameCursor},
+		{"windsurf remote server askpass is windsurf", map[string]string{"CLINE_ACTIVE": "1", envVSCodeGitAskpassNode: vscodeGitHelperPath("/home/ubuntu/.windsurf-server/bin")}, nameWindsurf},
+		{"stock vscode remote server is vscode", map[string]string{"GEMINI_CLI": "1", envVSCodeGitAskpassMain: vscodeGitHelperPath("/home/ubuntu/.vscode-server/bin")}, nameVSCode},
+		{"stock vscode via askpass node only", map[string]string{"GEMINI_CLI": "1", envVSCodeGitAskpassNode: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, nameVSCode},
 		// Inherited TERM_PROGRAM=vscode is not a vscode window (P13). Askpass of
 		// stock VS Code is stronger and does prove the host.
-		{"gemini with inherited vscode term", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: NameVSCode}, ""},
-		{"copilot cli with inherited vscode term", map[string]string{"COPILOT_CLI": "1", EnvTermProgram: NameVSCode}, ""},
-		{"copilot cli in stock vscode via askpass", map[string]string{"COPILOT_CLI": "1", EnvVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, NameVSCode},
-		{"gemini in unknown terminal app", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: "FooBar.app"}, "foobar"},
-		{"gemini in vscodium via askpass", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("VSCodium.app")), NameCodium},
-		{"trae agent is not vscode", map[string]string{"TRAE_AI_SHELL_ID": "1", EnvTermProgram: NameVSCode}, NameTrae},
-		{"copilot in visual studio", map[string]string{EnvCopilotAgent: "1", EnvVisualStudioVersion: "17.0"}, NameVisualStudio},
-		{"gemini in tmux via TMUX", map[string]string{"GEMINI_CLI": "1", EnvTmux: "1"}, NameTmux},
-		{"gemini in windows terminal", map[string]string{"GEMINI_CLI": "1", EnvWTSession: "abc"}, NameWindowsTerminal},
-		{"gemini in ghostty via TERM", map[string]string{"GEMINI_CLI": "1", EnvTerm: TermXtermGhostty}, NameGhostty},
-		{"gemini in kitty via window id", map[string]string{"GEMINI_CLI": "1", EnvKittyWindowID: "1"}, NameKitty},
-		{"gemini in alacritty via log", map[string]string{"GEMINI_CLI": "1", EnvAlacrittyLog: "/tmp/alacritty.log"}, NameAlacritty},
-		{"inherited vscode term plus tmux is tmux", map[string]string{"GEMINI_CLI": "1", EnvTermProgram: NameVSCode, EnvTmux: "1"}, NameTmux},
+		{"gemini with inherited vscode term", map[string]string{"GEMINI_CLI": "1", envTermProgram: nameVSCode}, ""},
+		{"copilot cli with inherited vscode term", map[string]string{"COPILOT_CLI": "1", envTermProgram: nameVSCode}, ""},
+		{"copilot cli in stock vscode via askpass", map[string]string{"COPILOT_CLI": "1", envVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, nameVSCode},
+		{"gemini in unknown terminal app", map[string]string{"GEMINI_CLI": "1", envTermProgram: "FooBar.app"}, "foobar"},
+		{"gemini in vscodium via askpass", mergeEnv(map[string]string{"GEMINI_CLI": "1"}, askpass("VSCodium.app")), nameCodium},
+		{"trae agent is not vscode", map[string]string{"TRAE_AI_SHELL_ID": "1", envTermProgram: nameVSCode}, nameTrae},
+		{"copilot in visual studio", map[string]string{envCopilotAgent: "1", envVisualStudioVersion: "17.0"}, nameVisualStudio},
+		{"gemini in tmux via TMUX", map[string]string{"GEMINI_CLI": "1", envTmux: "1"}, nameTmux},
+		{"gemini in windows terminal", map[string]string{"GEMINI_CLI": "1", envWTSession: "abc"}, nameWindowsTerminal},
+		{"gemini in ghostty via TERM", map[string]string{"GEMINI_CLI": "1", envTerm: termXtermGhostty}, nameGhostty},
+		{"gemini in kitty via window id", map[string]string{"GEMINI_CLI": "1", envKittyWindowID: "1"}, nameKitty},
+		{"gemini in alacritty via log", map[string]string{"GEMINI_CLI": "1", envAlacrittyLog: "/tmp/alacritty.log"}, nameAlacritty},
+		{"inherited vscode term plus tmux is tmux", map[string]string{"GEMINI_CLI": "1", envTermProgram: nameVSCode, envTmux: "1"}, nameTmux},
+		{"cursor agent in stock vscode is vscode", map[string]string{"CURSOR_AGENT": "1", envVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist")}, nameVSCode},
+		{"cursor agent in iterm is iterm", map[string]string{"CURSOR_AGENT": "1", envTermProgram: termProgramItermApp}, nameIterm},
+		{"cursor nightly askpass is not vscode", map[string]string{"GEMINI_CLI": "1", envVSCodeGitAskpassMain: vscodeGitHelperPath("/Applications/Cursor Nightly.app/Contents/Resources/app/extensions/git/dist")}, ""},
+		{"copilot plugin with no terminal is vscode", map[string]string{envCopilotAgent: "1"}, nameVSCode},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/common/commands/metrics_collector_test.go
+++ b/common/commands/metrics_collector_test.go
@@ -1050,8 +1050,8 @@ func TestAgentContextEndToEnd(t *testing.T) {
 	ClearAllMetrics()
 	clearAgentEnvVars(t)
 	t.Setenv("CURSOR_AGENT", "1")
-	t.Setenv("TERM_PROGRAM", NameVSCode)
-	t.Setenv("JFROG_CLI_AI_MODEL", "opus-4.7")
+	t.Setenv(EnvTermProgram, NameVSCode)
+	t.Setenv(EnvJFrogCLIAIModel, "opus-4.7")
 	resetExecutionContextForTest(t)
 
 	commandName := "rt_download"

--- a/common/commands/metrics_collector_test.go
+++ b/common/commands/metrics_collector_test.go
@@ -1050,8 +1050,9 @@ func TestAgentContextEndToEnd(t *testing.T) {
 	ClearAllMetrics()
 	clearAgentEnvVars(t)
 	t.Setenv("CURSOR_AGENT", "1")
-	t.Setenv(EnvTermProgram, NameVSCode)
-	t.Setenv(EnvJFrogCLIAIModel, "opus-4.7")
+	t.Setenv(envCursorTraceID, "trace-123")
+	t.Setenv(envTermProgram, nameVSCode)
+	t.Setenv(envJFrogCLIAIModel, "opus-4.7")
 	resetExecutionContextForTest(t)
 
 	commandName := "rt_download"
@@ -1063,10 +1064,10 @@ func TestAgentContextEndToEnd(t *testing.T) {
 	if collected == nil {
 		t.Fatal("Expected metrics to be collected")
 	}
-	if !collected.IsAgent || collected.Agent != NameCursor {
+	if !collected.IsAgent || collected.Agent != nameCursor {
 		t.Errorf("collected IsAgent/Agent wrong: IsAgent=%v Agent=%q", collected.IsAgent, collected.Agent)
 	}
-	if collected.Client != NameCursor || collected.Model != "opus-4.7" {
+	if collected.Client != nameCursor || collected.Model != "opus-4.7" {
 		t.Errorf("collected Client/Model wrong: Client=%q Model=%q", collected.Client, collected.Model)
 	}
 
@@ -1096,11 +1097,11 @@ func TestAgentContextEndToEnd(t *testing.T) {
 	if !strings.Contains(wire, `"is_agent":"true"`) {
 		t.Errorf("wire JSON missing is_agent=true: %s", wire)
 	}
-	if !strings.Contains(wire, `"agent":"`+NameCursor+`"`) {
-		t.Errorf("wire JSON missing agent=%s: %s", NameCursor, wire)
+	if !strings.Contains(wire, `"agent":"`+nameCursor+`"`) {
+		t.Errorf("wire JSON missing agent=%s: %s", nameCursor, wire)
 	}
-	if !strings.Contains(wire, `"client":"`+NameCursor+`"`) {
-		t.Errorf("wire JSON missing client=%s: %s", NameCursor, wire)
+	if !strings.Contains(wire, `"client":"`+nameCursor+`"`) {
+		t.Errorf("wire JSON missing client=%s: %s", nameCursor, wire)
 	}
 	if !strings.Contains(wire, `"model":"opus-4.7"`) {
 		t.Errorf("wire JSON missing model=opus-4.7: %s", wire)

--- a/common/commands/metrics_collector_test.go
+++ b/common/commands/metrics_collector_test.go
@@ -1066,7 +1066,7 @@ func TestAgentContextEndToEnd(t *testing.T) {
 	if !collected.IsAgent || collected.Agent != "cursor" {
 		t.Errorf("collected IsAgent/Agent wrong: IsAgent=%v Agent=%q", collected.IsAgent, collected.Agent)
 	}
-	if collected.Client != "vscode" || collected.Model != "opus-4.7" {
+	if collected.Client != "cursor" || collected.Model != "opus-4.7" {
 		t.Errorf("collected Client/Model wrong: Client=%q Model=%q", collected.Client, collected.Model)
 	}
 
@@ -1099,8 +1099,8 @@ func TestAgentContextEndToEnd(t *testing.T) {
 	if !strings.Contains(wire, `"agent":"cursor"`) {
 		t.Errorf("wire JSON missing agent=cursor: %s", wire)
 	}
-	if !strings.Contains(wire, `"client":"vscode"`) {
-		t.Errorf("wire JSON missing client=vscode: %s", wire)
+	if !strings.Contains(wire, `"client":"cursor"`) {
+		t.Errorf("wire JSON missing client=cursor: %s", wire)
 	}
 	if !strings.Contains(wire, `"model":"opus-4.7"`) {
 		t.Errorf("wire JSON missing model=opus-4.7: %s", wire)

--- a/common/commands/metrics_collector_test.go
+++ b/common/commands/metrics_collector_test.go
@@ -1050,7 +1050,7 @@ func TestAgentContextEndToEnd(t *testing.T) {
 	ClearAllMetrics()
 	clearAgentEnvVars(t)
 	t.Setenv("CURSOR_AGENT", "1")
-	t.Setenv("TERM_PROGRAM", "vscode")
+	t.Setenv("TERM_PROGRAM", NameVSCode)
 	t.Setenv("JFROG_CLI_AI_MODEL", "opus-4.7")
 	resetExecutionContextForTest(t)
 
@@ -1063,10 +1063,10 @@ func TestAgentContextEndToEnd(t *testing.T) {
 	if collected == nil {
 		t.Fatal("Expected metrics to be collected")
 	}
-	if !collected.IsAgent || collected.Agent != "cursor" {
+	if !collected.IsAgent || collected.Agent != NameCursor {
 		t.Errorf("collected IsAgent/Agent wrong: IsAgent=%v Agent=%q", collected.IsAgent, collected.Agent)
 	}
-	if collected.Client != "cursor" || collected.Model != "opus-4.7" {
+	if collected.Client != NameCursor || collected.Model != "opus-4.7" {
 		t.Errorf("collected Client/Model wrong: Client=%q Model=%q", collected.Client, collected.Model)
 	}
 
@@ -1096,11 +1096,11 @@ func TestAgentContextEndToEnd(t *testing.T) {
 	if !strings.Contains(wire, `"is_agent":"true"`) {
 		t.Errorf("wire JSON missing is_agent=true: %s", wire)
 	}
-	if !strings.Contains(wire, `"agent":"cursor"`) {
-		t.Errorf("wire JSON missing agent=cursor: %s", wire)
+	if !strings.Contains(wire, `"agent":"`+NameCursor+`"`) {
+		t.Errorf("wire JSON missing agent=%s: %s", NameCursor, wire)
 	}
-	if !strings.Contains(wire, `"client":"cursor"`) {
-		t.Errorf("wire JSON missing client=cursor: %s", wire)
+	if !strings.Contains(wire, `"client":"`+NameCursor+`"`) {
+		t.Errorf("wire JSON missing client=%s: %s", NameCursor, wire)
 	}
 	if !strings.Contains(wire, `"model":"opus-4.7"`) {
 		t.Errorf("wire JSON missing model=opus-4.7: %s", wire)

--- a/utils/metrics/metrics.go
+++ b/utils/metrics/metrics.go
@@ -11,7 +11,7 @@ type MetricsData struct {
 	IsContainer    bool     `json:"is_container,omitempty"`
 	IsAgent        bool     `json:"is_agent,omitempty"`
 	Agent          string   `json:"agent,omitempty"`  // "cursor", "claude"; empty when not an agent
-	Client         string   `json:"client,omitempty"` // IDE only: "cursor" or "vscode"
+	Client         string   `json:"client,omitempty"` // host IDE: "cursor", "vscode", "zed", "jetbrains", …
 	Model          string   `json:"model,omitempty"`  // "opus-4.7"
 	IsInteractive  bool     `json:"is_interactive,omitempty"`
 	PackageAlias   bool     `json:"package_alias,omitempty"`

--- a/utils/metrics/metrics.go
+++ b/utils/metrics/metrics.go
@@ -11,7 +11,7 @@ type MetricsData struct {
 	IsContainer    bool     `json:"is_container,omitempty"`
 	IsAgent        bool     `json:"is_agent,omitempty"`
 	Agent          string   `json:"agent,omitempty"`  // "cursor", "claude"; empty when not an agent
-	Client         string   `json:"client,omitempty"` // "vscode", "zed"
+	Client         string   `json:"client,omitempty"` // IDE only: "cursor" or "vscode"
 	Model          string   `json:"model,omitempty"`  // "opus-4.7"
 	IsInteractive  bool     `json:"is_interactive,omitempty"`
 	PackageAlias   bool     `json:"package_alias,omitempty"`

--- a/utils/metrics/metrics.go
+++ b/utils/metrics/metrics.go
@@ -11,7 +11,7 @@ type MetricsData struct {
 	IsContainer    bool     `json:"is_container,omitempty"`
 	IsAgent        bool     `json:"is_agent,omitempty"`
 	Agent          string   `json:"agent,omitempty"`  // "cursor", "claude"; empty when not an agent
-	Client         string   `json:"client,omitempty"` // host IDE: "cursor", "vscode", "zed", "jetbrains", …
+	Client         string   `json:"client,omitempty"` // host app: IDE, Claude, or terminal fallback
 	Model          string   `json:"model,omitempty"`  // "opus-4.7"
 	IsInteractive  bool     `json:"is_interactive,omitempty"`
 	PackageAlias   bool     `json:"package_alias,omitempty"`


### PR DESCRIPTION
## Overview

CLI telemetry stamps `client` with the real host app of a proven agent session: known IDE first, then Claude Code as a standalone app, then a short terminal name. Session detection is tightened so grok, kilo, Claude cowork, Copilot, and alias names match product rules.

## Details

Host (`ai-client/` / JSON `client`), strongest signal first:

- Known IDE: `cursor`, `vscode`, `zed`, `jetbrains`, `windsurf`, `antigravity`, `codium`, `trae`, `visualstudio` from editor-owned env (never raw `TERM_PROGRAM` for forks).
- Cursor / Windsurf / Antigravity / Trae / VSCodium keep their name even when `TERM_PROGRAM=vscode`.
- Askpass matching uses the editor install (`/cursor.app`, `/cursor/resources`, or `/.cursor-server` for Remote-SSH), not a username in the path.
- Desktop Visual Studio (`VisualStudioVersion`) is not labelled `vscode`.
- Claude Code with no proven IDE is `claude`, not iTerm.
- Otherwise map `TERM_PROGRAM` to a short product name: `iTerm.app` → `iterm`, `WarpTerminal` → `warp`, `Apple_Terminal` → `terminal`, `tmux` → `tmux`.
- When `TERM_PROGRAM` is empty or inherited `vscode`, fall back to `TMUX`, `WT_SESSION` (`windows-terminal`), Ghostty, Kitty, or Alacritty.
- Generic `GIT_ASKPASS` is not used as IDE proof.
- Humans still get no client; the axis is gated on an agent session.

Session (`ai-agent/`):

- Kilo only matches `KILOCODE_FEATURE=cli`. Grok matches exact `GROK_AGENT=1`. Cowork is classified as Claude before the generic Claude detector.
- Copilot extras: `COPILOT_AGENT`, `COPILOT_AGENT_JOB_ID`. Aliases such as `github_copilot_vscode_agent` and `grok-cli` map to canonical session names. The vscode-plugin alias is folded the same way as session detection (`AI_AGENT`/`AGENT`, case and `@version`) and last-resorts `client` to `vscode` when no IDE is proven.

```mermaid
flowchart LR
  env[Process env] --> detect[Detect agent session]
  detect --> host[Resolve host app]
  host --> ide[Known IDE]
  ide --> app[Claude if no IDE]
  app --> term[Short terminal name]
  term --> ua["ai-agent/ and ai-client/ on User-Agent"]
  ua --> metrics[Coralogix metrics]
```

## Notes

Companion PRs: jfrog-cli tests, jfrog-agent-hooks stamp, jfrog-skills EXTRACT split. Merge this module first so CLI can bump `jfrog-cli-core`.